### PR TITLE
fix(workspace): hydrate cold S3 Files view on session resume

### DIFF
--- a/backend/ecs/app.py
+++ b/backend/ecs/app.py
@@ -1149,6 +1149,25 @@ async def verify_token(authorization: str = Header(default="")):
     return claims
 
 
+def _looks_like_cold_workspace(tree: list) -> bool:
+    """Detect a session whose NFS view was evicted/never-imported.
+
+    True when the only top-level entry is `context/` (the session always
+    rewrites conversation_history.json on every message, so it stays warm
+    even when assets/, state/, and specs/ have been evicted).
+    """
+    if not tree:
+        return True
+    non_context = [n for n in tree if n.get("name") != "context"]
+    if not non_context:
+        return True
+    # All non-context top-level dirs are empty → assets weren't materialized.
+    return all(
+        n.get("type") == "dir" and not n.get("children")
+        for n in non_context
+    )
+
+
 def _build_tree(directory: str, current_depth: int = 0, max_depth: int = 3) -> list:
     """Recursively build file tree from directory."""
     entries = []
@@ -1233,6 +1252,16 @@ async def get_workspace_tree(
         sessions_exists = sessions_dir.exists()
 
         if not target.exists():
+            # Session dir not on NFS — could be cold (lazy-import miss after a
+            # task restart). Try hydrating once before giving up.
+            if not path:
+                try:
+                    from tools.s3_asset_storage import hydrate_session_workspace
+                    hydrate_session_workspace(session_id)
+                except Exception as e:
+                    logger.warning(f"[workspace-api] hydrate failed for {session_id}: {e}")
+
+        if not target.exists():
             # Log diagnostic info for debugging NFS mount issues
             mount_contents = "N/A"
             if mount_exists:
@@ -1249,6 +1278,21 @@ async def get_workspace_tree(
             return JSONResponse({"success": True, "tree": []})
 
         tree = _build_tree(str(target), max_depth=min(depth, 8))
+
+        # Self-heal: if the FileExplorer is loading a session whose NFS view
+        # has been evicted (cache eviction after 30 days, or never imported
+        # for files >10MB), copy the durable S3 copies back into the NFS path
+        # and rebuild the tree. Only runs at the workspace root, not for
+        # sub-path queries.
+        if not path and _looks_like_cold_workspace(tree):
+            try:
+                from tools.s3_asset_storage import hydrate_session_workspace
+                hydrate_session_workspace(session_id)
+                if target.exists():
+                    tree = _build_tree(str(target), max_depth=min(depth, 8))
+            except Exception as e:
+                logger.warning(f"[workspace-api] hydrate failed for {session_id}: {e}")
+
         return JSONResponse({"success": True, "tree": tree})
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/backend/ecs/src/tools/s3_asset_storage.py
+++ b/backend/ecs/src/tools/s3_asset_storage.py
@@ -664,101 +664,147 @@ def list_session_assets(session_id: str, s3_only: bool = False) -> list:
         return []
 
 
+def _copy_s3_key_to_nfs(s3_key: str, nfs_path: Path) -> bool:
+    """Download an S3 object and write it to *nfs_path* atomically.
+
+    Used by hydrate_session_workspace to repopulate the NFS view from the
+    durable S3 copy when lazy mountpoint-s3 import didn't bring the file
+    back (file >10MB, dir not yet read, or evicted after 30 days).
+    """
+    bucket = get_bucket_name()
+    if not bucket:
+        return False
+    try:
+        s3 = get_s3_client()
+        body = s3.get_object(Bucket=bucket, Key=s3_key)["Body"].read()
+    except ClientError as e:
+        code = e.response.get("Error", {}).get("Code", "")
+        if code != "NoSuchKey":
+            logger.warning(f"[HYDRATE] S3 GET failed {s3_key}: {e}")
+        return False
+    except Exception as e:
+        logger.warning(f"[HYDRATE] S3 GET error {s3_key}: {e}")
+        return False
+    try:
+        nfs_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = nfs_path.with_suffix(nfs_path.suffix + ".tmp")
+        with open(tmp, "wb") as f:
+            f.write(body)
+        os.rename(tmp, nfs_path)
+        return True
+    except OSError as e:
+        logger.warning(f"[HYDRATE] NFS write failed {nfs_path}: {e}")
+        return False
+
+
+def _list_s3_prefix(prefix: str) -> list:
+    """List every S3 key under *prefix* (handles pagination)."""
+    bucket = get_bucket_name()
+    if not bucket:
+        return []
+    keys: list = []
+    try:
+        s3 = get_s3_client()
+        paginator = s3.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            for obj in page.get("Contents", []):
+                keys.append(obj["Key"])
+    except Exception as e:
+        logger.warning(f"[HYDRATE] list {prefix} failed: {e}")
+    return keys
+
+
 def hydrate_session_workspace(session_id: str) -> dict:
     """
-    Warm the NFS view so every asset for a session is materialized.
+    Repopulate the NFS view from S3 so every asset for a session is visible.
 
-    S3 Files (mountpoint-s3) lazily imports each directory on first access
-    (ON_DIRECTORY_FIRST_ACCESS). After an ECS task restart, the NFS mount for
-    a resumed session is empty — assets exist in S3 but are not visible to
-    os.scandir until each ancestor directory has been read at least once.
-    That race causes /api/workspace/{sid}/tree to return a partial tree on
-    resume (only context/conversation_history.json shows up, because that
-    file is re-written by the backend on every message).
+    S3 Files (managed NFS over S3) lazily imports each directory on first
+    access (ON_DIRECTORY_FIRST_ACCESS) and only for files ≤10MB. Files larger
+    than that, or older than the 30-day eviction window, never come back via
+    auto-import — even though the underlying S3 objects still exist. Every
+    asset is dual-written: NFS at sessions/{sid}/assets/{type}/{file} AND a
+    durable PutObject at assets/{sid}/{type}/{file}. This helper bridges the
+    two: it lists the authoritative durable copy and copies any missing files
+    into the NFS view so the workspace tree shows the full session contents.
 
-    This helper is read-only: it lists the authoritative S3 state, scandirs
-    every ancestor directory (cheap — forces readdir import), then stats
-    each file. No writes back to the mount, so versioned bucket object
-    versions are not incremented.
+    Covers three S3 prefixes:
+      - assets/{sid}/{type}/...      → /mnt/s3/sessions/{sid}/assets/{type}/...
+      - assets/{sid}/specs/{op}.json → /mnt/s3/sessions/{sid}/assets/specs/...
+      - assets/{sid}/state/...       → /mnt/s3/sessions/{sid}/state/...
+
+    Idempotent: files already present on NFS are skipped.
 
     Args:
-        session_id: User session ID to warm.
+        session_id: User session ID to hydrate.
 
     Returns:
         dict with:
-          - listed:  number of S3 keys found under assets/{sid}/
-          - dirs:    number of ancestor directories warmed
-          - files:   number of files whose metadata was successfully resolved
-          - skipped: number of files still missing after warm (likely >10MB
-                     import cap, or not yet flushed from write cache)
+          - listed:   total S3 keys discovered for the session
+          - files:    files already present on NFS (no work needed)
+          - restored: files newly copied from S3 to NFS
+          - skipped:  files we couldn't restore (S3 read or NFS write failed)
     """
-    result = {"listed": 0, "dirs": 0, "files": 0, "skipped": 0}
+    result = {"listed": 0, "files": 0, "restored": 0, "skipped": 0}
 
     if not _nfs_available():
         logger.info(f"[HYDRATE] NFS not available, skipping for {session_id}")
         return result
 
-    # 1. List authoritative set of keys from S3 (bypasses possibly-stale NFS).
-    try:
-        keys = list_session_assets(session_id, s3_only=True)
-    except Exception as e:
-        logger.warning(f"[HYDRATE] S3 list failed for {session_id}: {e}")
-        return result
-
-    result["listed"] = len(keys)
-    if not keys:
-        return result
-
     safe_session = session_id.replace("..", "_").replace("/", "_")
-    mount_root = Path(S3FILES_MOUNT) / "sessions" / safe_session / "assets"
+    mount_root = Path(S3FILES_MOUNT) / "sessions" / safe_session
 
-    # 2. Collect every ancestor directory we need materialized.
-    dirs_to_warm = {mount_root}
-    file_paths = []
-    for key in keys:
+    # Map each S3 key to its target NFS path. Three durable prefixes:
+    #   - assets/{sid}/state/...   → state/...
+    #   - assets/{sid}/specs/...   → assets/specs/...
+    #   - assets/{sid}/{type}/...  → assets/{type}/...
+    plan: list[tuple[str, Path]] = []
+
+    # Asset files (lambda, openapi, contact_flow, infrastructure, prompt, faq, …).
+    try:
+        asset_keys = list_session_assets(session_id, s3_only=True)
+    except Exception as e:
+        logger.warning(f"[HYDRATE] list assets failed for {session_id}: {e}")
+        asset_keys = []
+    for key in asset_keys:
         _, asset_type, file_name, op_id = _parse_s3_key_to_nfs_components(key)
         if asset_type is None:
             continue
-        type_dir = mount_root / asset_type
-        dirs_to_warm.add(type_dir)
+        target = mount_root / "assets" / asset_type
         if op_id:
-            op_dir = type_dir / op_id
-            dirs_to_warm.add(op_dir)
-            file_paths.append(op_dir / file_name)
-        else:
-            file_paths.append(type_dir / file_name)
+            target = target / op_id
+        target = target / file_name
+        plan.append((key, target))
 
-    # 3. Warm directories shallow → deep so each readdir sees its parent imported.
-    for d in sorted(dirs_to_warm, key=lambda p: len(p.parts)):
+    # State files (project.json, progress.json, requirements/, schemas/).
+    state_prefix = f"assets/{safe_session}/state/"
+    for key in _list_s3_prefix(state_prefix):
+        rel = key[len(state_prefix):]
+        if not rel:
+            continue
+        plan.append((key, mount_root / "state" / rel))
+
+    result["listed"] = len(plan)
+    if not plan:
+        return result
+
+    for s3_key, nfs_path in plan:
         try:
-            with os.scandir(d) as it:
-                # Consume the iterator so mountpoint-s3 completes the import.
-                for _ in it:
-                    pass
-            result["dirs"] += 1
-        except FileNotFoundError:
-            # Mount didn't materialize this dir — S3 listing may have been empty
-            # for that prefix (e.g., asset type dir but no files), or the dir
-            # lives above SizeLessThan threshold (unlikely for directories).
-            pass
+            if nfs_path.exists():
+                result["files"] += 1
+                continue
         except OSError as e:
-            logger.warning(f"[HYDRATE] scandir failed for {d}: {e}")
-
-    # 4. Stat each file to confirm it materialized in the view.
-    for p in file_paths:
-        try:
-            p.stat()
-            result["files"] += 1
-        except FileNotFoundError:
+            logger.warning(f"[HYDRATE] stat failed for {nfs_path}: {e}")
             result["skipped"] += 1
-        except OSError as e:
-            logger.warning(f"[HYDRATE] stat failed for {p}: {e}")
+            continue
+        if _copy_s3_key_to_nfs(s3_key, nfs_path):
+            result["restored"] += 1
+        else:
             result["skipped"] += 1
 
     logger.info(
         f"[HYDRATE] session={session_id} "
-        f"listed={result['listed']} dirs={result['dirs']} "
-        f"files={result['files']} skipped={result['skipped']}"
+        f"listed={result['listed']} files={result['files']} "
+        f"restored={result['restored']} skipped={result['skipped']}"
     )
     return result
 

--- a/backend/ecs/tests/test_hydrate_workspace.py
+++ b/backend/ecs/tests/test_hydrate_workspace.py
@@ -1,0 +1,147 @@
+"""Tests for hydrate_session_workspace copy-on-miss behavior.
+
+S3 Files (managed NFS over S3) only auto-imports files ≤10MB on directory
+first access, and evicts everything after 30 days. After an ECS restart, an
+old session opens with `assets/` empty even though the durable PutObject
+copies still exist in S3. hydrate_session_workspace bridges the gap by
+copying the durable S3 objects back into the NFS view.
+
+These tests stub the S3 client so they run with no AWS dependency.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.abspath(os.path.join(_HERE, "..", "src"))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+
+@pytest.fixture
+def nfs_mount(tmp_path, monkeypatch):
+    """Point the module at a temp NFS mount and reset its cached client."""
+    mount = tmp_path / "s3files"
+    mount.mkdir()
+    monkeypatch.setenv("S3FILES_MOUNT_PATH", str(mount))
+    monkeypatch.setenv("ASSETS_BUCKET_NAME", "test-bucket")
+
+    # Reload the module so it picks up the patched env vars.
+    if "tools.s3_asset_storage" in sys.modules:
+        del sys.modules["tools.s3_asset_storage"]
+    import tools.s3_asset_storage as mod  # noqa: E402
+
+    return mount, mod
+
+
+def _fake_s3_client(objects: dict[str, bytes]) -> MagicMock:
+    """Build a MagicMock S3 client that serves *objects* via get/list."""
+    client = MagicMock()
+
+    def get_object(Bucket, Key):
+        if Key not in objects:
+            from botocore.exceptions import ClientError
+            raise ClientError({"Error": {"Code": "NoSuchKey"}}, "GetObject")
+        return {"Body": io.BytesIO(objects[Key])}
+
+    client.get_object.side_effect = get_object
+
+    def paginate(Bucket, Prefix):
+        contents = [{"Key": k} for k in sorted(objects) if k.startswith(Prefix)]
+        return [{"Contents": contents}] if contents else [{}]
+
+    paginator = MagicMock()
+    paginator.paginate.side_effect = paginate
+    client.get_paginator.return_value = paginator
+
+    def list_objects_v2(Bucket, Prefix, ContinuationToken=None):
+        contents = [{"Key": k} for k in sorted(objects) if k.startswith(Prefix)]
+        return {"Contents": contents, "IsTruncated": False}
+
+    client.list_objects_v2.side_effect = list_objects_v2
+    return client
+
+
+def test_missing_asset_is_restored_from_s3(nfs_mount):
+    mount, mod = nfs_mount
+    sid = "session-cold-abc"
+    objects = {
+        f"assets/{sid}/lambda/create_reservation/handler.py": b"def handler(): pass\n",
+        f"assets/{sid}/openapi/openapi.yaml": b"openapi: 3.0.0\n",
+        f"assets/{sid}/state/project.json": b'{"name": "demo"}\n',
+        f"assets/{sid}/specs/op_create.json": b'{"op_id": "op_create"}\n',
+    }
+    client = _fake_s3_client(objects)
+
+    with patch.object(mod, "get_s3_client", return_value=client):
+        result = mod.hydrate_session_workspace(sid)
+
+    # Every key listed; every file restored (none were on NFS); none skipped.
+    assert result["listed"] == 4
+    assert result["restored"] == 4
+    assert result["files"] == 0
+    assert result["skipped"] == 0
+
+    base = mount / "sessions" / sid
+    assert (base / "assets" / "lambda" / "create_reservation" / "handler.py").read_bytes() == \
+        b"def handler(): pass\n"
+    assert (base / "assets" / "openapi" / "openapi.yaml").read_bytes() == b"openapi: 3.0.0\n"
+    assert (base / "state" / "project.json").read_bytes() == b'{"name": "demo"}\n'
+    assert (base / "assets" / "specs" / "op_create.json").read_bytes() == b'{"op_id": "op_create"}\n'
+
+
+def test_present_files_are_left_untouched(nfs_mount):
+    mount, mod = nfs_mount
+    sid = "session-warm-xyz"
+    nfs_path = mount / "sessions" / sid / "assets" / "lambda" / "op" / "handler.py"
+    nfs_path.parent.mkdir(parents=True)
+    nfs_path.write_bytes(b"local-newer-content\n")
+
+    objects = {
+        f"assets/{sid}/lambda/op/handler.py": b"s3-stale-content\n",
+    }
+    client = _fake_s3_client(objects)
+
+    with patch.object(mod, "get_s3_client", return_value=client):
+        result = mod.hydrate_session_workspace(sid)
+
+    assert result["files"] == 1  # already present
+    assert result["restored"] == 0  # not overwritten
+    assert nfs_path.read_bytes() == b"local-newer-content\n"
+
+
+def test_missing_s3_object_is_skipped(nfs_mount):
+    mount, mod = nfs_mount
+    sid = "session-empty"
+    # list_session_assets returns this key, but get_object will 404.
+    listed = {f"assets/{sid}/lambda/op/handler.py": b""}
+    client = _fake_s3_client(listed)
+    # Simulate the listing reporting a key that no longer exists at GET time.
+    from botocore.exceptions import ClientError
+    client.get_object.side_effect = ClientError(
+        {"Error": {"Code": "NoSuchKey"}}, "GetObject"
+    )
+
+    with patch.object(mod, "get_s3_client", return_value=client):
+        result = mod.hydrate_session_workspace(sid)
+
+    assert result["restored"] == 0
+    assert result["skipped"] == 1
+    assert not (mount / "sessions" / sid / "assets" / "lambda" / "op" / "handler.py").exists()
+
+
+def test_no_nfs_mount_returns_zeros(tmp_path, monkeypatch):
+    monkeypatch.setenv("S3FILES_MOUNT_PATH", "")
+    if "tools.s3_asset_storage" in sys.modules:
+        del sys.modules["tools.s3_asset_storage"]
+    import tools.s3_asset_storage as mod  # noqa: E402
+
+    result = mod.hydrate_session_workspace("anything")
+    assert result == {"listed": 0, "files": 0, "restored": 0, "skipped": 0}


### PR DESCRIPTION
## Summary

When a user reopens an older session, the **Workspace** panel often shows only `context/conversation_history.json`, even though the rest of the assets (lambda, openapi, contact_flow, infrastructure, prompt, faq) were generated days ago and still exist in S3.

Root cause: the S3 Files NFS layer (`AWS::S3Files::FileSystem`) only auto-imports on directory first access and only for files ≤10MB (`SizeLessThan: 10485760`), and evicts entries after 30 days of no access (`DaysAfterLastAccess: 30`). After an ECS task restart or eviction window, an old session's NFS view at `/mnt/s3/sessions/{sid}/` is cold, while the durable PutObject copies under `assets/{sid}/` in S3 are intact. Only `conversation_history.json` survived because the live session rewrites it on every message.

## Changes

- `backend/ecs/src/tools/s3_asset_storage.py` — Rewrite `hydrate_session_workspace` from stat-only warm to **copy-on-miss**. Lists three durable S3 prefixes (`assets/{sid}/{type}/`, `assets/{sid}/specs/`, `assets/{sid}/state/`) and downloads any files missing from NFS into the correct NFS paths atomically. Adds helpers `_copy_s3_key_to_nfs` and `_list_s3_prefix`. Returns a new `restored` counter.
- `backend/ecs/app.py` — `get_workspace_tree` now self-heals: when the tree is empty or only `context/` is populated (`_looks_like_cold_workspace`), it runs hydration once and rebuilds. Also runs hydration when the session directory doesn't exist on NFS at all. The FileExplorer no longer requires a WebSocket reconnect to surface assets.
- `backend/ecs/tests/test_hydrate_workspace.py` — New tests with mocked boto3 covering: missing → restored, present → untouched, S3 404 → skipped, no NFS mount → noop.

## Test plan

- [x] `python -m pytest backend/ecs/tests/test_hydrate_workspace.py -v` — 4/4 pass
- [x] End-to-end simulation: NFS pre-populated with only `context/conversation_history.json` + S3 with full asset set → `hydrate_session_workspace` restores all 11 files (assets, state, specs) byte-for-byte
- [x] `python -c "import py_compile; py_compile.compile('backend/ecs/app.py', doraise=True); py_compile.compile('backend/ecs/src/tools/s3_asset_storage.py', doraise=True)"`
- [ ] Post-deploy verification: open an existing session in the UI; confirm `assets/lambda/`, `assets/openapi/`, `state/`, `assets/specs/` repopulate. Watch CloudWatch for `[HYDRATE] session=… restored=N` lines on first tree fetch per session per task.

## Production safety

Hydration is read-from-S3 / write-to-NFS only. No `s3.delete_object`, no destructive operation. The S3 bucket is unmodified. Idempotent — repeated calls report `restored=0` once warm. The bucket is versioned, so any NFS-side write would create new object versions; we explicitly avoid that by skipping files already present on NFS.