### PR TITLE
docs: embed demo videos at top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,18 @@
 
 ---
 
+## Demo
+
+**Part 1 — Build an Amazon Connect AI agent in ~1 hour**
+
+https://github.com/user-attachments/assets/074983eb-43ed-4b04-a873-720795db847f
+
+**Part 2 — Live call with the generated agent**
+
+https://github.com/user-attachments/assets/64b4cd24-4653-4fed-86f9-4cd62866e1e2
+
+---
+
 <a id="english"></a>
 
 ## What is AICC Builder?


### PR DESCRIPTION
## Summary

Add a Demo section above the English/Korean split so visitors land on the video walkthrough first.

- **Part 1** — end-to-end AICC Builder run (~1 hour conversation → PoC bundle)
- **Part 2** — live call against the generated Amazon Connect agent

Videos are hosted on GitHub user-attachments (uploaded via a throwaway issue). Zero repo size impact, no changes to `.gitignore`, no LFS needed.

## Test plan

- [ ] README renders the two `user-attachments/assets/...` URLs as inline video players on github.com
- [ ] No broken markdown around the new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)