### PR TITLE
fix(contact-flow + session): API-validated import hardening + session-sync bugs

### DIFF
--- a/backend/ecs/app.py
+++ b/backend/ecs/app.py
@@ -1210,8 +1210,16 @@ def _build_tree(directory: str, current_depth: int = 0, max_depth: int = 3) -> l
 
 
 @app.get("/api/debug/nfs")
-async def debug_nfs():
-    """NFS mount diagnostics — no auth required for quick debugging."""
+async def debug_nfs(session_id: str = ""):
+    """NFS mount diagnostics — no auth required for quick debugging.
+
+    When `session_id` is provided, also returns an AUTHORITATIVE existence
+    check for that exact session dir (`session_exists`). Callers MUST prefer
+    `session_exists` over membership in `recent_sessions`: the latter is a
+    truncated top-10-by-mtime list, so an older-but-valid session is absent
+    from it. Treating that absence as "session is dead" wrongly rotates the
+    user onto a fresh session and discards completed work.
+    """
     s3files_mount = os.environ.get("S3FILES_MOUNT_PATH", "/mnt/s3")
     mount_exists = os.path.isdir(s3files_mount)
     sessions_dir = os.path.join(s3files_mount, "sessions")
@@ -1230,6 +1238,12 @@ async def debug_nfs():
             session_count = -1
             session_ids = [f"error: {e}"]
 
+    # Authoritative per-session existence check (not bounded by the top-10 list).
+    session_exists = None
+    if session_id:
+        safe_id = session_id.replace("..", "_").replace("/", "_")
+        session_exists = os.path.isdir(os.path.join(sessions_dir, safe_id))
+
     # Check mount contents at root level
     mount_contents: list = []
     if mount_exists:
@@ -1245,6 +1259,8 @@ async def debug_nfs():
         "sessions_dir_exists": sessions_exists,
         "session_dirs_count": session_count,
         "recent_sessions": session_ids,
+        "queried_session_id": session_id or None,
+        "session_exists": session_exists,
     })
 
 

--- a/backend/ecs/app.py
+++ b/backend/ecs/app.py
@@ -1239,10 +1239,20 @@ async def debug_nfs(session_id: str = ""):
             session_ids = [f"error: {e}"]
 
     # Authoritative per-session existence check (not bounded by the top-10 list).
+    # Strictly allowlist the session_id to a safe charset BEFORE using it in a
+    # path expression (defeats path-injection / traversal — CodeQL py/path-injection).
+    # Then verify the resolved path stays inside sessions_dir as defense in depth.
     session_exists = None
     if session_id:
-        safe_id = session_id.replace("..", "_").replace("/", "_")
-        session_exists = os.path.isdir(os.path.join(sessions_dir, safe_id))
+        if not re.fullmatch(r"[A-Za-z0-9._-]{1,128}", session_id) or session_id in (".", ".."):
+            session_exists = False
+        else:
+            sessions_root = os.path.realpath(sessions_dir)
+            candidate = os.path.realpath(os.path.join(sessions_root, session_id))
+            if candidate == sessions_root or os.path.commonpath([sessions_root, candidate]) != sessions_root:
+                session_exists = False
+            else:
+                session_exists = os.path.isdir(candidate)
 
     # Check mount contents at root level
     mount_contents: list = []

--- a/backend/ecs/app.py
+++ b/backend/ecs/app.py
@@ -1226,12 +1226,13 @@ async def debug_nfs(session_id: str = ""):
     sessions_exists = os.path.isdir(sessions_dir)
     session_count = 0
     session_ids: list = []
+    all_dirs: list = []
     if sessions_exists:
         try:
-            dirs = os.listdir(sessions_dir)
-            session_count = len(dirs)
+            all_dirs = os.listdir(sessions_dir)
+            session_count = len(all_dirs)
             # Show last 10 session dirs (sorted by modification time, newest first)
-            full_paths = [(d, os.path.getmtime(os.path.join(sessions_dir, d))) for d in dirs]
+            full_paths = [(d, os.path.getmtime(os.path.join(sessions_dir, d))) for d in all_dirs]
             full_paths.sort(key=lambda x: x[1], reverse=True)
             session_ids = [d for d, _ in full_paths[:10]]
         except OSError as e:
@@ -1239,20 +1240,12 @@ async def debug_nfs(session_id: str = ""):
             session_ids = [f"error: {e}"]
 
     # Authoritative per-session existence check (not bounded by the top-10 list).
-    # Strictly allowlist the session_id to a safe charset BEFORE using it in a
-    # path expression (defeats path-injection / traversal — CodeQL py/path-injection).
-    # Then verify the resolved path stays inside sessions_dir as defense in depth.
+    # Path-injection-safe (CodeQL py/path-injection): the user-provided session_id
+    # is NEVER used to build a filesystem path. We only test membership against
+    # the already-listed directory names (derived solely from the trusted mount).
     session_exists = None
     if session_id:
-        if not re.fullmatch(r"[A-Za-z0-9._-]{1,128}", session_id) or session_id in (".", ".."):
-            session_exists = False
-        else:
-            sessions_root = os.path.realpath(sessions_dir)
-            candidate = os.path.realpath(os.path.join(sessions_root, session_id))
-            if candidate == sessions_root or os.path.commonpath([sessions_root, candidate]) != sessions_root:
-                session_exists = False
-            else:
-                session_exists = os.path.isdir(candidate)
+        session_exists = session_id in all_dirs
 
     # Check mount contents at root level
     mount_contents: list = []

--- a/backend/ecs/src/agents/_consistency_rules.py
+++ b/backend/ecs/src/agents/_consistency_rules.py
@@ -260,11 +260,35 @@ def _render_field_tree(field: dict, indent: int = 0) -> list:
     but always emitted when nested inside items/properties (context matters).
     """
     lines = []
+    # Fault-tolerance: a field may arrive as a JSON string (double-encoded) or a
+    # bare string field name. Recover/skip rather than crashing downstream with
+    # "'str' object has no attribute 'get'".
+    if isinstance(field, str):
+        try:
+            import json as _json
+            parsed = _json.loads(field)
+            if isinstance(parsed, dict):
+                field = parsed
+            else:
+                return [f"{'  ' * indent}- `{field}`: string"]
+        except Exception:
+            return [f"{'  ' * indent}- `{field}`: string"]
+    if not isinstance(field, dict):
+        return lines
     name = field.get("name", "?")
     ftype = (field.get("field_type") or field.get("type") or "string")
     enum_values = field.get("enum_values") or field.get("enum") or field.get("allowed_values") or field.get("options")
     items = field.get("items") or field.get("item") or field.get("element")
     properties = field.get("properties") or field.get("sub_fields") or field.get("fields")
+    # items may be a JSON string; normalize to dict or None
+    if isinstance(items, str):
+        try:
+            import json as _json
+            items = _json.loads(items)
+        except Exception:
+            items = None
+        if not isinstance(items, dict):
+            items = None
 
     pad = "  " * indent
     suffix = ""
@@ -277,15 +301,35 @@ def _render_field_tree(field: dict, indent: int = 0) -> list:
     if items is not None:
         lines.append(f"{pad}  items:")
         lines.extend(_render_field_tree(items, indent + 2))
-    if properties:
+    # properties may be a JSON string; normalize to a list before iterating
+    if isinstance(properties, str):
+        try:
+            import json as _json
+            properties = _json.loads(properties)
+        except Exception:
+            properties = None
+    if properties and isinstance(properties, (list, tuple)):
         lines.append(f"{pad}  properties:")
         for sub in properties:
             lines.extend(_render_field_tree(sub, indent + 2))
     return lines
 
 
-def _field_has_nested_structure(field: dict) -> bool:
-    """True if this field carries nested / enum info worth surfacing."""
+def _field_has_nested_structure(field) -> bool:
+    """True if this field carries nested / enum info worth surfacing.
+
+    Tolerates a non-dict `field` (e.g. a bare string field name or a
+    double-encoded JSON string) — returns False rather than raising.
+    """
+    if isinstance(field, str):
+        try:
+            import json as _json
+            parsed = _json.loads(field)
+            field = parsed if isinstance(parsed, dict) else None
+        except Exception:
+            field = None
+    if not isinstance(field, dict):
+        return False
     if field.get("enum_values") or field.get("enum") or field.get("allowed_values") or field.get("options"):
         return True
     if field.get("items") or field.get("item") or field.get("element"):

--- a/backend/ecs/src/agents/_consistency_rules.py
+++ b/backend/ecs/src/agents/_consistency_rules.py
@@ -184,6 +184,34 @@ SUBAGENT_TERMINOLOGY_AND_ESCALATION = """
   — do not hard-code "built on Nova Sonic" into generated prompts unless the
   user specified it.
 
+## AI-BOT ↔ CONTACT-FLOW TOOL-RESULT CONTRACT (canonical, do not improvise)
+
+The AI agent (Lex/Q-in-Connect bot) communicates its decision back to the
+Contact Flow through ONE session attribute: **`$.Lex.SessionAttributes.Tool`**.
+The flow's `Compare` block branches on its value. The vocabulary is FIXED:
+
+- **`Complete`** — the conversation is finished; end the call. (Self-service
+  done, customer satisfied, or graceful close.) Flow → goodbye → Disconnect.
+- **`Escalate`** — connect the customer to a human agent. Flow → set escalation
+  context → UpdateContactTargetQueue → TransferContactToQueue.
+
+These TWO values are the REQUIRED baseline. NEVER invent alternates like
+`END_CALL`, `END_CONVERSATION`, `ESCALATE` (wrong case), `TRANSFER`, `DONE`, or
+`actionType`. The prompt_generator MUST teach the bot to set exactly `Complete`
+or `Escalate`; the contact_flow_generator MUST `Compare` on exactly those.
+
+**Permitted extensions** (only when the spec/requirements call for distinct
+downstream handling — e.g. routing to a different queue or passing extra context
+to a Connect 1P/MCP agent transfer):
+- Additional ESCALATE-family values that still route to a human but differ in
+  context/queue: e.g. `EscalateBilling`, `EscalateTechnical`.
+- Additional COMPLETE-family values that still end the call but differ in
+  closing handling: e.g. `OutOfHoursComplete`, `CallbackScheduledComplete`.
+
+Even with extensions, the base `Complete` and `Escalate` MUST exist and be the
+default branches. Any extra value MUST be matched by a corresponding `Compare`
+condition in the flow AND documented in the bot prompt — never one side only.
+
 ## SPEC-LEVEL MODIFICATION ESCALATION (applies when modification_request is set)
 
 Before patching a file, classify the request:

--- a/backend/ecs/src/agents/contact_flow_generator/agent.py
+++ b/backend/ecs/src/agents/contact_flow_generator/agent.py
@@ -759,10 +759,19 @@ Operations:
             # missing terminal block — the things that make an Amazon Connect
             # flow fail to import. Surface in the result so the orchestrator can
             # patch before packaging. Fault-tolerant.
-            flow_lint = {"ok": True, "errors": [], "warnings": []}
+            flow_lint = {"ok": True, "errors": [], "warnings": [], "fixes_applied": []}
             try:
                 from tools.asset_linters import lint_contact_flow
                 flow_lint = lint_contact_flow(json_content)
+                # Apply deterministic auto-fixes (e.g. RealTime→PostContact in
+                # Voice AnalyticsModes, which otherwise breaks Connect import).
+                if flow_lint.get("fixes_applied") and flow_lint.get("fixed_json") and flow_lint["fixed_json"] != json_content:
+                    json_content = flow_lint["fixed_json"]
+                    logger.info(f"[CONTACT_FLOW] applied import-safety auto-fixes: {flow_lint['fixes_applied']}")
+                    try:
+                        _stream_asset("contact_flow", json_file_name, json_content, flow_name)
+                    except Exception as e:
+                        logger.warning(f"[CONTACT_FLOW] re-stream after autofix failed: {e}")
                 if not flow_lint["ok"]:
                     logger.warning(f"[CONTACT_FLOW] structural lint errors: {flow_lint['errors'][:5]}")
             except Exception as e:
@@ -777,6 +786,7 @@ Operations:
                 "lint_ok": flow_lint["ok"],
                 "lint_errors": flow_lint["errors"][:15],
                 "lint_warnings": flow_lint["warnings"][:8],
+                "lint_fixes_applied": flow_lint.get("fixes_applied", []),
                 "summary": (
                     f"Generated Contact Flow for {flow_name}" + (f" with diagram" if mermaid_content else "")
                     + (f". ⚠️ {len(flow_lint['errors'])} structural error(s) — PATCH before deploy: {flow_lint['errors'][:3]}" if not flow_lint["ok"] else " (structure OK)")

--- a/backend/ecs/src/agents/contact_flow_generator/system_prompt.py
+++ b/backend/ecs/src/agents/contact_flow_generator/system_prompt.py
@@ -345,15 +345,26 @@ ANY of them makes the flow fail to import with `InvalidContactFlowException`.
 | `CheckCondition` / `CheckValue` / `Condition` / `CheckAttribute` | `Compare` (params: `ComparisonValue` + `Conditions`) |
 | `SetWorkingQueue` | `UpdateContactTargetQueue` |
 | `SetCallbackNumber` | `UpdateContactCallbackNumber` |
-| `CheckStaffing` | `CheckMetricData` (MetricType: NumberOfAgentsAvailable) |
-| `GetQueueMetrics` | `CheckMetricData` (MetricType: NumberOfContactsInQueue) |
-| `TransferToAgent` | `TransferContactToAgent` |
-| `TransferToPhoneNumber` | `TransferParticipantToThirdParty` |
+| `CheckStaffing` / `CheckQueueStatus` | `CheckMetricData` (MetricType: `AgentsAvailable` / `ContactsInQueue`) |
+| `GetQueueMetrics` | `CheckMetricData` or `GetMetricData` |
+| `TransferToAgent` | `TransferContactToQueue` |
+| `TransferToPhoneNumber` / `TransferToThirdParty` | `TransferParticipantToThirdParty` |
 | `SetContactAttributes` | `UpdateContactAttributes` |
-| `StoreCustomerInput` | `StoreUserInput` |
+| `StoreCustomerInput` / `StoreUserInput` | `GetParticipantInput` (with `StoreInput:"True"`) |
 | `PlayPrompt` | `MessageParticipant` |
+| `Distribute` | `DistributeByPercentage` |
+| `StartMediaStreaming` / `StopMediaStreaming` | `UpdateContactMediaStreamingBehavior` |
+| `ReturnFromFlowModule` | `EndFlowExecution` |
+| `InvokeAPI` | `InvokeLambdaFunction` |
+| `SetLoggingBehavior` | `UpdateFlowLoggingBehavior` |
 | `CreateCallbackContact` | `UpdateContactCallbackNumber` + `TransferContactToQueue` |
 | `EndFlow` / `Disconnect` | `DisconnectParticipant` |
+
+> ✅ **All mappings above are API-verified (CreateContactFlow, 2026-06-08).** The
+> WRONG names previously listed (`TransferContactToAgent`, `StoreUserInput`) were
+> themselves invalid — these corrected targets are the ones that actually import.
+> Full verified Type list + console-name mapping is in the KB doc
+> `_VERIFIED-block-type-reference.md` (retrieve it when unsure of a Type).
 
 **RULE: `StartAction` MUST point at a REAL functional first action (not a
 Trigger/EntryPoint).** The flow's first executed block is typically

--- a/backend/ecs/src/agents/contact_flow_generator/system_prompt.py
+++ b/backend/ecs/src/agents/contact_flow_generator/system_prompt.py
@@ -334,8 +334,15 @@ When you need to implement a feature, use ONLY these block combinations:
 
 ## ⚠️ NON-EXISTENT BLOCKS (NEVER USE!)
 
+These block `Type`s DO NOT EXIST in the Amazon Connect flow language. Emitting
+ANY of them makes the flow fail to import with `InvalidContactFlowException`.
+
 | ❌ Wrong | ✅ Correct Alternative |
 |----------|------------------------|
+| `Trigger` / `EntryPoint` | **NONE — there is no entry/trigger block.** A flow simply starts at the action `StartAction` points to. The FIRST real action (e.g. `UpdateFlowLoggingBehavior` or `UpdateContactRecordingBehavior`) IS the start. NEVER emit a `Trigger`/`EntryPoint` wrapper action. |
+| `InvokeAgentAction` | `ConnectParticipantWithLexBot` (AI self-service runs through a Q-in-Connect-enabled **Lex V2 bot** — params are `LexV2Bot.AliasArn` + one of `Text`/`SSML`/`PromptId`. There is NO `AgentAliasArn`, `IdleSessionTimeout`, or `EndConversationPhrase` param.) |
+| `InvokeBedrockAgent` / `InvokeAmazonQConnect` / `InvokeQConnect` | `CreateWisdomSession` (early) + `ConnectParticipantWithLexBot` |
+| `CheckCondition` / `CheckValue` / `Condition` / `CheckAttribute` | `Compare` (params: `ComparisonValue` + `Conditions`) |
 | `SetWorkingQueue` | `UpdateContactTargetQueue` |
 | `SetCallbackNumber` | `UpdateContactCallbackNumber` |
 | `CheckStaffing` | `CheckMetricData` (MetricType: NumberOfAgentsAvailable) |
@@ -344,6 +351,14 @@ When you need to implement a feature, use ONLY these block combinations:
 | `TransferToPhoneNumber` | `TransferParticipantToThirdParty` |
 | `SetContactAttributes` | `UpdateContactAttributes` |
 | `StoreCustomerInput` | `StoreUserInput` |
+| `PlayPrompt` | `MessageParticipant` |
+| `CreateCallbackContact` | `UpdateContactCallbackNumber` + `TransferContactToQueue` |
+| `EndFlow` / `Disconnect` | `DisconnectParticipant` |
+
+**RULE: `StartAction` MUST point at a REAL functional first action (not a
+Trigger/EntryPoint).** The flow's first executed block is typically
+`UpdateFlowLoggingBehavior`, `UpdateContactRecordingBehavior`, or
+`UpdateContactTextToSpeechVoice` — never a synthetic entry wrapper.
 
 ---
 

--- a/backend/ecs/src/agents/contact_flow_generator/system_prompt.py
+++ b/backend/ecs/src/agents/contact_flow_generator/system_prompt.py
@@ -397,11 +397,18 @@ Voice recording (when channel is VOICE):
  "Parameters": {
    "RecordingBehavior": {"RecordedParticipants": ["Agent", "Customer"], "IVRRecordingBehavior": "Enabled"},
    "AnalyticsBehavior": {"Enabled": "True", "AnalyticsLanguage": "en-US",
-     "ChannelConfiguration": {"Chat": {"AnalyticsModes": []}, "Voice": {"AnalyticsModes": ["RealTime", "PostContact"]}},
+     "ChannelConfiguration": {"Chat": {"AnalyticsModes": []}, "Voice": {"AnalyticsModes": ["PostContact"]}},
      "SummaryConfiguration": {"SummaryModes": ["PostContact"]},
      "SentimentConfiguration": {"Enabled": "True"}}},
  "Transitions": {"NextAction": "next_block"}}
 ```
+⚠️ **Voice `AnalyticsModes` MUST be `["PostContact"]` (NOT `["RealTime", ...]`).**
+`RealTime` in `Voice.AnalyticsModes` is rejected by Amazon Connect on import
+(`InvalidContactFlowException: Invalid Action property value ... ChannelConfiguration.Voice`)
+unless the instance/flow meets real-time Contact Lens preconditions — it breaks
+import for everyone. Use `PostContact`. (Q in Connect real-time assistance does
+NOT require RealTime voice *analytics* in this block — the Lex/Wisdom session
+drives the assistant; post-contact analytics is the safe, always-importable choice.)
 Chat recording (when channel is CHAT):
 ```json
 {"Identifier": "chat-recording", "Type": "UpdateContactRecordingBehavior",
@@ -589,7 +596,7 @@ The workshop uses a 3-module structure. Your generated flow MUST include these p
 - **UpdateFlowLoggingBehavior**: Enable flow logging (REQUIRED - often missing!)
 - **Compare**: Check channel (VOICE vs CHAT) for recording settings
 - **UpdateContactRecordingBehavior**:
-  - VOICE: Record Agent+Customer, Contact Lens RealTime
+  - VOICE: Record Agent+Customer, Voice `AnalyticsModes: ["PostContact"]` (NOT RealTime — import-safe)
   - CHAT: No recording, Contact Lens only
 
 Reference: `static/contact-flows/basic-setting-configurations.json`

--- a/backend/ecs/src/agents/contact_flow_generator/system_prompt.py
+++ b/backend/ecs/src/agents/contact_flow_generator/system_prompt.py
@@ -367,19 +367,54 @@ Trigger/EntryPoint).** The flow's first executed block is typically
 ### Parameters & Errors by Type
 | Type | Parameters | Required Errors |
 |------|------------|-----------------|
-| `DisconnectParticipant` | `{}` | (none - terminal) |
-| `MessageParticipant` | `Text` | `NoMatchingError` |
-| `TransferContactToQueue` | `QueueId` | `QueueAtCapacity`, `NoMatchingError` |
-| `Compare` | `ComparisonValue` | `NoMatchingCondition` |
+| `DisconnectParticipant` | `{}` | (none — terminal, NO Transitions/Conditions/Errors) |
+| `MessageParticipant` | exactly ONE of `Text`/`SSML`/`PromptId`/`Media` | `NoMatchingError` |
+| `TransferContactToQueue` | `{}` (uses queue set by UpdateContactTargetQueue) | `QueueAtCapacity`, `NoMatchingError` |
+| `UpdateContactTargetQueue` | `QueueId` (string ARN — NOT nested object) | `NoMatchingError` |
+| `Compare` | `ComparisonValue` (valid JSONPath root) | `NoMatchingCondition` ONLY (never `NoMatchingError`) |
 | `Loop` | `LoopCount` | Branches: `Looping`, `Complete` |
 | `Wait` | `WaitTime` (seconds) | `NoMatchingError` |
-| `GetParticipantInput` | `Text`, `DTMFConfiguration` | `InputTimeLimitExceeded`, `NoMatchingCondition`, `NoMatchingError` |
+| `GetParticipantInput` | exactly ONE of `Text`/`SSML`, + `DTMFConfiguration` | `InputTimeLimitExceeded`, `NoMatchingCondition`, `NoMatchingError` |
 | `UpdateContactCallbackNumber` | `CallbackNumber` | `InvalidNumber`, `NotDialable`, `NoMatchingError` |
-| `CheckMetricData` | `{}` | Conditions: `True`, `False` |
+| `CheckHoursOfOperation` | `HoursOfOperationId` (non-null) | `NoMatchingError`; Conditions MUST include BOTH `True` AND `False` |
 | `CheckMetricData` | `QueueId` | `NoMatchingError` |
-| `InvokeLambdaFunction` | `LambdaFunctionARN`, `InvocationTimeLimitSeconds` (max 8) | `NoMatchingError` |
+| `InvokeLambdaFunction` | `LambdaFunctionARN`, `InvocationTimeLimitSeconds` (max 8), `LambdaInvocationAttributes` (NOT `RequestAttributes`), `ResponseValidation.ResponseType`=`STRING_MAP` | `NoMatchingError` |
+| `ConnectParticipantWithLexBot` | `LexV2Bot.AliasArn` + exactly ONE of `Text`/`SSML`/`PromptId`; optional `LexSessionAttributes` | `NoMatchingError`, `NoMatchingCondition` (NEVER `AgentError`) |
+| `UpdateContactTextToSpeechVoice` | `TextToSpeechVoice`, `TextToSpeechEngine` (NOT `VoiceId`/`Engine`/`LanguageCode`) | `NoMatchingError` |
+| `UpdateContactRecordingBehavior` | `RecordingBehavior{RecordedParticipants,IVRRecordingBehavior}` + `AnalyticsBehavior` (NOT `Agent`/`Customer`) | (none) |
+| `UpdateFlowLoggingBehavior` | `FlowLoggingBehavior` (NOT `LoggingBehavior`) | (none) |
 | `CreateWisdomSession` | `WisdomAssistantArn` | `NoMatchingError` |
 | `UpdateContactData` | `WisdomSessionArn` | `NoMatchingError` |
+
+### ⚠️ EXACT PARAMETER NAMES — API-validated (these EXACT mistakes fail import)
+
+These are the precise property-name errors Amazon Connect's `CreateContactFlow`
+API rejects. NEVER emit the ❌ form:
+
+| Block | ❌ NEVER | ✅ ALWAYS |
+|-------|---------|----------|
+| `UpdateContactRecordingBehavior` | `{"Agent":…,"Customer":…}` | `{"RecordingBehavior":{"RecordedParticipants":["Agent","Customer"],"IVRRecordingBehavior":"Enabled"},"AnalyticsBehavior":{…}}` |
+| `UpdateContactTextToSpeechVoice` | `{"VoiceId":…,"Engine":…,"LanguageCode":…}` | `{"TextToSpeechVoice":"Seoyeon","TextToSpeechEngine":"Generative"}` |
+| `UpdateFlowLoggingBehavior` | `{"LoggingBehavior":"Enabled"}` | `{"FlowLoggingBehavior":"Enabled"}` |
+| `UpdateContactTargetQueue` | `{"Queue":…}` or `{"QueueId":{"QueueId":…}}` | `{"QueueId":"<arn-string>"}` |
+| `ConnectParticipantWithLexBot` | `BotAliasArn`, `ParticipantRole`, `SessionAttributes`, `RequestAttributes`, `LexBot.AliasArn` | `{"LexV2Bot":{"AliasArn":…},"Text":…}` (+ optional `LexSessionAttributes`) |
+| `InvokeLambdaFunction` | `RequestAttributes` | `LambdaInvocationAttributes` |
+
+**Hard rules (import-blockers):**
+1. **Terminal blocks** (`DisconnectParticipant`, `EndFlowExecution`,
+   `ReturnFromFlowModule`) carry NO `Transitions`, NO `Conditions`, NO `Errors` —
+   nothing but `Identifier`/`Type`/`Parameters`.
+2. **`Compare`** allows ONLY `NoMatchingCondition` as an Error — never
+   `NoMatchingError`. Its `ComparisonValue` MUST use a real JSONPath root:
+   `$.Attributes.X`, `$.Channel`, `$.Lex.SessionAttributes.X`,
+   `$.CustomerEndpoint.Address`, `$.External.X`, `$.StoredCustomerInput`.
+   There is NO `$.Agent.*` namespace — read agent/bot results from
+   `$.Lex.SessionAttributes.*` or a contact attribute.
+3. **`CheckHoursOfOperation`** needs a non-null `HoursOfOperationId` and Conditions
+   for BOTH `True` and `False`; its only Error is `NoMatchingError`.
+4. **`MessageParticipant`/`GetParticipantInput`** define EXACTLY ONE of
+   `Text`/`SSML`/`PromptId`/`Media` — never both `Text` and `SSML`.
+5. **`ConnectParticipantWithLexBot`** never uses `AgentError` as an Error type.
 
 ---
 

--- a/backend/ecs/src/tools/asset_linters.py
+++ b/backend/ecs/src/tools/asset_linters.py
@@ -482,6 +482,72 @@ def lint_lambda(session_id: str = "", operation_id: str = "", file_name: str = "
 # Contact Flow (Amazon Connect flow JSON) — structural integrity
 # ---------------------------------------------------------------------------
 
+# Official Amazon Connect flow-language Action Types (the `Type` field of an
+# Action). Source: Amazon Connect Flow language — flow block / action reference
+# (contact-actions.html + branch/interact/integrate/set/terminate actions).
+# A flow that contains a `Type` NOT in this set FAILS to import with
+# InvalidContactFlowException. Keep this list complete — when adding support for
+# a new block, add its Type here too.
+VALID_CONTACT_FLOW_ACTION_TYPES = frozenset({
+    # Interact
+    "MessageParticipant", "MessageParticipantIteratively", "GetParticipantInput",
+    "ConnectParticipantWithLexBot", "StartMediaStreaming", "StopMediaStreaming",
+    "GetParticipantWithLexV2Bot",
+    # Set
+    "UpdateContactAttributes", "UpdateContactData", "UpdateContactRecordingBehavior",
+    "UpdateContactTextToSpeechVoice", "UpdateContactTargetQueue",
+    "UpdateContactCallbackNumber", "UpdateContactEventHooks",
+    "UpdateContactRoutingBehavior", "UpdateContactRoutingData",
+    "UpdateFlowLoggingBehavior", "UpdateFlowAttributes", "UpdateContactMediaStreamingBehavior",
+    "UpdateContactTextToSpeechManner",
+    # Branch / control
+    "Compare", "Distribute", "Loop", "DistributeByPercentage",
+    "CheckHoursOfOperation", "CheckMetricData", "CheckQueueStatus",
+    # Integrate
+    "InvokeLambdaFunction", "InvokeFlowModule", "CreateWisdomSession",
+    "InvokeAPI", "CreateTask", "AssociateContactToCustomerProfile",
+    "GetCustomerProfile", "PutCustomerProfile", "CreatePersistentContactAssociation",
+    "GetCustomerProfileObject", "UpdateCustomerProfileObject", "TagContact", "UntagContact",
+    # Transfer / terminate
+    "TransferContactToQueue", "TransferToFlow", "TransferToThirdParty",
+    "TransferToAgent", "TransferToPhoneNumber", "DisconnectParticipant",
+    "EndFlowExecution", "ReturnFromFlowModule",
+})
+
+# Known LLM hallucinations / wrong names → the correct official Type (or None
+# when there is no 1:1 replacement and the block must be removed/redesigned).
+# These are blocks the model has actually emitted that break import.
+INVALID_CONTACT_FLOW_TYPE_HINTS = {
+    # There is no "Trigger" / entry-point block — a flow starts at the action
+    # that StartAction points to. Drop the wrapper and start at its NextAction.
+    "Trigger": "(remove — flows start at StartAction, no Trigger block exists)",
+    "EntryPoint": "(remove — flows start at StartAction, no EntryPoint block exists)",
+    # Branch-on-value is `Compare`, not CheckCondition / CheckValue / Condition.
+    "CheckCondition": "Compare",
+    "CheckValue": "Compare",
+    "Condition": "Compare",
+    "CheckAttribute": "Compare",
+    # No "InvokeAgentAction" / Bedrock-agent block exists in the flow language.
+    # AI self-service runs through a Q-in-Connect-enabled Lex V2 bot.
+    "InvokeAgentAction": "ConnectParticipantWithLexBot",
+    "InvokeBedrockAgent": "ConnectParticipantWithLexBot",
+    "InvokeAmazonQConnect": "ConnectParticipantWithLexBot",
+    "InvokeQConnect": "ConnectParticipantWithLexBot",
+    # Common other hallucinations.
+    "PlayPrompt": "MessageParticipant",
+    "GetUserInput": "GetParticipantInput",
+    "SetWorkingQueue": "UpdateContactTargetQueue",
+    "SetCallbackNumber": "UpdateContactCallbackNumber",
+    "SetContactAttributes": "UpdateContactAttributes",
+    "SetRecordingBehavior": "UpdateContactRecordingBehavior",
+    "SetLoggingBehavior": "UpdateFlowLoggingBehavior",
+    "SetVoice": "UpdateContactTextToSpeechVoice",
+    "CreateCallbackContact": "(remove — use UpdateContactCallbackNumber + TransferContactToQueue)",
+    "TransferToQueue": "TransferContactToQueue",
+    "EndFlow": "DisconnectParticipant",
+    "Disconnect": "DisconnectParticipant",
+}
+
 
 def lint_contact_flow(flow_json: str) -> dict:
     """Validate Amazon Connect Contact Flow JSON structural integrity.
@@ -505,7 +571,6 @@ def lint_contact_flow(flow_json: str) -> dict:
         return {"ok": False, "errors": ["Flow root is not an object"], "warnings": [], "fixes_applied": [], "fixed_json": flow_json}
 
     actions = doc.get("Actions") or doc.get("actions") or []
-    start = doc.get("StartAction") or doc.get("startAction")
     errors: list[str] = []
     warnings: list[str] = []
     fixes_applied: list[str] = []
@@ -531,10 +596,89 @@ def lint_contact_flow(flow_json: str) -> dict:
             fixes_applied.append(
                 f"Removed 'RealTime' from Voice.AnalyticsModes (→ {new_modes}) — RealTime breaks Connect import"
             )
+    # Deterministic auto-fix: a `Trigger` / `EntryPoint` block does not exist in
+    # the flow language — a flow starts directly at the action StartAction points
+    # to. The model sometimes emits a no-op Trigger as the StartAction. Rewire
+    # StartAction to the Trigger's NextAction and drop the Trigger block so the
+    # flow imports.
+    _start_id = doc.get("StartAction") or doc.get("startAction")
+    for a in list(actions):
+        if not isinstance(a, dict):
+            continue
+        if (a.get("Type") or a.get("type")) not in ("Trigger", "EntryPoint"):
+            continue
+        aid = a.get("Identifier") or a.get("identifier")
+        trans = a.get("Transitions") or a.get("transitions") or {}
+        nxt = trans.get("NextAction") or trans.get("nextAction")
+        if aid == _start_id and nxt:
+            # Repoint StartAction past the Trigger, then remove the Trigger block.
+            if "StartAction" in doc:
+                doc["StartAction"] = nxt
+            else:
+                doc["startAction"] = nxt
+            actions.remove(a)
+            # Drop its ActionMetadata entry if present.
+            md = doc.get("Metadata") or {}
+            am = md.get("ActionMetadata") if isinstance(md, dict) else None
+            if isinstance(am, dict):
+                am.pop(aid, None)
+            fixes_applied.append(
+                f"Removed invalid '{a.get('Type') or a.get('type')}' block '{aid}'; "
+                f"StartAction → '{nxt}' (no Trigger block exists in flow language)"
+            )
+
+    # Deterministic block-type validation: an Action whose Type is not a real
+    # Amazon Connect flow-language Action Type makes the flow fail to import
+    # (InvalidContactFlowException). The model occasionally hallucinates blocks
+    # like `Trigger`, `CheckCondition`, `InvokeAgentAction`. Catch every such
+    # Type and, for the known 1:1 renames, auto-fix it.
+    invalid_types: list[str] = []
+    for a in actions:
+        if not isinstance(a, dict):
+            continue
+        t = a.get("Type") or a.get("type")
+        if not t or t in VALID_CONTACT_FLOW_ACTION_TYPES:
+            continue
+        hint = INVALID_CONTACT_FLOW_TYPE_HINTS.get(t)
+        if hint and not hint.startswith("("):
+            # Safe 1:1 rename to a real Type.
+            if "Type" in a:
+                a["Type"] = hint
+            else:
+                a["type"] = hint
+            # When renaming a hallucinated AI block to ConnectParticipantWithLexBot,
+            # the old params (AgentAliasArn / IdleSessionTimeout / EndConversationPhrase)
+            # are invalid for the Lex block and Connect rejects them on import.
+            # Rewrite to the minimum valid shape: LexV2Bot.AliasArn + Text.
+            if hint == "ConnectParticipantWithLexBot":
+                p = a.get("Parameters") or a.get("parameters") or {}
+                if "LexV2Bot" not in p and "LexBot" not in p:
+                    old_arn = p.pop("AgentAliasArn", None) or p.pop("BotAliasArn", None)
+                    phrase = p.pop("EndConversationPhrase", None)
+                    p.pop("IdleSessionTimeout", None)
+                    p["LexV2Bot"] = {"AliasArn": old_arn or "{{LEX_BOT_ALIAS_ARN}}"}
+                    if "Text" not in p and "SSML" not in p and "PromptId" not in p and "Media" not in p:
+                        p["Text"] = phrase or "{{WELCOME_MESSAGE}}"
+                    if "Parameters" in a:
+                        a["Parameters"] = p
+                    else:
+                        a["parameters"] = p
+                    fixes_applied.append(
+                        f"Rewrote '{t}' params → ConnectParticipantWithLexBot (LexV2Bot.AliasArn + Text)"
+                    )
+            fixes_applied.append(f"Renamed invalid block Type '{t}' → '{hint}'")
+        else:
+            suffix = f" — {hint}" if hint else " (not a valid Amazon Connect flow Action Type)"
+            invalid_types.append(f"Action '{a.get('Identifier') or a.get('identifier')}' has invalid Type '{t}'{suffix}")
+
     flow_json_fixed = _json.dumps(doc, ensure_ascii=False, indent=2) if fixes_applied else flow_json
 
     if not actions:
         return {"ok": False, "errors": ["No Actions in flow"], "warnings": []}
+
+    # Read StartAction AFTER the auto-fixes above (the Trigger fix may have
+    # repointed it) so downstream validation reflects the corrected flow.
+    start = doc.get("StartAction") or doc.get("startAction")
 
     ids = set()
     for a in actions:
@@ -594,8 +738,12 @@ def lint_contact_flow(flow_json: str) -> dict:
             warnings.append(f"{len(orphans)} action(s) unreachable from StartAction: {sorted(orphans)[:5]}")
 
     types = {(a.get("Type") or a.get("type")) for a in actions if isinstance(a, dict)}
+    # Re-evaluate terminal block AFTER any Type auto-fixes (e.g. EndFlow→Disconnect).
     if "DisconnectParticipant" not in types:
         warnings.append("No DisconnectParticipant (terminal) block — flow may not end cleanly")
+
+    # Invalid Types that could NOT be auto-renamed are hard import-blockers.
+    errors.extend(invalid_types)
 
     return {"ok": not errors, "errors": errors, "warnings": warnings,
             "fixes_applied": fixes_applied, "fixed_json": flow_json_fixed}

--- a/backend/ecs/src/tools/asset_linters.py
+++ b/backend/ecs/src/tools/asset_linters.py
@@ -499,15 +499,39 @@ def lint_contact_flow(flow_json: str) -> dict:
     try:
         doc = _json.loads(flow_json)
     except Exception as e:
-        return {"ok": False, "errors": [f"Invalid JSON: {e}"], "warnings": []}
+        return {"ok": False, "errors": [f"Invalid JSON: {e}"], "warnings": [], "fixes_applied": [], "fixed_json": flow_json}
 
     if not isinstance(doc, dict):
-        return {"ok": False, "errors": ["Flow root is not an object"], "warnings": []}
+        return {"ok": False, "errors": ["Flow root is not an object"], "warnings": [], "fixes_applied": [], "fixed_json": flow_json}
 
     actions = doc.get("Actions") or doc.get("actions") or []
     start = doc.get("StartAction") or doc.get("startAction")
     errors: list[str] = []
     warnings: list[str] = []
+    fixes_applied: list[str] = []
+
+    # Deterministic auto-fix: `RealTime` in a Voice AnalyticsModes list breaks
+    # Amazon Connect import (InvalidContactFlowException on
+    # AnalyticsBehavior.ChannelConfiguration.Voice) unless real-time Contact Lens
+    # preconditions are met. Drop it (keep PostContact / others) so the flow
+    # always imports. Verified against create-contact-flow.
+    for a in actions:
+        if not isinstance(a, dict):
+            continue
+        if (a.get("Type") or a.get("type")) != "UpdateContactRecordingBehavior":
+            continue
+        params = a.get("Parameters") or a.get("parameters") or {}
+        ab = params.get("AnalyticsBehavior") or {}
+        cc = ab.get("ChannelConfiguration") or {}
+        voice = cc.get("Voice") or {}
+        modes = voice.get("AnalyticsModes")
+        if isinstance(modes, list) and "RealTime" in modes:
+            new_modes = [m for m in modes if m != "RealTime"] or ["PostContact"]
+            voice["AnalyticsModes"] = new_modes
+            fixes_applied.append(
+                f"Removed 'RealTime' from Voice.AnalyticsModes (→ {new_modes}) — RealTime breaks Connect import"
+            )
+    flow_json_fixed = _json.dumps(doc, ensure_ascii=False, indent=2) if fixes_applied else flow_json
 
     if not actions:
         return {"ok": False, "errors": ["No Actions in flow"], "warnings": []}
@@ -573,7 +597,8 @@ def lint_contact_flow(flow_json: str) -> dict:
     if "DisconnectParticipant" not in types:
         warnings.append("No DisconnectParticipant (terminal) block — flow may not end cleanly")
 
-    return {"ok": not errors, "errors": errors, "warnings": warnings}
+    return {"ok": not errors, "errors": errors, "warnings": warnings,
+            "fixes_applied": fixes_applied, "fixed_json": flow_json_fixed}
 
 
 @tool

--- a/backend/ecs/src/tools/asset_linters.py
+++ b/backend/ecs/src/tools/asset_linters.py
@@ -483,35 +483,38 @@ def lint_lambda(session_id: str = "", operation_id: str = "", file_name: str = "
 # ---------------------------------------------------------------------------
 
 # Official Amazon Connect flow-language Action Types (the `Type` field of an
-# Action). Source: Amazon Connect Flow language — flow block / action reference
-# (contact-actions.html + branch/interact/integrate/set/terminate actions).
-# A flow that contains a `Type` NOT in this set FAILS to import with
-# InvalidContactFlowException. Keep this list complete — when adding support for
-# a new block, add its Type here too.
+# Action). VERIFIED against a real Amazon Connect console export (all 43 block
+# types) PLUS individual CreateContactFlow API probes (2026-06-08). A flow whose
+# `Type` is NOT in this set FAILS to import with InvalidContactFlowException.
+# Source of truth: knowledge-base-docs/contact-flow/_reference-console-export-all-blocks.json
+# Do NOT add a Type here without confirming it imports via the API — guessed
+# names (TransferToAgent, TransferToPhoneNumber, CheckQueueStatus, ...) were the
+# cause of import failures and are listed as invalid below.
 VALID_CONTACT_FLOW_ACTION_TYPES = frozenset({
     # Interact
     "MessageParticipant", "MessageParticipantIteratively", "GetParticipantInput",
-    "ConnectParticipantWithLexBot", "StartMediaStreaming", "StopMediaStreaming",
-    "GetParticipantWithLexV2Bot",
-    # Set
+    "ConnectParticipantWithLexBot", "RenderMessageTemplate",
+    # Set / update
     "UpdateContactAttributes", "UpdateContactData", "UpdateContactRecordingBehavior",
-    "UpdateContactTextToSpeechVoice", "UpdateContactTargetQueue",
-    "UpdateContactCallbackNumber", "UpdateContactEventHooks",
-    "UpdateContactRoutingBehavior", "UpdateContactRoutingData",
-    "UpdateFlowLoggingBehavior", "UpdateFlowAttributes", "UpdateContactMediaStreamingBehavior",
-    "UpdateContactTextToSpeechManner",
+    "UpdateContactRecordingAndAnalyticsBehavior", "UpdateContactTextToSpeechVoice",
+    "UpdateContactTargetQueue", "UpdateContactCallbackNumber", "UpdateContactEventHooks",
+    "UpdateContactRoutingBehavior", "UpdateContactRoutingCriteria",
+    "UpdateFlowLoggingBehavior", "UpdateFlowAttributes",
+    "UpdateContactMediaStreamingBehavior", "UpdatePreviousContactParticipantState",
+    "TagContact", "UntagContact",
     # Branch / control
-    "Compare", "Distribute", "Loop", "DistributeByPercentage",
-    "CheckHoursOfOperation", "CheckMetricData", "CheckQueueStatus",
+    "Compare", "Loop", "Wait", "DistributeByPercentage",
+    "CheckHoursOfOperation", "CheckMetricData", "GetMetricData", "CheckOutboundCallStatus",
+    "EvaluateDataTableValues",
     # Integrate
     "InvokeLambdaFunction", "InvokeFlowModule", "CreateWisdomSession",
-    "InvokeAPI", "CreateTask", "AssociateContactToCustomerProfile",
-    "GetCustomerProfile", "PutCustomerProfile", "CreatePersistentContactAssociation",
-    "GetCustomerProfileObject", "UpdateCustomerProfileObject", "TagContact", "UntagContact",
+    "CreateTask", "CreateCase", "CreateContact", "StartOutboundEmailContact",
+    "AssociateContactToCustomerProfile", "GetCustomerProfile", "GetCustomerProfileObject",
+    "CreatePersistentContactAssociation", "LoadContactContent",
+    "AuthenticateParticipant", "ShowView", "ResumeContact",
     # Transfer / terminate
-    "TransferContactToQueue", "TransferToFlow", "TransferToThirdParty",
-    "TransferToAgent", "TransferToPhoneNumber", "DisconnectParticipant",
-    "EndFlowExecution", "ReturnFromFlowModule",
+    "TransferContactToQueue", "TransferParticipantToThirdParty", "TransferToFlow",
+    "DisconnectParticipant", "EndFlowExecution",
 })
 
 # Known LLM hallucinations / wrong names → the correct official Type (or None
@@ -546,6 +549,24 @@ INVALID_CONTACT_FLOW_TYPE_HINTS = {
     "TransferToQueue": "TransferContactToQueue",
     "EndFlow": "DisconnectParticipant",
     "Disconnect": "DisconnectParticipant",
+    # API-confirmed INVALID Types (2026-06-08) — these returned "Invalid Action
+    # type" from CreateContactFlow. Map to the real Type the console export uses.
+    "TransferToAgent": "TransferContactToQueue",
+    "TransferToPhoneNumber": "TransferParticipantToThirdParty",
+    "TransferToThirdParty": "TransferParticipantToThirdParty",
+    "CheckQueueStatus": "CheckMetricData",
+    "CheckStaffing": "CheckMetricData",
+    "Distribute": "DistributeByPercentage",
+    "StartMediaStreaming": "UpdateContactMediaStreamingBehavior",
+    "StopMediaStreaming": "UpdateContactMediaStreamingBehavior",
+    "ReturnFromFlowModule": "EndFlowExecution",
+    "InvokeAPI": "InvokeLambdaFunction",
+    "GetParticipantWithLexV2Bot": "ConnectParticipantWithLexBot",
+    "PutCustomerProfile": "(use Customer Profiles integration / UpdateContactData)",
+    "UpdateCustomerProfileObject": "(use Customer Profiles integration)",
+    "UpdateContactRoutingData": "UpdateContactRoutingCriteria",
+    "UpdateContactTextToSpeechManner": "UpdateContactTextToSpeechVoice",
+    "SetRecordingAndAnalyticsBehavior": "UpdateContactRecordingAndAnalyticsBehavior",
 }
 
 
@@ -562,9 +583,12 @@ NO_TRANSITION_ACTION_TYPES = frozenset({
 })
 
 # Required Error handlers per Action Type (Connect import enforces these).
+# Required Error handlers per Action Type — all verified against the real
+# CreateContactFlow API (instance 5bf5005e, ap-northeast-2, 2026-06-08).
+# NOTE: GetParticipantInput is intentionally absent — its required errors depend
+# on mode (menu vs store) and are handled in the dedicated normalizer above.
 REQUIRED_ERRORS_BY_TYPE = {
     "MessageParticipant": ["NoMatchingError"],
-    "GetParticipantInput": ["NoMatchingError", "InputTimeLimitExceeded", "NoMatchingCondition"],
     "Compare": ["NoMatchingCondition"],
     "ConnectParticipantWithLexBot": ["NoMatchingError", "NoMatchingCondition"],
     "InvokeLambdaFunction": ["NoMatchingError"],
@@ -572,8 +596,9 @@ REQUIRED_ERRORS_BY_TYPE = {
     "UpdateContactData": ["NoMatchingError"],
     "TransferContactToQueue": ["QueueAtCapacity", "NoMatchingError"],
     "UpdateContactTargetQueue": ["NoMatchingError"],
-    "CheckHoursOfOperation": ["NoMatchingError"],   # branches via True/False Conditions; needs NoMatchingError
-    "UpdateContactCallbackNumber": ["InvalidNumber", "NotDialable", "NoMatchingError"],
+    "UpdateContactAttributes": ["NoMatchingError"],   # API-verified: required
+    "CheckHoursOfOperation": ["NoMatchingError"],     # branches via True/False Conditions; needs NoMatchingError
+    "UpdateContactCallbackNumber": ["NoMatchingError"],  # API-verified: InvalidNumber/NotDialable are NOT valid here
 }
 
 # Error types that are NOT valid for a given block — strip them on import.
@@ -794,6 +819,60 @@ def _normalize_contact_flow_params(actions: list, ids_to_first: dict, fixes: lis
             if not msg_keys:
                 p["Text"] = "{{WELCOME_MESSAGE}}"
                 fixes.append(f"[{aid}] ConnectParticipantWithLexBot: added required Text")
+
+        # --- GetParticipantInput: two distinct API-verified modes.
+        #   MENU mode  (branches via Conditions): StoreInput=False, NO
+        #     DTMFConfiguration, errors must be NoMatchingCondition +
+        #     InputTimeLimitExceeded + NoMatchingError.
+        #   STORE mode (captures input to an attribute): StoreInput=True,
+        #     requires InputValidation.CustomValidation.MaximumLength, optional
+        #     DTMFConfiguration{DisableCancelKey} (NEVER InputTerminationSequence),
+        #     errors = NoMatchingError only.
+        # (Both verified against CreateContactFlow; the empty/guessed forms the
+        #  model emits otherwise fail import with misleading "Invalid Action type".)
+        if t == "GetParticipantInput":
+            tr_gp = a.get("Transitions") or a.get("transitions") or {}
+            conds_gp = tr_gp.get("Conditions") or tr_gp.get("conditions") or []
+            is_menu = bool(conds_gp)
+            if is_menu:
+                if str(p.get("StoreInput")) != "False":
+                    p["StoreInput"] = "False"
+                    fixes.append(f"[{aid}] GetParticipantInput(menu): StoreInput=False")
+                if "DTMFConfiguration" in p:
+                    p.pop("DTMFConfiguration", None)
+                    fixes.append(f"[{aid}] GetParticipantInput(menu): removed DTMFConfiguration")
+                p.pop("InputValidation", None)
+            else:
+                if str(p.get("StoreInput")) != "True":
+                    p["StoreInput"] = "True"
+                    fixes.append(f"[{aid}] GetParticipantInput(store): StoreInput=True")
+                dtmf = p.get("DTMFConfiguration")
+                if isinstance(dtmf, dict) and "InputTerminationSequence" in dtmf:
+                    dtmf.pop("InputTerminationSequence", None)
+                    dtmf.setdefault("DisableCancelKey", "False")
+                    fixes.append(f"[{aid}] GetParticipantInput(store): dropped invalid DTMFConfiguration.InputTerminationSequence")
+                if "InputValidation" not in p:
+                    p["InputValidation"] = {"CustomValidation": {"MaximumLength": "6"}}
+                    fixes.append(f"[{aid}] GetParticipantInput(store): added required InputValidation")
+
+        # --- Loop: condition operands are DoneLooping/ContinueLooping (NOT Looping/Complete)
+        if t == "Loop":
+            tr_lp = a.get("Transitions") or a.get("transitions") or {}
+            for c in (tr_lp.get("Conditions") or tr_lp.get("conditions") or []):
+                if not isinstance(c, dict):
+                    continue
+                ops = c.get("Condition", {}).get("Operands")
+                if isinstance(ops, list):
+                    for i_o, v in enumerate(ops):
+                        lv = str(v).strip().lower()
+                        if lv in ("looping", "continue", "continuelooping"):
+                            if ops[i_o] != "ContinueLooping":
+                                ops[i_o] = "ContinueLooping"
+                                fixes.append(f"[{aid}] Loop: operand → ContinueLooping")
+                        elif lv in ("complete", "done", "donelooping"):
+                            if ops[i_o] != "DoneLooping":
+                                ops[i_o] = "DoneLooping"
+                                fixes.append(f"[{aid}] Loop: operand → DoneLooping")
 
         # --- MessageParticipant / GetParticipantInput: only ONE of Text/SSML/Media
         if t in ("MessageParticipant", "GetParticipantInput", "MessageParticipantIteratively"):

--- a/backend/ecs/src/tools/asset_linters.py
+++ b/backend/ecs/src/tools/asset_linters.py
@@ -549,6 +549,318 @@ INVALID_CONTACT_FLOW_TYPE_HINTS = {
 }
 
 
+# Action Types that are TERMINAL — they end flow execution and MUST NOT carry
+# Transitions. Connect rejects "Action does not support transitions" otherwise.
+TERMINAL_ACTION_TYPES = frozenset({
+    "DisconnectParticipant", "EndFlowExecution", "ReturnFromFlowModule",
+    "TransferToFlow", "TransferContactToQueue", "TransferToAgent",
+})
+# TransferContactToQueue/TransferToAgent DO support transitions (queue-full etc.)
+# so keep only the truly terminal ones for the no-transitions rule.
+NO_TRANSITION_ACTION_TYPES = frozenset({
+    "DisconnectParticipant", "EndFlowExecution", "ReturnFromFlowModule",
+})
+
+# Required Error handlers per Action Type (Connect import enforces these).
+REQUIRED_ERRORS_BY_TYPE = {
+    "MessageParticipant": ["NoMatchingError"],
+    "GetParticipantInput": ["NoMatchingError", "InputTimeLimitExceeded", "NoMatchingCondition"],
+    "Compare": ["NoMatchingCondition"],
+    "ConnectParticipantWithLexBot": ["NoMatchingError", "NoMatchingCondition"],
+    "InvokeLambdaFunction": ["NoMatchingError"],
+    "CreateWisdomSession": ["NoMatchingError"],
+    "UpdateContactData": ["NoMatchingError"],
+    "TransferContactToQueue": ["QueueAtCapacity", "NoMatchingError"],
+    "UpdateContactTargetQueue": ["NoMatchingError"],
+    "CheckHoursOfOperation": ["NoMatchingError"],   # branches via True/False Conditions; needs NoMatchingError
+    "UpdateContactCallbackNumber": ["InvalidNumber", "NotDialable", "NoMatchingError"],
+}
+
+# Error types that are NOT valid for a given block — strip them on import.
+INVALID_ERRORS_BY_TYPE = {
+    "ConnectParticipantWithLexBot": {"AgentError"},
+    "CheckHoursOfOperation": {"NoMatchingCondition"},
+    # Compare branches via Conditions; its only valid Error is NoMatchingCondition.
+    "Compare": {"NoMatchingError"},
+}
+
+# Canonical AI-bot tool-result vocabulary (see SUBAGENT_TERMINOLOGY_AND_ESCALATION).
+# The bot returns exactly `Complete` (end call) or `Escalate` (human transfer);
+# the flow's Compare branches on these. Map common LLM synonyms back to canonical.
+# Keys are upper-cased for case-insensitive matching. Spec-driven extensions like
+# `OutOfHoursComplete` / `EscalateBilling` are intentionally NOT remapped.
+_CANONICAL_TOOL_RESULT = {
+    "COMPLETE": "Complete",
+    "END_CALL": "Complete",
+    "ENDCALL": "Complete",
+    "END_CONVERSATION": "Complete",
+    "ENDCONVERSATION": "Complete",
+    "DONE": "Complete",
+    "FINISH": "Complete",
+    "FINISHED": "Complete",
+    "HANGUP": "Complete",
+    "DISCONNECT": "Complete",
+    "ESCALATE": "Escalate",
+    "ESCALATION": "Escalate",
+    "TRANSFER": "Escalate",
+    "TRANSFER_TO_AGENT": "Escalate",
+    "AGENT": "Escalate",
+    "HUMAN": "Escalate",
+    "HANDOFF": "Escalate",
+}
+
+# Valid JSONPath root namespaces for Compare.ComparisonValue / attribute refs.
+# The model sometimes invents roots like `$.Agent.ReturnControlEvent.Type`.
+_VALID_JSONPATH_ROOTS = (
+    "$.Attributes.", "$.Channel", "$.CustomerEndpoint", "$.SystemEndpoint",
+    "$.Lex.", "$.Customer.", "$.External.", "$.StoredCustomerInput",
+    "$.Media.", "$.ContactId", "$.InitialContactId", "$.Queue.",
+    "$.Metadata.", "$.FlowAttributes.",
+)
+
+
+def _normalize_contact_flow_params(actions: list, ids_to_first: dict, fixes: list) -> None:
+    """Rewrite block Parameters/Transitions to the shapes Amazon Connect's
+    CreateContactFlow API actually accepts. Mutates `actions` in place and
+    appends human-readable notes to `fixes`.
+
+    Every rule here was derived from real InvalidContactFlowException `problems`
+    returned by the Connect API (the strict validator the console import uses):
+      - UpdateContactRecordingBehavior: {Agent,Customer} → {RecordingBehavior,…}
+      - UpdateContactTextToSpeechVoice: {VoiceId,Engine,LanguageCode} → {TextToSpeechVoice,TextToSpeechEngine}
+      - UpdateFlowLoggingBehavior:      {LoggingBehavior} → {FlowLoggingBehavior}
+      - UpdateContactTargetQueue:       {Queue} → {QueueId}
+      - ConnectParticipantWithLexBot:   {BotAliasArn,LexBot{AliasArn},Participant…} → {LexV2Bot{AliasArn},Text}
+      - terminal blocks:                strip Transitions
+      - MessageParticipant:             only ONE of Text/SSML/Media
+      - missing required Error handlers: injected, routed to a safe fallback
+    """
+    # A safe fallback target for injected error transitions: prefer an existing
+    # disconnect/terminal block, else the first action.
+    fallback = None
+    for a in actions:
+        if isinstance(a, dict) and (a.get("Type") or a.get("type")) == "DisconnectParticipant":
+            fallback = a.get("Identifier") or a.get("identifier")
+            break
+    if not fallback and actions:
+        fallback = actions[0].get("Identifier") or actions[0].get("identifier")
+
+    for a in actions:
+        if not isinstance(a, dict):
+            continue
+        t = a.get("Type") or a.get("type")
+        p = a.get("Parameters")
+        if p is None:
+            p = a.get("parameters")
+        if p is None:
+            p = {}
+        pkey = "Parameters" if "Parameters" in a or "parameters" not in a else "parameters"
+        aid = a.get("Identifier") or a.get("identifier")
+
+        # --- UpdateContactRecordingBehavior: {Agent, Customer} → RecordingBehavior
+        if t == "UpdateContactRecordingBehavior":
+            if "RecordingBehavior" not in p:
+                p.pop("Agent", None)
+                p.pop("Customer", None)
+                p["RecordingBehavior"] = {
+                    "RecordedParticipants": ["Agent", "Customer"],
+                    "IVRRecordingBehavior": "Enabled",
+                }
+                p.setdefault("AnalyticsBehavior", {
+                    "Enabled": "True",
+                    "AnalyticsLanguage": "ko-KR",
+                    "ChannelConfiguration": {
+                        "Chat": {"AnalyticsModes": ["ContactLens"]},
+                        "Voice": {"AnalyticsModes": ["PostContact"]},
+                    },
+                })
+                fixes.append(f"[{aid}] UpdateContactRecordingBehavior: rebuilt RecordingBehavior (removed Agent/Customer)")
+
+        # --- UpdateContactTextToSpeechVoice: {VoiceId,Engine,LanguageCode} → {TextToSpeechVoice,Engine}
+        elif t == "UpdateContactTextToSpeechVoice":
+            if "TextToSpeechVoice" not in p:
+                voice = p.pop("VoiceId", None) or "Seoyeon"
+                eng = p.pop("Engine", None) or "Generative"
+                p.pop("LanguageCode", None)
+                p["TextToSpeechVoice"] = voice
+                p["TextToSpeechEngine"] = eng
+                p.setdefault("TextToSpeechStyle", "None")
+                fixes.append(f"[{aid}] UpdateContactTextToSpeechVoice: VoiceId/Engine/LanguageCode → TextToSpeechVoice/TextToSpeechEngine")
+
+        # --- UpdateFlowLoggingBehavior: {LoggingBehavior} → {FlowLoggingBehavior}
+        elif t == "UpdateFlowLoggingBehavior":
+            if "FlowLoggingBehavior" not in p and "LoggingBehavior" in p:
+                p["FlowLoggingBehavior"] = p.pop("LoggingBehavior")
+                fixes.append(f"[{aid}] UpdateFlowLoggingBehavior: LoggingBehavior → FlowLoggingBehavior")
+
+        # --- UpdateContactTargetQueue: {Queue} → {QueueId}; flatten nested QueueId
+        elif t == "UpdateContactTargetQueue":
+            if "QueueId" not in p and "Queue" in p:
+                p["QueueId"] = p.pop("Queue")
+                fixes.append(f"[{aid}] UpdateContactTargetQueue: Queue → QueueId")
+            # QueueId must be a string ARN/id, not a nested object {"QueueId": "..."}
+            if isinstance(p.get("QueueId"), dict):
+                inner = p["QueueId"].get("QueueId") or p["QueueId"].get("Id") or next(iter(p["QueueId"].values()), None)
+                p["QueueId"] = inner or "{{QUEUE_ARN}}"
+                fixes.append(f"[{aid}] UpdateContactTargetQueue: flattened nested QueueId → string")
+
+        # --- InvokeLambdaFunction: RequestAttributes → LambdaInvocationAttributes
+        elif t == "InvokeLambdaFunction":
+            if "RequestAttributes" in p:
+                p.setdefault("LambdaInvocationAttributes", p.pop("RequestAttributes"))
+                fixes.append(f"[{aid}] InvokeLambdaFunction: RequestAttributes → LambdaInvocationAttributes")
+            # ResponseValidation.ResponseType must be STRING_MAP (JSON is not accepted)
+            rv = p.get("ResponseValidation")
+            if isinstance(rv, dict) and rv.get("ResponseType") not in ("STRING_MAP", "JSON_OBJECT"):
+                rv["ResponseType"] = "STRING_MAP"
+                fixes.append(f"[{aid}] InvokeLambdaFunction: ResponseValidation.ResponseType → STRING_MAP")
+
+        # --- CheckHoursOfOperation: null/missing HoursOfOperationId → placeholder
+        elif t == "CheckHoursOfOperation":
+            if not p.get("HoursOfOperationId"):
+                p["HoursOfOperationId"] = "{{HOURS_OF_OPERATION_ID}}"
+                fixes.append(f"[{aid}] CheckHoursOfOperation: filled missing HoursOfOperationId placeholder")
+            # Must branch on BOTH True and False conditions.
+            tr = a.get("Transitions") or a.get("transitions") or {}
+            conds = tr.get("Conditions") or tr.get("conditions") or []
+            operands = {str(c.get("Condition", {}).get("Operands", [None])[0])
+                        for c in conds if isinstance(c, dict)}
+            nxt = tr.get("NextAction") or tr.get("nextAction") or fallback
+            true_target = next((c.get("NextAction") for c in conds
+                                if isinstance(c, dict) and str(c.get("Condition", {}).get("Operands", [None])[0]) == "True"), None)
+            if "False" not in operands:
+                conds.append({"Condition": {"Operator": "Equals", "Operands": ["False"]},
+                              "NextAction": nxt})
+                fixes.append(f"[{aid}] CheckHoursOfOperation: added missing 'False' branch")
+            if "True" not in operands:
+                conds.insert(0, {"Condition": {"Operator": "Equals", "Operands": ["True"]},
+                                 "NextAction": true_target or nxt})
+                fixes.append(f"[{aid}] CheckHoursOfOperation: added missing 'True' branch")
+            tr["Conditions"] = conds
+            a["Transitions" if "Transitions" in a or "transitions" not in a else "transitions"] = tr
+
+        # --- Compare: ComparisonValue must use a valid JSONPath root
+        elif t == "Compare":
+            cv = p.get("ComparisonValue")
+            if isinstance(cv, str) and cv.startswith("$.") and not cv.startswith(_VALID_JSONPATH_ROOTS):
+                # Re-home an invented root (e.g. $.Agent.ReturnControlEvent.Type)
+                # to a contact attribute, which is where flow logic should read.
+                leaf = cv.rstrip(".").split(".")[-1]
+                p["ComparisonValue"] = f"$.Attributes.{leaf}"
+                fixes.append(f"[{aid}] Compare: ComparisonValue '{cv}' → '$.Attributes.{leaf}' (invalid JSONPath root)")
+            # Canonical AI-bot tool-result vocabulary: when this Compare branches on
+            # the bot's Tool result, the operands MUST be `Complete`/`Escalate`
+            # (see SUBAGENT_TERMINOLOGY_AND_ESCALATION). Normalize known wrong
+            # synonyms so the flow's branch matches what the bot actually returns.
+            cv2 = p.get("ComparisonValue") or ""
+            if isinstance(cv2, str) and (".Tool" in cv2 or "actionType" in cv2 or ".toolResult" in cv2 or ".Tool." in cv2):
+                tr = a.get("Transitions") or a.get("transitions") or {}
+                for cond in (tr.get("Conditions") or tr.get("conditions") or []):
+                    if not isinstance(cond, dict):
+                        continue
+                    ops = cond.get("Condition", {}).get("Operands")
+                    if not isinstance(ops, list):
+                        continue
+                    for i_op, val in enumerate(ops):
+                        canon = _CANONICAL_TOOL_RESULT.get(str(val).strip().upper())
+                        if canon and val != canon:
+                            ops[i_op] = canon
+                            fixes.append(f"[{aid}] Compare: tool-result operand '{val}' → '{canon}' (canonical Complete/Escalate vocabulary)")
+
+        # --- ConnectParticipantWithLexBot: normalize to LexV2Bot.AliasArn + one message
+        elif t == "ConnectParticipantWithLexBot":
+            # Collect any ARN the model produced under various wrong keys.
+            arn = (p.pop("BotAliasArn", None)
+                   or p.pop("AgentAliasArn", None)
+                   or (isinstance(p.get("LexBot"), dict) and p["LexBot"].get("AliasArn"))
+                   or (isinstance(p.get("LexV2Bot"), dict) and p["LexV2Bot"].get("AliasArn")))
+            # Drop non-existent params.
+            for bad in ("ParticipantRole", "SessionAttributes", "RequestAttributes",
+                        "IdleSessionTimeout", "EndConversationPhrase"):
+                if bad in p and bad != "SessionAttributes":
+                    p.pop(bad, None)
+            # Migrate LexSessionAttributes-style key if present under SessionAttributes.
+            if "SessionAttributes" in p:
+                p.setdefault("LexSessionAttributes", p.pop("SessionAttributes"))
+            # Remove a malformed LexBot (V1 requires Name+Region+Alias; we use V2).
+            lexbot = p.get("LexBot")
+            if isinstance(lexbot, dict) and not all(k in lexbot for k in ("Name", "Region", "Alias")):
+                p.pop("LexBot", None)
+            if "LexV2Bot" not in p and "LexBot" not in p:
+                p["LexV2Bot"] = {"AliasArn": arn or "{{LEX_BOT_ALIAS_ARN}}"}
+                fixes.append(f"[{aid}] ConnectParticipantWithLexBot: normalized to LexV2Bot.AliasArn")
+            # Must have exactly one message property.
+            msg_keys = [k for k in ("Text", "SSML", "PromptId", "Media", "LexInitializationData") if k in p]
+            if not msg_keys:
+                p["Text"] = "{{WELCOME_MESSAGE}}"
+                fixes.append(f"[{aid}] ConnectParticipantWithLexBot: added required Text")
+
+        # --- MessageParticipant / GetParticipantInput: only ONE of Text/SSML/Media
+        if t in ("MessageParticipant", "GetParticipantInput", "MessageParticipantIteratively"):
+            present = [k for k in ("Text", "SSML", "PromptId", "Media") if k in p]
+            if len(present) > 1:
+                # Keep Text if present, else the first; drop the rest.
+                keep = "Text" if "Text" in present else present[0]
+                for k in present:
+                    if k != keep:
+                        p.pop(k, None)
+                fixes.append(f"[{aid}] {t}: kept only '{keep}' (removed {[k for k in present if k!=keep]})")
+
+        # write params back
+        if pkey in a or p:
+            a[pkey] = p
+
+        # --- Terminal blocks must not carry Transitions / Conditions / Errors
+        if t in NO_TRANSITION_ACTION_TYPES:
+            removed = []
+            for k in ("Transitions", "transitions", "Conditions", "Errors"):
+                if a.get(k):
+                    a.pop(k, None)
+                    removed.append(k)
+                elif k in a:
+                    a.pop(k, None)
+            if removed:
+                fixes.append(f"[{aid}] {t}: removed {removed} (terminal block carries none)")
+
+        # --- Strip Error types that are invalid for this block
+        bad_errs = INVALID_ERRORS_BY_TYPE.get(t)
+        if bad_errs:
+            tr = a.get("Transitions") or a.get("transitions")
+            if isinstance(tr, dict):
+                errs = tr.get("Errors") or tr.get("errors")
+                if isinstance(errs, list):
+                    kept = [e for e in errs if (e.get("ErrorType") or e.get("errorType")) not in bad_errs]
+                    if len(kept) != len(errs):
+                        tr["Errors" if "Errors" in tr else "errors"] = kept
+                        fixes.append(f"[{aid}] {t}: removed invalid Error type(s) {sorted(bad_errs & {e.get('ErrorType') or e.get('errorType') for e in errs})}")
+
+        # --- Inject missing required Error handlers
+        req = REQUIRED_ERRORS_BY_TYPE.get(t)
+        if req and t not in NO_TRANSITION_ACTION_TYPES:
+            tr = a.get("Transitions")
+            trkey = "Transitions"
+            if tr is None:
+                tr = a.get("transitions")
+                trkey = "transitions"
+            if tr is None:
+                tr = {}
+                trkey = "Transitions"
+            errs = tr.get("Errors")
+            if errs is None:
+                errs = tr.get("errors") or []
+            have = {e.get("ErrorType") or e.get("errorType") for e in errs if isinstance(e, dict)}
+            nxt = tr.get("NextAction") or tr.get("nextAction") or fallback
+            added = []
+            for et in req:
+                if et not in have:
+                    errs.append({"ErrorType": et, "NextAction": fallback or nxt})
+                    added.append(et)
+            if added:
+                tr["Errors"] = errs
+                a[trkey] = tr
+                fixes.append(f"[{aid}] {t}: added required Error(s) {added}")
+
+
 def lint_contact_flow(flow_json: str) -> dict:
     """Validate Amazon Connect Contact Flow JSON structural integrity.
 
@@ -670,6 +982,15 @@ def lint_contact_flow(flow_json: str) -> dict:
         else:
             suffix = f" — {hint}" if hint else " (not a valid Amazon Connect flow Action Type)"
             invalid_types.append(f"Action '{a.get('Identifier') or a.get('identifier')}' has invalid Type '{t}'{suffix}")
+
+    # Deterministic parameter normalization: rewrite block Parameters/Transitions
+    # to the exact shapes Connect's CreateContactFlow API accepts (derived from
+    # real InvalidContactFlowException problems). This fixes the param-name and
+    # required-error drift that makes generated flows fail to import.
+    try:
+        _normalize_contact_flow_params(actions, {}, fixes_applied)
+    except Exception as _e:  # never let normalization break linting
+        warnings.append(f"param normalization skipped: {_e}")
 
     flow_json_fixed = _json.dumps(doc, ensure_ascii=False, indent=2) if fixes_applied else flow_json
 

--- a/backend/ecs/src/tools/asset_linters.py
+++ b/backend/ecs/src/tools/asset_linters.py
@@ -846,14 +846,37 @@ def _normalize_contact_flow_params(actions: list, ids_to_first: dict, fixes: lis
                 if str(p.get("StoreInput")) != "True":
                     p["StoreInput"] = "True"
                     fixes.append(f"[{aid}] GetParticipantInput(store): StoreInput=True")
+                # DTMFConfiguration in store mode accepts ONLY DisableCancelKey.
+                # Any other key (InputTerminationSequence, InputTimeLimitSeconds,
+                # FinishKey, ...) is rejected — InputTimeLimitSeconds belongs at the
+                # Parameters root, not inside DTMFConfiguration.
                 dtmf = p.get("DTMFConfiguration")
-                if isinstance(dtmf, dict) and "InputTerminationSequence" in dtmf:
-                    dtmf.pop("InputTerminationSequence", None)
-                    dtmf.setdefault("DisableCancelKey", "False")
-                    fixes.append(f"[{aid}] GetParticipantInput(store): dropped invalid DTMFConfiguration.InputTerminationSequence")
+                if isinstance(dtmf, dict):
+                    bad = [k for k in list(dtmf.keys()) if k != "DisableCancelKey"]
+                    if bad:
+                        # InputTimeLimitSeconds is a real top-level param — re-home it.
+                        if "InputTimeLimitSeconds" in dtmf and "InputTimeLimitSeconds" not in p:
+                            p["InputTimeLimitSeconds"] = dtmf["InputTimeLimitSeconds"]
+                        for k in bad:
+                            dtmf.pop(k, None)
+                        dtmf.setdefault("DisableCancelKey", "False")
+                        fixes.append(f"[{aid}] GetParticipantInput(store): stripped invalid DTMFConfiguration keys {bad}")
                 if "InputValidation" not in p:
                     p["InputValidation"] = {"CustomValidation": {"MaximumLength": "6"}}
                     fixes.append(f"[{aid}] GetParticipantInput(store): added required InputValidation")
+                # Store mode: ONLY NoMatchingError is valid (no Conditions → no
+                # NoMatchingCondition; InputTimeLimitExceeded is rejected here).
+                tr_st = a.get("Transitions") or a.get("transitions")
+                if isinstance(tr_st, dict):
+                    errs = tr_st.get("Errors") or tr_st.get("errors") or []
+                    nxt = tr_st.get("NextAction") or tr_st.get("nextAction")
+                    bad_err = [e for e in errs if (e.get("ErrorType") or e.get("errorType")) != "NoMatchingError"]
+                    if bad_err:
+                        kept = [e for e in errs if (e.get("ErrorType") or e.get("errorType")) == "NoMatchingError"]
+                        if not kept:
+                            kept = [{"ErrorType": "NoMatchingError", "NextAction": nxt}]
+                        tr_st["Errors" if "Errors" in tr_st else "errors"] = kept
+                        fixes.append(f"[{aid}] GetParticipantInput(store): kept only NoMatchingError (removed {[e.get('ErrorType') for e in bad_err]})")
 
         # --- Loop: condition operands are DoneLooping/ContinueLooping (NOT Looping/Complete)
         if t == "Loop":

--- a/backend/ecs/tests/test_contact_flow_linter.py
+++ b/backend/ecs/tests/test_contact_flow_linter.py
@@ -282,3 +282,28 @@ def test_lex_bot_v1_and_wrong_keys_normalized():
     # required errors injected
     types = {e["ErrorType"] for e in a["Transitions"]["Errors"]}
     assert {"NoMatchingError", "NoMatchingCondition"} <= types
+
+
+def test_getparticipantinput_store_mode_strips_invalid_dtmf_and_errors():
+    # Store mode (no Conditions): DTMFConfiguration may carry ONLY DisableCancelKey;
+    # InputTimeLimitSeconds belongs at the root; only NoMatchingError is valid.
+    flow = _valid_flow()
+    flow["Actions"].insert(1, {
+        "Identifier": "auth", "Type": "GetParticipantInput",
+        "Parameters": {"Text": "Enter 6 digits", "StoreInput": "True",
+                       "DTMFConfiguration": {"InputTimeLimitSeconds": "8", "FinishKey": "#", "DisableCancelKey": "False"}},
+        "Transitions": {"NextAction": "end",
+                        "Errors": [{"ErrorType": "InputTimeLimitExceeded", "NextAction": "end"},
+                                   {"ErrorType": "NoMatchingCondition", "NextAction": "end"},
+                                   {"ErrorType": "NoMatchingError", "NextAction": "end"}]}})
+    flow["Actions"][0]["Transitions"]["NextAction"] = "auth"
+    a, _ = _fixed_action(flow, "auth")
+    # DTMFConfiguration reduced to DisableCancelKey only
+    assert set(a["Parameters"]["DTMFConfiguration"].keys()) == {"DisableCancelKey"}
+    # InputTimeLimitSeconds re-homed to root
+    assert a["Parameters"].get("InputTimeLimitSeconds") == "8"
+    # InputValidation added
+    assert "InputValidation" in a["Parameters"]
+    # only NoMatchingError remains
+    types = {e["ErrorType"] for e in a["Transitions"]["Errors"]}
+    assert types == {"NoMatchingError"}

--- a/backend/ecs/tests/test_contact_flow_linter.py
+++ b/backend/ecs/tests/test_contact_flow_linter.py
@@ -1,0 +1,126 @@
+"""Tests for the Contact Flow structural / import-safety linter.
+
+Covers the hallucinated-block regressions that broke Amazon Connect import:
+  - `Trigger` / `EntryPoint` entry wrappers (no such block exists)
+  - `InvokeAgentAction` (→ ConnectParticipantWithLexBot, with param rewrite)
+  - `CheckCondition` (→ Compare)
+  - `RealTime` in Voice AnalyticsModes
+and asserts valid flows are left untouched (no false positives).
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from tools.asset_linters import lint_contact_flow  # noqa: E402
+
+
+def _valid_flow():
+    return {
+        "Version": "2019-10-30",
+        "StartAction": "log",
+        "Actions": [
+            {"Identifier": "log", "Type": "UpdateFlowLoggingBehavior",
+             "Parameters": {"FlowLoggingBehavior": "Enabled"},
+             "Transitions": {"NextAction": "end"}},
+            {"Identifier": "end", "Type": "DisconnectParticipant",
+             "Parameters": {}, "Transitions": {}},
+        ],
+    }
+
+
+def test_valid_flow_passes_untouched():
+    r = lint_contact_flow(json.dumps(_valid_flow()))
+    assert r["ok"] is True
+    assert r["fixes_applied"] == []
+    assert r["errors"] == []
+
+
+def test_trigger_block_is_removed_and_startaction_repointed():
+    flow = {
+        "Version": "2019-10-30",
+        "StartAction": "entry-point",
+        "Actions": [
+            {"Identifier": "entry-point", "Type": "Trigger", "Parameters": {},
+             "Transitions": {"NextAction": "log"}},
+            {"Identifier": "log", "Type": "UpdateFlowLoggingBehavior",
+             "Parameters": {"FlowLoggingBehavior": "Enabled"},
+             "Transitions": {"NextAction": "end"}},
+            {"Identifier": "end", "Type": "DisconnectParticipant",
+             "Parameters": {}, "Transitions": {}},
+        ],
+    }
+    r = lint_contact_flow(json.dumps(flow))
+    assert r["ok"] is True, r["errors"]
+    fixed = json.loads(r["fixed_json"])
+    assert fixed["StartAction"] == "log"
+    assert all(a["Type"] != "Trigger" for a in fixed["Actions"])
+
+
+def test_checkcondition_renamed_to_compare():
+    flow = _valid_flow()
+    flow["Actions"].insert(1, {
+        "Identifier": "branch", "Type": "CheckCondition",
+        "Parameters": {"ComparisonValue": "$.Channel"},
+        "Transitions": {"NextAction": "end",
+                        "Conditions": [{"NextAction": "end",
+                                        "Condition": {"Operator": "Equals", "Operands": ["VOICE"]}}],
+                        "Errors": [{"ErrorType": "NoMatchingCondition", "NextAction": "end"}]},
+    })
+    flow["Actions"][0]["Transitions"]["NextAction"] = "branch"
+    r = lint_contact_flow(json.dumps(flow))
+    assert r["ok"] is True, r["errors"]
+    fixed = json.loads(r["fixed_json"])
+    types = {a["Type"] for a in fixed["Actions"]}
+    assert "CheckCondition" not in types
+    assert "Compare" in types
+
+
+def test_invoke_agent_action_rewritten_to_lex_bot():
+    flow = _valid_flow()
+    flow["Actions"].insert(1, {
+        "Identifier": "ai", "Type": "InvokeAgentAction",
+        "Parameters": {"AgentAliasArn": "{{AgentAliasArn}}",
+                       "IdleSessionTimeout": "300",
+                       "EndConversationPhrase": "Goodbye"},
+        "Transitions": {"NextAction": "end",
+                        "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "end"}]},
+    })
+    flow["Actions"][0]["Transitions"]["NextAction"] = "ai"
+    r = lint_contact_flow(json.dumps(flow))
+    assert r["ok"] is True, r["errors"]
+    fixed = json.loads(r["fixed_json"])
+    ai = next(a for a in fixed["Actions"] if a["Identifier"] == "ai")
+    assert ai["Type"] == "ConnectParticipantWithLexBot"
+    # invalid params dropped, valid Lex params present
+    assert "AgentAliasArn" not in ai["Parameters"]
+    assert "IdleSessionTimeout" not in ai["Parameters"]
+    assert ai["Parameters"]["LexV2Bot"]["AliasArn"] == "{{AgentAliasArn}}"
+    assert ai["Parameters"]["Text"] == "Goodbye"
+
+
+def test_realtime_stripped_from_voice_analytics():
+    flow = _valid_flow()
+    flow["Actions"].insert(1, {
+        "Identifier": "rec", "Type": "UpdateContactRecordingBehavior",
+        "Parameters": {"AnalyticsBehavior": {"ChannelConfiguration": {
+            "Voice": {"AnalyticsModes": ["RealTime", "PostContact"]}}}},
+        "Transitions": {"NextAction": "end"},
+    })
+    flow["Actions"][0]["Transitions"]["NextAction"] = "rec"
+    r = lint_contact_flow(json.dumps(flow))
+    assert r["ok"] is True, r["errors"]
+    fixed = json.loads(r["fixed_json"])
+    rec = next(a for a in fixed["Actions"] if a["Identifier"] == "rec")
+    modes = rec["Parameters"]["AnalyticsBehavior"]["ChannelConfiguration"]["Voice"]["AnalyticsModes"]
+    assert "RealTime" not in modes
+    assert modes == ["PostContact"]
+
+
+def test_truly_unknown_type_is_hard_error():
+    flow = _valid_flow()
+    flow["Actions"][0]["Type"] = "TotallyMadeUpBlock"
+    r = lint_contact_flow(json.dumps(flow))
+    assert r["ok"] is False
+    assert any("TotallyMadeUpBlock" in e for e in r["errors"])

--- a/backend/ecs/tests/test_contact_flow_linter.py
+++ b/backend/ecs/tests/test_contact_flow_linter.py
@@ -124,3 +124,161 @@ def test_truly_unknown_type_is_hard_error():
     r = lint_contact_flow(json.dumps(flow))
     assert r["ok"] is False
     assert any("TotallyMadeUpBlock" in e for e in r["errors"])
+
+
+# ---------------------------------------------------------------------------
+# Parameter normalization — every rule below was derived from real
+# InvalidContactFlowException `problems` returned by Connect's CreateContactFlow.
+# ---------------------------------------------------------------------------
+
+def _fixed_action(flow, identifier):
+    r = lint_contact_flow(json.dumps(flow))
+    d = json.loads(r["fixed_json"])
+    return next(a for a in d["Actions"] if a["Identifier"] == identifier), r
+
+
+def test_recording_behavior_agent_customer_rebuilt():
+    flow = _valid_flow()
+    flow["Actions"].insert(1, {"Identifier": "rec", "Type": "UpdateContactRecordingBehavior",
+                               "Parameters": {"Agent": "Enabled", "Customer": "Enabled"},
+                               "Transitions": {"NextAction": "end"}})
+    flow["Actions"][0]["Transitions"]["NextAction"] = "rec"
+    a, _ = _fixed_action(flow, "rec")
+    assert "Agent" not in a["Parameters"] and "Customer" not in a["Parameters"]
+    assert a["Parameters"]["RecordingBehavior"]["RecordedParticipants"] == ["Agent", "Customer"]
+
+
+def test_tts_voice_params_renamed():
+    flow = _valid_flow()
+    flow["Actions"].insert(1, {"Identifier": "v", "Type": "UpdateContactTextToSpeechVoice",
+                               "Parameters": {"VoiceId": "Seoyeon", "Engine": "Generative", "LanguageCode": "ko-KR"},
+                               "Transitions": {"NextAction": "end"}})
+    flow["Actions"][0]["Transitions"]["NextAction"] = "v"
+    a, _ = _fixed_action(flow, "v")
+    assert a["Parameters"]["TextToSpeechVoice"] == "Seoyeon"
+    assert a["Parameters"]["TextToSpeechEngine"] == "Generative"
+    assert "VoiceId" not in a["Parameters"] and "LanguageCode" not in a["Parameters"]
+
+
+def test_logging_behavior_renamed():
+    flow = _valid_flow()
+    flow["Actions"][0]["Type"] = "UpdateFlowLoggingBehavior"
+    flow["Actions"][0]["Parameters"] = {"LoggingBehavior": "Enabled"}
+    a, _ = _fixed_action(flow, "log")
+    assert a["Parameters"]["FlowLoggingBehavior"] == "Enabled"
+    assert "LoggingBehavior" not in a["Parameters"]
+
+
+def test_target_queue_flattened_and_renamed():
+    flow = _valid_flow()
+    flow["Actions"].insert(1, {"Identifier": "q", "Type": "UpdateContactTargetQueue",
+                               "Parameters": {"QueueId": {"QueueId": "arn:q"}},
+                               "Transitions": {"NextAction": "end"}})
+    flow["Actions"][0]["Transitions"]["NextAction"] = "q"
+    a, _ = _fixed_action(flow, "q")
+    assert a["Parameters"]["QueueId"] == "arn:q"
+
+
+def test_lambda_request_attributes_renamed():
+    flow = _valid_flow()
+    flow["Actions"].insert(1, {"Identifier": "fn", "Type": "InvokeLambdaFunction",
+                               "Parameters": {"LambdaFunctionARN": "arn:fn", "InvocationTimeLimitSeconds": "8",
+                                              "RequestAttributes": {"phone": "$.x"}},
+                               "Transitions": {"NextAction": "end"}})
+    flow["Actions"][0]["Transitions"]["NextAction"] = "fn"
+    a, _ = _fixed_action(flow, "fn")
+    assert "RequestAttributes" not in a["Parameters"]
+    assert a["Parameters"]["LambdaInvocationAttributes"] == {"phone": "$.x"}
+
+
+def test_terminal_block_strips_stray_conditions_errors():
+    flow = _valid_flow()
+    # DisconnectParticipant with stray top-level Conditions/Errors
+    flow["Actions"][1]["Conditions"] = []
+    flow["Actions"][1]["Errors"] = [{"ErrorType": "NoMatchingError", "NextAction": "log"}]
+    a, _ = _fixed_action(flow, "end")
+    assert "Conditions" not in a and "Errors" not in a and "Transitions" not in a
+
+
+def test_check_hours_gets_both_true_false_branches():
+    flow = _valid_flow()
+    flow["Actions"].insert(1, {"Identifier": "h", "Type": "CheckHoursOfOperation",
+                               "Parameters": {"HoursOfOperationId": None},
+                               "Transitions": {"NextAction": "end",
+                                               "Conditions": [{"Condition": {"Operator": "Equals", "Operands": ["True"]},
+                                                               "NextAction": "end"}]}})
+    flow["Actions"][0]["Transitions"]["NextAction"] = "h"
+    a, _ = _fixed_action(flow, "h")
+    operands = {c["Condition"]["Operands"][0] for c in a["Transitions"]["Conditions"]}
+    assert operands == {"True", "False"}
+    assert a["Parameters"]["HoursOfOperationId"]  # placeholder filled
+
+
+def test_compare_invalid_jsonpath_root_rehomed():
+    flow = _valid_flow()
+    flow["Actions"].insert(1, {"Identifier": "c", "Type": "Compare",
+                               "Parameters": {"ComparisonValue": "$.Agent.ReturnControlEvent.Type"},
+                               "Transitions": {"NextAction": "end",
+                                               "Conditions": [{"Condition": {"Operator": "Equals", "Operands": ["X"]}, "NextAction": "end"}]}})
+    flow["Actions"][0]["Transitions"]["NextAction"] = "c"
+    a, _ = _fixed_action(flow, "c")
+    assert a["Parameters"]["ComparisonValue"] == "$.Attributes.Type"
+
+
+def test_compare_invalid_error_type_stripped():
+    flow = _valid_flow()
+    flow["Actions"].insert(1, {"Identifier": "c", "Type": "Compare",
+                               "Parameters": {"ComparisonValue": "$.Attributes.x"},
+                               "Transitions": {"NextAction": "end",
+                                               "Conditions": [{"Condition": {"Operator": "Equals", "Operands": ["X"]}, "NextAction": "end"}],
+                                               "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "end"}]}})
+    flow["Actions"][0]["Transitions"]["NextAction"] = "c"
+    a, _ = _fixed_action(flow, "c")
+    types = {e["ErrorType"] for e in a["Transitions"].get("Errors", [])}
+    assert "NoMatchingError" not in types
+    assert "NoMatchingCondition" in types
+
+
+def test_tool_result_operands_normalized_to_canonical():
+    flow = _valid_flow()
+    flow["Actions"].insert(1, {"Identifier": "c", "Type": "Compare",
+                               "Parameters": {"ComparisonValue": "$.Lex.SessionAttributes.Tool"},
+                               "Transitions": {"NextAction": "end",
+                                               "Conditions": [
+                                                   {"Condition": {"Operator": "Equals", "Operands": ["ESCALATE"]}, "NextAction": "end"},
+                                                   {"Condition": {"Operator": "Equals", "Operands": ["END_CALL"]}, "NextAction": "end"}]}})
+    flow["Actions"][0]["Transitions"]["NextAction"] = "c"
+    a, _ = _fixed_action(flow, "c")
+    operands = {c["Condition"]["Operands"][0] for c in a["Transitions"]["Conditions"]}
+    assert operands == {"Escalate", "Complete"}
+
+
+def test_tool_result_spec_extension_preserved():
+    # Spec-driven extensions like OutOfHoursComplete must NOT be remapped.
+    flow = _valid_flow()
+    flow["Actions"].insert(1, {"Identifier": "c", "Type": "Compare",
+                               "Parameters": {"ComparisonValue": "$.Lex.SessionAttributes.Tool"},
+                               "Transitions": {"NextAction": "end",
+                                               "Conditions": [
+                                                   {"Condition": {"Operator": "Equals", "Operands": ["Escalate"]}, "NextAction": "end"},
+                                                   {"Condition": {"Operator": "Equals", "Operands": ["OutOfHoursComplete"]}, "NextAction": "end"}]}})
+    flow["Actions"][0]["Transitions"]["NextAction"] = "c"
+    a, _ = _fixed_action(flow, "c")
+    operands = {c["Condition"]["Operands"][0] for c in a["Transitions"]["Conditions"]}
+    assert operands == {"Escalate", "OutOfHoursComplete"}
+
+
+def test_lex_bot_v1_and_wrong_keys_normalized():
+    flow = _valid_flow()
+    flow["Actions"].insert(1, {"Identifier": "lex", "Type": "ConnectParticipantWithLexBot",
+                               "Parameters": {"BotAliasArn": "arn:lex", "ParticipantRole": "X",
+                                              "SessionAttributes": {"k": "v"}},
+                               "Transitions": {"NextAction": "end"}})
+    flow["Actions"][0]["Transitions"]["NextAction"] = "lex"
+    a, _ = _fixed_action(flow, "lex")
+    assert a["Parameters"]["LexV2Bot"]["AliasArn"] == "arn:lex"
+    assert "BotAliasArn" not in a["Parameters"] and "ParticipantRole" not in a["Parameters"]
+    assert any(k in a["Parameters"] for k in ("Text", "SSML", "PromptId", "Media"))
+    # required errors injected
+    types = {e["ErrorType"] for e in a["Transitions"]["Errors"]}
+    assert {"NoMatchingError", "NoMatchingCondition"} <= types

--- a/backend/ecs/tests/test_field_schema_section.py
+++ b/backend/ecs/tests/test_field_schema_section.py
@@ -1,0 +1,61 @@
+"""Regression tests for build_field_schema_section robustness.
+
+This helper is shared by the lambda_generator and openapi_generator. A complex
+spec whose input_fields/output_fields contain a bare string element, or whose
+nested items/properties arrive as double-encoded JSON strings, used to crash
+every generation with "'str' object has no attribute 'get'". These tests lock
+in the fault-tolerant behavior.
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from agents._consistency_rules import (  # noqa: E402
+    build_field_schema_section,
+    _render_field_tree,
+    _field_has_nested_structure,
+)
+
+
+def test_bare_string_field_does_not_crash():
+    assert _field_has_nested_structure("cardId") is False
+    assert _render_field_tree("cardId") == ["- `cardId`: string"]
+
+
+def test_double_encoded_field_recovered():
+    encoded = json.dumps({"name": "status", "enum_values": ["A", "B"]})
+    lines = _render_field_tree(encoded)
+    assert any("status" in ln and "enum" in ln for ln in lines)
+
+
+def test_json_string_items_and_properties():
+    op = {
+        "operation_id": "check_suspicious_transactions",
+        "input_fields": [
+            "cardId",  # bare string element
+            {"name": "filters", "field_type": "object",
+             "properties": json.dumps([{"name": "minAmount", "field_type": "number"}])},
+        ],
+        "output_fields": [
+            {"name": "transactions", "field_type": "array",
+             "items": json.dumps({"name": "tx", "field_type": "object",
+                                  "properties": [{"name": "status", "enum_values": ["SUSPICIOUS", "CANCELLED"]}]})},
+        ],
+    }
+    out = build_field_schema_section([op])
+    # Renders without raising, and recovers the nested enum from the encoded items
+    assert "check_suspicious_transactions" in out
+    assert "minAmount" in out
+    assert "SUSPICIOUS" in out
+
+
+def test_all_string_fields_yields_no_section():
+    # purely scalar / string fields → no nested schema section (no noise, no crash)
+    op = {"operation_id": "x", "input_fields": ["a", "b"], "output_fields": ["c"]}
+    assert build_field_schema_section([op]) == ""
+
+
+def test_non_dict_op_skipped():
+    assert build_field_schema_section(["not-a-dict", 42, None]) == ""

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -8,6 +8,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useBuilderStore } from "../stores/builderStore";
 import { useAuthStore } from "../stores/authStore";
+import { useSessionStore } from "../stores/sessionStore";
 import type { WebSocketMessage, SubagentActivity, SubagentToolCall, AttachedFile, MessageAttachment, AttachmentData, AssetPreview, BuilderPhase } from "../types";
 import { PHASE_LABELS } from "../types";
 import { getSessionHistory, getSessionAssets, getSessionData, getMessageLog, generatePresignedUrl, generateUploadPresignedUrl, uploadFileToS3, fetchAssetContent, type StoredAsset, type ConversationMessage } from "../services/sessions";
@@ -2514,6 +2515,19 @@ export function useWebSocket() {
       // Update the global session ID
       const sub = await getUserSub();
       setCurrentSessionId(newSessionId, sub);
+
+      // Keep the zustand session store in lock-step with the WebSocket session.
+      // FileExplorer (and other components) read currentSessionId from this store,
+      // NOT from useWebSocket's global. Without this sync the store could lag on a
+      // previous session, so the workspace tree rendered a DIFFERENT (often empty)
+      // session's files than the active chat — assets appeared "missing" even
+      // though the backend had them. switchSession is the single chokepoint every
+      // session change flows through, so syncing here covers create/switch/rotate.
+      try {
+        useSessionStore.getState().setCurrentSession(newSessionId);
+      } catch (e) {
+        console.warn("[useWebSocket] failed to sync sessionStore:", e);
+      }
 
       // Close existing connection - mark as intentional to prevent auto-reconnect
       if (globalWs?.readyState === WebSocket.OPEN) {

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -2095,11 +2095,34 @@ export function useWebSocket() {
               fetchNfsDiagnostics(currentId),
               getSessionHistory(currentId).catch(() => null),
             ]);
-            const nfsMissing =
+            // Authoritative: prefer the backend's exact per-session existence
+            // check. `recent_sessions` is a truncated top-10-by-mtime list, so
+            // an older-but-valid session is absent from it — using that as the
+            // signal wrongly rotates the user onto a fresh session and discards
+            // completed work (observed: a generation-phase session got reset to
+            // a brand-new interview session on reload).
+            let nfsMissing: boolean;
+            if (diag && "session_exists" in diag && diag.session_exists !== null && diag.session_exists !== undefined) {
+              nfsMissing = diag.session_exists === false;
+            } else if (
               diag &&
               "recent_sessions" in diag &&
-              Array.isArray(diag.recent_sessions) &&
-              !diag.recent_sessions.includes(currentId);
+              Array.isArray(diag.recent_sessions)
+            ) {
+              // Legacy fallback (old backend without session_exists): only treat
+              // as missing when the sessions dir is non-empty yet this id is
+              // absent AND the dir count is small enough that the top-10 list is
+              // actually exhaustive — otherwise we cannot conclude "missing".
+              const count =
+                "session_dirs_count" in diag && typeof diag.session_dirs_count === "number"
+                  ? diag.session_dirs_count
+                  : Infinity;
+              nfsMissing =
+                count <= diag.recent_sessions.length &&
+                !diag.recent_sessions.includes(currentId);
+            } else {
+              nfsMissing = false;
+            }
             const historyEmpty = !history || history.length === 0;
             if (nfsMissing && historyEmpty && switchSessionRef.current) {
               const lang = useBuilderStore.getState().language;

--- a/frontend/src/services/workspaceApi.ts
+++ b/frontend/src/services/workspaceApi.ts
@@ -69,6 +69,10 @@ export interface NfsDiagnostics {
   sessions_dir_exists: boolean;
   session_dirs_count: number;
   recent_sessions: string[];
+  /** Authoritative existence of the queried session dir (when session_id passed).
+   *  Prefer this over `recent_sessions` membership — the latter is truncated. */
+  queried_session_id?: string | null;
+  session_exists?: boolean | null;
 }
 
 /** Fallback diagnostics gathered without /api/debug/nfs endpoint */
@@ -86,9 +90,14 @@ export async function fetchNfsDiagnostics(
 ): Promise<NfsDiagnostics | FallbackDiagnostics | null> {
   const base = getApiBase();
 
-  // Try the dedicated debug endpoint first
+  // Try the dedicated debug endpoint first. Pass session_id so the backend
+  // returns an authoritative `session_exists` for THIS session (not just the
+  // truncated top-10 recent_sessions list).
   try {
-    const res = await fetch(`${base}/api/debug/nfs`);
+    const url = sessionId
+      ? `${base}/api/debug/nfs?session_id=${encodeURIComponent(sessionId)}`
+      : `${base}/api/debug/nfs`;
+    const res = await fetch(url);
     if (res.ok) {
       return await res.json();
     }

--- a/infrastructure/lib/knowledge-base-stack.ts
+++ b/infrastructure/lib/knowledge-base-stack.ts
@@ -69,6 +69,30 @@ export class KnowledgeBaseStack extends cdk.Stack {
       instruction: "Use this knowledge base to answer questions about Amazon Connect contact flow blocks, patterns, and best practices.",
     });
 
+    // The cdklabs construct grants the KB role PutVectors/GetVectors/QueryVectors
+    // but NOT DeleteVectors. Re-ingestion (after docs change) must delete the old
+    // vectors first, so without this the FIRST ingest works but every UPDATE
+    // fails with AccessDenied on s3vectors:DeleteVectors. Grant the full vector
+    // read/write/delete set on this index + bucket explicitly.
+    kb.role.addToPrincipalPolicy(
+      new iam.PolicyStatement({
+        actions: [
+          "s3vectors:PutVectors",
+          "s3vectors:GetVectors",
+          "s3vectors:QueryVectors",
+          "s3vectors:DeleteVectors",
+          "s3vectors:ListVectors",
+          "s3vectors:GetIndex",
+          "s3vectors:GetVectorBucket",
+        ],
+        resources: [
+          vectorBucket.vectorBucketArn,
+          `${vectorBucket.vectorBucketArn}/*`,
+          vectorIndex.vectorIndexArn,
+        ],
+      })
+    );
+
     // S3 Data Source
     const dataSource = new bedrock.S3DataSource(this, "ContactFlowDataSource", {
       bucket: docsBucket,

--- a/knowledge-base-docs/contact-flow/_VERIFIED-block-type-reference.md
+++ b/knowledge-base-docs/contact-flow/_VERIFIED-block-type-reference.md
@@ -1,0 +1,103 @@
+# Amazon Connect Flow Block Type Reference (API-VERIFIED)
+
+## Question
+What are the valid Amazon Connect contact-flow block `Type` strings, and which
+console block name maps to which JSON `Type`?
+
+## Answer
+This list is the GROUND TRUTH. Every `Type` below was confirmed to import via the
+real `CreateContactFlow` API (verified 2026-06-08 against a console export of all
+blocks). Do NOT invent or guess `Type` names — guessed names like `TransferToAgent`
+or `CheckStaffing` FAIL import with `InvalidContactFlowException: Invalid Action type`.
+
+### Console name → JSON `Type` (verified)
+| Console block | JSON `Type` |
+|---|---|
+| Get customer input / Store customer input | `GetParticipantInput` |
+| Play prompt / Send message | `MessageParticipant` |
+| Message (templated) | `RenderMessageTemplate` |
+| Connect assistant (Q in Connect) | `CreateWisdomSession` |
+| Set callback number | `UpdateContactCallbackNumber` |
+| Set contact attributes | `UpdateContactAttributes` |
+| Set working queue | `UpdateContactTargetQueue` |
+| Set voice | `UpdateContactTextToSpeechVoice` |
+| Set logging behavior | `UpdateFlowLoggingBehavior` |
+| Set recording / analytics | `UpdateContactRecordingAndAnalyticsBehavior` (also legacy `UpdateContactRecordingBehavior`) |
+| Set event flow / hooks | `UpdateContactEventHooks` |
+| Set routing criteria | `UpdateContactRoutingCriteria` |
+| Change routing priority / age | `UpdateContactRoutingBehavior` |
+| Set flow attributes | `UpdateFlowAttributes` |
+| Media streaming (start/stop) | `UpdateContactMediaStreamingBehavior` |
+| Check hours of operation | `CheckHoursOfOperation` |
+| Check contact attributes | `Compare` |
+| Check staffing / Get metrics | `CheckMetricData`, `GetMetricData` |
+| Check call progress (outbound) | `CheckOutboundCallStatus` |
+| Loop | `Loop` |
+| Wait | `Wait` |
+| Distribute by percentage | `DistributeByPercentage` |
+| AWS Lambda function | `InvokeLambdaFunction` |
+| Invoke module | `InvokeFlowModule` |
+| Create task | `CreateTask` |
+| Cases (create) | `CreateCase` |
+| Create contact | `CreateContact` |
+| Outbound email | `StartOutboundEmailContact` |
+| Customer profiles | `GetCustomerProfile`, `GetCustomerProfileObject`, `AssociateContactToCustomerProfile` |
+| Data table | `EvaluateDataTableValues` |
+| Get stored content | `LoadContactContent` |
+| Authenticate customer | `AuthenticateParticipant` |
+| Show view | `ShowView` |
+| Resume contact | `ResumeContact` |
+| Contact tags (tag/untag) | `TagContact`, `UntagContact` |
+| Create persistent contact association | `CreatePersistentContactAssociation` |
+| Q in Connect AI bot | `ConnectParticipantWithLexBot` |
+| Message iteratively | `MessageParticipantIteratively` |
+| Update previous participant state | `UpdatePreviousContactParticipantState` |
+| Transfer to queue | `TransferContactToQueue` |
+| Transfer to phone number / third party | `TransferParticipantToThirdParty` |
+| Transfer to flow | `TransferToFlow` |
+| Disconnect | `DisconnectParticipant` |
+| End flow / resume | `EndFlowExecution` |
+
+### ❌ INVALID Types — never emit (they fail import)
+| Wrong (guessed) | Use instead |
+|---|---|
+| `TransferToAgent` | `TransferContactToQueue` |
+| `TransferToPhoneNumber` / `TransferToThirdParty` | `TransferParticipantToThirdParty` |
+| `CheckStaffing` / `CheckQueueStatus` | `CheckMetricData` |
+| `Distribute` | `DistributeByPercentage` |
+| `StartMediaStreaming` / `StopMediaStreaming` | `UpdateContactMediaStreamingBehavior` |
+| `ReturnFromFlowModule` | `EndFlowExecution` |
+| `InvokeAPI` | `InvokeLambdaFunction` |
+| `GetParticipantWithLexV2Bot` | `ConnectParticipantWithLexBot` |
+| `PutCustomerProfile` / `UpdateCustomerProfileObject` | Customer Profiles integration |
+| `UpdateContactRoutingData` | `UpdateContactRoutingCriteria` |
+| `UpdateContactTextToSpeechManner` | `UpdateContactTextToSpeechVoice` |
+| `SetLoggingBehavior` | `UpdateFlowLoggingBehavior` |
+| `PlayPrompt` | `MessageParticipant` |
+| `StoreUserInput` | `GetParticipantInput` (StoreInput=True) |
+| `Trigger` / `EntryPoint` | none — flow starts at `StartAction`'s target |
+| `InvokeAgentAction` / `InvokeBedrockAgent` | `ConnectParticipantWithLexBot` |
+| `CheckCondition` / `CheckValue` | `Compare` |
+
+### Key per-block schema gotchas (API-verified)
+- **GetParticipantInput** has TWO modes:
+  - *Menu* (branches via Conditions): `StoreInput:"False"`, NO `DTMFConfiguration`;
+    errors = `NoMatchingCondition` + `InputTimeLimitExceeded` + `NoMatchingError`.
+  - *Store* (captures to attribute): `StoreInput:"True"`, requires
+    `InputValidation.CustomValidation.MaximumLength`, optional
+    `DTMFConfiguration.DisableCancelKey` (NEVER `InputTerminationSequence`);
+    error = `NoMatchingError`.
+- **Loop**: Conditions operands are `ContinueLooping` / `DoneLooping` (NOT Looping/Complete).
+- **TransferContactToQueue**: NO `QueueId` param (queue is set by a prior
+  `UpdateContactTargetQueue`); errors `QueueAtCapacity` + `NoMatchingError`.
+- **UpdateContactAttributes**: requires `NoMatchingError`.
+- **UpdateContactCallbackNumber**: only `NoMatchingError` (NOT InvalidNumber/NotDialable).
+- **Compare**: only `NoMatchingCondition` error; `ComparisonValue` must use a real
+  JSONPath root (`$.Attributes.*`, `$.Channel`, `$.Lex.SessionAttributes.*`, etc.).
+- **DisconnectParticipant** / **EndFlowExecution**: terminal — NO Transitions.
+- **CreateWisdomSession**: `WisdomAssistantArn` must be a real existing assistant ARN.
+
+---
+**Metadata**
+- Category: Reference
+- Keywords: block types, action type, valid blocks, invalid blocks, import error, console mapping, verified

--- a/knowledge-base-docs/contact-flow/_reference-console-export-all-blocks.json
+++ b/knowledge-base-docs/contact-flow/_reference-console-export-all-blocks.json
@@ -1,0 +1,1399 @@
+{
+  "Version": "2019-10-30",
+  "StartAction": "",
+  "Metadata": {
+    "entryPointPosition": {
+      "x": 40,
+      "y": 40
+    },
+    "ActionMetadata": {
+      "3b9159fe-c0cd-490a-90c1-e204f7cc2e3e": {
+        "position": {
+          "x": 1810.4,
+          "y": 276
+        },
+        "children": [
+          "2046fe54-3811-4d18-9370-ef7e2e27f876",
+          "dd40e3b1-a426-4041-9919-33232b72f8a5"
+        ]
+      },
+      "2046fe54-3811-4d18-9370-ef7e2e27f876": {
+        "position": {
+          "x": 1810.4,
+          "y": 276
+        }
+      },
+      "dd40e3b1-a426-4041-9919-33232b72f8a5": {
+        "position": {
+          "x": 1810.4,
+          "y": 276
+        }
+      },
+      "70ebff06-8406-44a0-99a1-9fda02b60797": {
+        "position": {
+          "x": 860.8,
+          "y": 511.2
+        },
+        "children": [
+          "2f899339-9c0e-47a6-a226-74d60802ec90"
+        ],
+        "fragments": {
+          "SetContactData": "2f899339-9c0e-47a6-a226-74d60802ec90"
+        }
+      },
+      "2f899339-9c0e-47a6-a226-74d60802ec90": {
+        "position": {
+          "x": 860.8,
+          "y": 511.2
+        },
+        "dynamicParams": []
+      },
+      "d9525de3-f109-4d3b-920d-2d8af074f63e": {
+        "position": {
+          "x": 284.8,
+          "y": 120.8
+        }
+      },
+      "a9744638-1a6b-4b61-9abc-6aa5964dfda3": {
+        "position": {
+          "x": 540,
+          "y": 189.6
+        }
+      },
+      "022164ad-4e26-4052-a9fa-d5f84a49e10d": {
+        "position": {
+          "x": 765.6,
+          "y": 225.6
+        }
+      },
+      "652c3102-acb1-4f05-b5ca-a3e85c85a9eb": {
+        "position": {
+          "x": 1015.2,
+          "y": 252
+        },
+        "conditionMetadata": []
+      },
+      "4403ce89-0daf-41c3-9597-66ff6bbd46b6": {
+        "position": {
+          "x": 1274.4,
+          "y": 270.4
+        }
+      },
+      "bbd2fba2-1786-48fa-bc66-a2a7d66b66ab": {
+        "position": {
+          "x": 1540.8,
+          "y": 259.2
+        }
+      },
+      "cc16283d-1276-4c05-b1e3-d17df10ef5ad": {
+        "position": {
+          "x": 2071.2,
+          "y": 282.4
+        },
+        "conditionMetadata": [],
+        "countryCodePrefix": "+1"
+      },
+      "95f8b0be-db17-46d0-aed6-e5f1bec845e5": {
+        "position": {
+          "x": 1075.2,
+          "y": 512
+        }
+      },
+      "15329f36-3268-462d-8871-7f354805f64f": {
+        "position": {
+          "x": 1319.2,
+          "y": 527.2
+        }
+      },
+      "8a145123-a5bc-4c3f-8231-bdcf4b2723dc": {
+        "position": {
+          "x": 1574.4,
+          "y": 559.2
+        }
+      },
+      "2f5a13eb-68fa-4025-924c-5e3d96514e38": {
+        "position": {
+          "x": 1851.2,
+          "y": 566.4
+        }
+      },
+      "1e9b8e32-7f59-4dff-9805-1091a5a20a81": {
+        "position": {
+          "x": 2101.6,
+          "y": 568.8
+        },
+        "dynamicParams": []
+      },
+      "95270a7b-9d75-4727-8d61-0760b2a76880": {
+        "position": {
+          "x": 2344.8,
+          "y": 608
+        },
+        "parameters": {
+          "EventHooks": {}
+        }
+      },
+      "fbdb6e81-2f7c-4ca7-91a6-d2212ed499d5": {
+        "position": {
+          "x": 2579.2,
+          "y": 635.2
+        },
+        "parameters": {
+          "EventHooks": {}
+        }
+      },
+      "cc9a4039-6db8-425e-a107-c8ed0672ac2c": {
+        "position": {
+          "x": 2806.4,
+          "y": 654.4
+        },
+        "parameters": {
+          "EventHooks": {}
+        }
+      },
+      "01703608-c04b-418f-9d15-ca3f57e02997": {
+        "position": {
+          "x": 3020.8,
+          "y": 671.2
+        },
+        "parameters": {
+          "EventHooks": {}
+        }
+      },
+      "df8e8d07-cf13-47af-aec1-74fa6892dd7f": {
+        "position": {
+          "x": 3256.8,
+          "y": 709.6
+        }
+      },
+      "bba6809b-de21-4b8c-bd93-d61a526919ea": {
+        "position": {
+          "x": 3514.4,
+          "y": 693.6
+        },
+        "conditionMetadata": []
+      },
+      "9768184c-c847-435b-b20b-ad4da56decfa": {
+        "position": {
+          "x": 3746.4,
+          "y": 708
+        },
+        "parameters": {
+          "TextToSpeechVoice": {
+            "languageCode": "en-US"
+          }
+        },
+        "overrideConsoleVoice": false
+      },
+      "00deabc7-8f3e-41c4-af06-67e88812681d": {
+        "position": {
+          "x": 3996.8,
+          "y": 732.8
+        },
+        "parameters": {
+          "EventHooks": {}
+        }
+      },
+      "2fb281a1-b8b5-48f0-ac84-f74094bf74d7": {
+        "position": {
+          "x": 4269.6,
+          "y": 728.8
+        }
+      },
+      "362d1047-4d36-4df9-8ae0-ff5e84f1144e": {
+        "position": {
+          "x": 4503.2,
+          "y": 736.8
+        }
+      },
+      "0c7b88e8-a7ed-434c-a815-9c024cf5115a": {
+        "position": {
+          "x": 670.4,
+          "y": 781.6
+        }
+      },
+      "dfe3f165-5a6f-4a60-94ee-7f41d6c73c50": {
+        "position": {
+          "x": 936.8,
+          "y": 844
+        },
+        "conditionMetadata": []
+      },
+      "9da6d2c1-2ff5-4c3b-8b51-fbf177733b1a": {
+        "position": {
+          "x": 1220.8,
+          "y": 861.6
+        }
+      },
+      "1e8c881b-9234-4e73-88be-3b8500ef22a8": {
+        "position": {
+          "x": 1451.2,
+          "y": 856
+        },
+        "conditionMetadata": []
+      },
+      "c9e42ae9-1a35-4098-be4e-f78e4b5608a0": {
+        "position": {
+          "x": 1696.8,
+          "y": 854.4
+        }
+      },
+      "ee1d8b0d-29e2-40eb-b6e4-c84443b3538a": {
+        "position": {
+          "x": 1938.4,
+          "y": 895.2
+        }
+      },
+      "be51c3e8-27d2-4042-8523-23a178955667": {
+        "position": {
+          "x": 1063.2,
+          "y": 1165.6
+        }
+      },
+      "e81ee789-83af-4dfe-bbf4-0f2eb06a27fd": {
+        "position": {
+          "x": 1285.6,
+          "y": 1134.4
+        }
+      },
+      "6dee7181-ad17-42ef-b7b7-90c6276e684f": {
+        "position": {
+          "x": 1524.8,
+          "y": 1180
+        },
+        "toCustomer": true,
+        "fromCustomer": true
+      },
+      "6fa757e9-a54e-4e65-ba88-dafe314253a1": {
+        "position": {
+          "x": 1738.4,
+          "y": 1177.6
+        }
+      },
+      "eb40a0a7-ca7d-443e-ba83-53b0a7f6d943": {
+        "position": {
+          "x": 1055.2,
+          "y": 1451.2
+        },
+        "conditions": [],
+        "conditionMetadata": []
+      },
+      "767192ee-d9cf-4917-8d90-08268ad8e177": {
+        "position": {
+          "x": 1312,
+          "y": 1470.4
+        }
+      },
+      "1d98bca9-a26e-4413-87b1-c72969be5285": {
+        "position": {
+          "x": 1589.6,
+          "y": 1492.8
+        }
+      },
+      "dfad72bb-96ea-429a-97b1-e28eaf6c223c": {
+        "position": {
+          "x": 1016,
+          "y": 1710.4
+        },
+        "dynamicMetadata": {}
+      },
+      "7ea054d2-bd15-4751-89c9-8c6277390bf7": {
+        "position": {
+          "x": 1232.8,
+          "y": 1744.8
+        },
+        "action": "createCaseAction",
+        "requestFieldsOptions": {},
+        "requiredFieldsOptions": []
+      },
+      "d5f46c83-abbe-4364-a591-9a30d4e09e30": {
+        "position": {
+          "x": 1472,
+          "y": 1740.8
+        },
+        "parameters": {},
+        "useDynamic": {},
+        "customerProfilesAction": "GetCustomerProfile"
+      },
+      "f043fd39-f29d-4ecd-914d-8a5fd1ad5ea1": {
+        "position": {
+          "x": 1724,
+          "y": 1762.4
+        },
+        "parameters": {
+          "DataTableId": {}
+        }
+      },
+      "88417f3d-a54f-4562-8a0c-2d67a987ec47": {
+        "position": {
+          "x": 2004,
+          "y": 1779.2
+        }
+      },
+      "4f8b8898-6637-4d14-aeb2-3480a73fdf2d": {
+        "position": {
+          "x": 2259.2,
+          "y": 1800.8
+        },
+        "parameters": {
+          "ViewResource": {
+            "Id": {
+              "displayName": ""
+            }
+          }
+        }
+      },
+      "bcc89e25-33db-4997-bee7-71fc54546bae": {
+        "position": {
+          "x": 1091.2,
+          "y": 2012.8
+        }
+      },
+      "fadd2209-f1fc-4ab0-ac05-5964c3cbb3de": {
+        "position": {
+          "x": 1323.2,
+          "y": 2039.2
+        }
+      },
+      "8134b785-032c-446f-b715-2b68a8c3c42b": {
+        "position": {
+          "x": 1570.4,
+          "y": 2044.8
+        }
+      },
+      "13f57914-992d-4730-971a-3a415e49542d": {
+        "position": {
+          "x": 1817.6,
+          "y": 2063.2
+        }
+      },
+      "0c46ad52-45ea-40c5-8767-a953edf03df5": {
+        "position": {
+          "x": 2040.8,
+          "y": 2069.6
+        }
+      }
+    },
+    "Annotations": [],
+    "name": "everything-everywhere",
+    "description": "",
+    "type": "contactFlow",
+    "status": "SAVED",
+    "hash": {}
+  },
+  "Actions": [
+    {
+      "Parameters": {},
+      "Identifier": "3b9159fe-c0cd-490a-90c1-e204f7cc2e3e",
+      "Type": "RenderMessageTemplate",
+      "Transitions": {
+        "NextAction": "2046fe54-3811-4d18-9370-ef7e2e27f876",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          },
+          {
+            "NextAction": "",
+            "ErrorType": "TemplateRenderingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "Channel": "EMAIL",
+        "RelatedContact": "CURRENT"
+      },
+      "Identifier": "2046fe54-3811-4d18-9370-ef7e2e27f876",
+      "Type": "CreateContact",
+      "Transitions": {
+        "NextAction": "dd40e3b1-a426-4041-9919-33232b72f8a5",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "FromEmailAddress": {
+          "EmailAddress": ""
+        },
+        "EmailMessage": {
+          "MessageSourceType": "RAW"
+        }
+      },
+      "Identifier": "dd40e3b1-a426-4041-9919-33232b72f8a5",
+      "Type": "StartOutboundEmailContact",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {},
+      "Identifier": "70ebff06-8406-44a0-99a1-9fda02b60797",
+      "Type": "CreateWisdomSession",
+      "Transitions": {
+        "NextAction": "2f899339-9c0e-47a6-a226-74d60802ec90",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "WisdomSessionArn": "$.Wisdom.SessionArn"
+      },
+      "Identifier": "2f899339-9c0e-47a6-a226-74d60802ec90",
+      "Type": "UpdateContactData",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "CognitoConfiguration": {},
+        "CustomerProfilesConfiguration": {
+          "ObjectTypeName": "Cognito-attributes"
+        },
+        "TimeLimitMinutes": "3"
+      },
+      "Identifier": "d9525de3-f109-4d3b-920d-2d8af074f63e",
+      "Type": "AuthenticateParticipant",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "TimeLimitExceeded"
+          },
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ],
+        "Conditions": [
+          {
+            "NextAction": "",
+            "Condition": {
+              "Operator": "Equals",
+              "Operands": [
+                "OptedOut"
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "RehydrationType": "From Segment"
+      },
+      "Identifier": "a9744638-1a6b-4b61-9abc-6aa5964dfda3",
+      "Type": "CreatePersistentContactAssociation",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "Name": "",
+        "ContactFlowId": ""
+      },
+      "Identifier": "022164ad-4e26-4052-a9fa-d5f84a49e10d",
+      "Type": "CreateTask",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "StoreInput": "False",
+        "InputTimeLimitSeconds": "5"
+      },
+      "Identifier": "652c3102-acb1-4f05-b5ca-a3e85c85a9eb",
+      "Type": "GetParticipantInput",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "InputTimeLimitExceeded"
+          },
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingCondition"
+          },
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "ContentType": "EmailMessage"
+      },
+      "Identifier": "4403ce89-0daf-41c3-9597-66ff6bbd46b6",
+      "Type": "LoadContactContent",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "SkipWhenDTMFBufferEnabled": "false"
+      },
+      "Identifier": "bbd2fba2-1786-48fa-bc66-a2a7d66b66ab",
+      "Type": "MessageParticipant",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "StoreInput": "True",
+        "InputTimeLimitSeconds": "5",
+        "DTMFConfiguration": {
+          "DisableCancelKey": "False",
+          "InterdigitTimeLimitSeconds": "5"
+        },
+        "InputValidation": {
+          "CustomValidation": {
+            "MaximumLength": "20"
+          }
+        }
+      },
+      "Identifier": "cc16283d-1276-4c05-b1e3-d17df10ef5ad",
+      "Type": "GetParticipantInput",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "Tags": {}
+      },
+      "Identifier": "95f8b0be-db17-46d0-aed6-e5f1bec845e5",
+      "Type": "TagContact",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {},
+      "Identifier": "15329f36-3268-462d-8871-7f354805f64f",
+      "Type": "UpdatePreviousContactParticipantState",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {},
+      "Identifier": "8a145123-a5bc-4c3f-8231-bdcf4b2723dc",
+      "Type": "ResumeContact",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {},
+      "Identifier": "2f5a13eb-68fa-4025-924c-5e3d96514e38",
+      "Type": "UpdateContactCallbackNumber",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "InvalidCallbackNumber"
+          },
+          {
+            "NextAction": "",
+            "ErrorType": "CallbackNumberNotDialable"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "Attributes": {},
+        "TargetContact": "Current"
+      },
+      "Identifier": "1e9b8e32-7f59-4dff-9805-1091a5a20a81",
+      "Type": "UpdateContactAttributes",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "EventHooks": {
+          "CustomerQueue": ""
+        }
+      },
+      "Identifier": "95270a7b-9d75-4727-8d61-0760b2a76880",
+      "Type": "UpdateContactEventHooks",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "EventHooks": {
+          "CustomerRemaining": ""
+        }
+      },
+      "Identifier": "fbdb6e81-2f7c-4ca7-91a6-d2212ed499d5",
+      "Type": "UpdateContactEventHooks",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "EventHooks": {}
+      },
+      "Identifier": "cc9a4039-6db8-425e-a107-c8ed0672ac2c",
+      "Type": "UpdateContactEventHooks",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "EventHooks": {
+          "AgentHold": ""
+        }
+      },
+      "Identifier": "01703608-c04b-418f-9d15-ca3f57e02997",
+      "Type": "UpdateContactEventHooks",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "RoutingCriteria": {}
+      },
+      "Identifier": "df8e8d07-cf13-47af-aec1-74fa6892dd7f",
+      "Type": "UpdateContactRoutingCriteria",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "EnableDTMFBuffer": "True"
+      },
+      "Identifier": "bba6809b-de21-4b8c-bd93-d61a526919ea",
+      "Type": "GetParticipantInput",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "TextToSpeechVoice": "Joanna"
+      },
+      "Identifier": "9768184c-c847-435b-b20b-ad4da56decfa",
+      "Type": "UpdateContactTextToSpeechVoice",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "EventHooks": {
+          "AgentWhisper": ""
+        },
+        "EventHooksConfiguration": {
+          "AgentWhisper": {
+            "DisableExecution": "false"
+          }
+        }
+      },
+      "Identifier": "00deabc7-8f3e-41c4-af06-67e88812681d",
+      "Type": "UpdateContactEventHooks",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {},
+      "Identifier": "2fb281a1-b8b5-48f0-ac84-f74094bf74d7",
+      "Type": "UpdateContactTargetQueue",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "QueuePriority": "5"
+      },
+      "Identifier": "362d1047-4d36-4df9-8ae0-ff5e84f1144e",
+      "Type": "UpdateContactRoutingBehavior",
+      "Transitions": {
+        "NextAction": ""
+      }
+    },
+    {
+      "Parameters": {},
+      "Identifier": "0c7b88e8-a7ed-434c-a815-9c024cf5115a",
+      "Type": "CheckOutboundCallStatus",
+      "Transitions": {
+        "NextAction": "",
+        "Conditions": [
+          {
+            "NextAction": "",
+            "Condition": {
+              "Operator": "Equals",
+              "Operands": [
+                "CallAnswered"
+              ]
+            }
+          },
+          {
+            "NextAction": "",
+            "Condition": {
+              "Operator": "Equals",
+              "Operands": [
+                "VoicemailBeep"
+              ]
+            }
+          },
+          {
+            "NextAction": "",
+            "Condition": {
+              "Operator": "Equals",
+              "Operands": [
+                "VoicemailNoBeep"
+              ]
+            }
+          },
+          {
+            "NextAction": "",
+            "Condition": {
+              "Operator": "Equals",
+              "Operands": [
+                "NotDetected"
+              ]
+            }
+          }
+        ],
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "ComparisonValue": ""
+      },
+      "Identifier": "dfe3f165-5a6f-4a60-94ee-7f41d6c73c50",
+      "Type": "Compare",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingCondition"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {},
+      "Identifier": "9da6d2c1-2ff5-4c3b-8b51-fbf177733b1a",
+      "Type": "CheckHoursOfOperation",
+      "Transitions": {
+        "NextAction": "",
+        "Conditions": [
+          {
+            "NextAction": "",
+            "Condition": {
+              "Operator": "Equals",
+              "Operands": [
+                "True"
+              ]
+            }
+          },
+          {
+            "NextAction": "",
+            "Condition": {
+              "Operator": "Equals",
+              "Operands": [
+                "False"
+              ]
+            }
+          }
+        ],
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "MetricType": "OldestContactInQueueAgeSeconds"
+      },
+      "Identifier": "1e8c881b-9234-4e73-88be-3b8500ef22a8",
+      "Type": "CheckMetricData",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingCondition"
+          },
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "MetricType": "NumberOfAgentsAvailable"
+      },
+      "Identifier": "c9e42ae9-1a35-4098-be4e-f78e4b5608a0",
+      "Type": "CheckMetricData",
+      "Transitions": {
+        "NextAction": "",
+        "Conditions": [
+          {
+            "NextAction": "",
+            "Condition": {
+              "Operator": "NumberGreaterThan",
+              "Operands": [
+                "0"
+              ]
+            }
+          }
+        ],
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingCondition"
+          },
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {},
+      "Identifier": "ee1d8b0d-29e2-40eb-b6e4-c84443b3538a",
+      "Type": "GetMetricData",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "FlowLoggingBehavior": "Enabled"
+      },
+      "Identifier": "be51c3e8-27d2-4042-8523-23a178955667",
+      "Type": "UpdateFlowLoggingBehavior",
+      "Transitions": {
+        "NextAction": ""
+      }
+    },
+    {
+      "Parameters": {
+        "ChatBehavior": {
+          "ChatAnalyticsBehavior": {
+            "Enabled": "False"
+          }
+        }
+      },
+      "Identifier": "e81ee789-83af-4dfe-bbf4-0f2eb06a27fd",
+      "Type": "UpdateContactRecordingAndAnalyticsBehavior",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          },
+          {
+            "NextAction": "",
+            "ErrorType": "ChannelMismatch"
+          },
+          {
+            "NextAction": "",
+            "ErrorType": "InFlightRedactionConfigurationFailed"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "MediaStreamingState": "Enabled",
+        "MediaStreamType": "Audio",
+        "Participants": [
+          {
+            "ParticipantType": "Customer",
+            "MediaDirections": [
+              "To",
+              "From"
+            ]
+          }
+        ]
+      },
+      "Identifier": "6dee7181-ad17-42ef-b7b7-90c6276e684f",
+      "Type": "UpdateContactMediaStreamingBehavior",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "MediaStreamingState": "Disabled",
+        "Participants": [
+          {
+            "ParticipantType": "Customer",
+            "MediaDirections": [
+              "To",
+              "From"
+            ]
+          }
+        ],
+        "MediaStreamType": "Audio"
+      },
+      "Identifier": "6fa757e9-a54e-4e65-ba88-dafe314253a1",
+      "Type": "UpdateContactMediaStreamingBehavior",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {},
+      "Identifier": "eb40a0a7-ca7d-443e-ba83-53b0a7f6d943",
+      "Type": "DistributeByPercentage",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingCondition"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "LoopCount": "3"
+      },
+      "Identifier": "767192ee-d9cf-4917-8d90-08268ad8e177",
+      "Type": "Loop",
+      "Transitions": {
+        "NextAction": "",
+        "Conditions": [
+          {
+            "NextAction": "",
+            "Condition": {
+              "Operator": "Equals",
+              "Operands": [
+                "ContinueLooping"
+              ]
+            }
+          },
+          {
+            "NextAction": "",
+            "Condition": {
+              "Operator": "Equals",
+              "Operands": [
+                "DoneLooping"
+              ]
+            }
+          }
+        ],
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {},
+      "Identifier": "1d98bca9-a26e-4413-87b1-c72969be5285",
+      "Type": "Wait",
+      "Transitions": {
+        "NextAction": "",
+        "Conditions": [
+          {
+            "NextAction": "",
+            "Condition": {
+              "Operator": "Equals",
+              "Operands": [
+                "WaitCompleted"
+              ]
+            }
+          }
+        ],
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "InvocationTimeLimitSeconds": "3",
+        "InvocationType": "SYNCHRONOUS",
+        "ResponseValidation": {
+          "ResponseType": "STRING_MAP"
+        }
+      },
+      "Identifier": "dfad72bb-96ea-429a-97b1-e28eaf6c223c",
+      "Type": "InvokeLambdaFunction",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "LinkContactToCase": "true",
+        "CaseTemplateId": "",
+        "ContactToLink": "Current"
+      },
+      "Identifier": "7ea054d2-bd15-4751-89c9-8c6277390bf7",
+      "Type": "CreateCase",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "ContactNotLinked"
+          },
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "ProfileRequestData": {},
+        "ProfileResponseData": []
+      },
+      "Identifier": "d5f46c83-abbe-4364-a591-9a30d4e09e30",
+      "Type": "GetCustomerProfile",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "$end",
+            "ErrorType": "NoMatchingError"
+          },
+          {
+            "NextAction": "$end",
+            "ErrorType": "MultipleFoundError"
+          },
+          {
+            "NextAction": "$end",
+            "ErrorType": "NoneFoundError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "DataTableId": "",
+        "Queries": []
+      },
+      "Identifier": "f043fd39-f29d-4ecd-914d-8a5fd1ad5ea1",
+      "Type": "EvaluateDataTableValues",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {},
+      "Identifier": "88417f3d-a54f-4562-8a0c-2d67a987ec47",
+      "Type": "InvokeFlowModule",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingCondition"
+          },
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "ViewResource": {
+          "Id": ""
+        },
+        "InvocationTimeLimitSeconds": "undefined",
+        "ViewData": {}
+      },
+      "Identifier": "4f8b8898-6637-4d14-aeb2-3480a73fdf2d",
+      "Type": "ShowView",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingCondition"
+          },
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          },
+          {
+            "NextAction": "",
+            "ErrorType": "TimeLimitExceeded"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {},
+      "Identifier": "bcc89e25-33db-4997-bee7-71fc54546bae",
+      "Type": "DisconnectParticipant",
+      "Transitions": {}
+    },
+    {
+      "Parameters": {},
+      "Identifier": "fadd2209-f1fc-4ab0-ac05-5964c3cbb3de",
+      "Type": "EndFlowExecution",
+      "Transitions": {}
+    },
+    {
+      "Parameters": {},
+      "Identifier": "8134b785-032c-446f-b715-2b68a8c3c42b",
+      "Type": "TransferToFlow",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {
+        "ThirdPartyPhoneNumber": "",
+        "ThirdPartyConnectionTimeLimitSeconds": "30",
+        "ContinueFlowExecution": "True"
+      },
+      "Identifier": "13f57914-992d-4730-971a-3a415e49542d",
+      "Type": "TransferParticipantToThirdParty",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "CallFailed"
+          },
+          {
+            "NextAction": "",
+            "ErrorType": "ConnectionTimeLimitExceeded"
+          },
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    },
+    {
+      "Parameters": {},
+      "Identifier": "0c46ad52-45ea-40c5-8767-a953edf03df5",
+      "Type": "TransferContactToQueue",
+      "Transitions": {
+        "NextAction": "",
+        "Errors": [
+          {
+            "NextAction": "",
+            "ErrorType": "QueueAtCapacity"
+          },
+          {
+            "NextAction": "",
+            "ErrorType": "NoMatchingError"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/knowledge-base-docs/contact-flow/best-practices/error-handling.md
+++ b/knowledge-base-docs/contact-flow/best-practices/error-handling.md
@@ -88,8 +88,8 @@ Use Loop block for retryable errors:
   "Parameters": {"LoopCount": "3"},
   "Transitions": {
     "Conditions": [
-      {"Condition": {"Operator": "Equals", "Operands": ["Looping"]}, "NextAction": "retry-action"},
-      {"Condition": {"Operator": "Equals", "Operands": ["Complete"]}, "NextAction": "max-retries"}
+      {"Condition": {"Operator": "Equals", "Operands": ["ContinueLooping"]}, "NextAction": "retry-action"},
+      {"Condition": {"Operator": "Equals", "Operands": ["DoneLooping"]}, "NextAction": "max-retries"}
     ],
     "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]
   }

--- a/knowledge-base-docs/contact-flow/best-practices/error-handling.md
+++ b/knowledge-base-docs/contact-flow/best-practices/error-handling.md
@@ -16,7 +16,7 @@ Proper error handling ensures customers aren't left stranded when issues occur. 
 | UpdateContactTextToSpeechVoice | NoMatchingError |
 | UpdateContactRecordingBehavior | (Success only) |
 | UpdateFlowLoggingBehavior | (Success only) |
-| SetWorkingQueue | NoMatchingError |
+| UpdateContactTargetQueue | NoMatchingError |
 | InvokeLambdaFunction | NoMatchingError |
 | Wait | NoMatchingError |
 
@@ -29,7 +29,7 @@ Proper error handling ensures customers aren't left stranded when issues occur. 
 | CheckStaffing | NoMatchingError (+ True/False conditions) |
 | CheckHoursOfOperation | NoMatchingError (+ True/False conditions) |
 | GetParticipantInput | InputTimeLimitExceeded, NoMatchingCondition, NoMatchingError |
-| SetCallbackNumber | InvalidNumber, NotDialable, NoMatchingError |
+| UpdateContactCallbackNumber | InvalidNumber, NotDialable, NoMatchingError |
 | GetCustomerProfile | MultipleFoundError, NoneFoundError, NoMatchingError |
 
 ### Terminal Blocks (No Errors)
@@ -123,7 +123,7 @@ CORRECT:
 ```
 
 ### Mistake 2: Missing Required Error Types
-WRONG (SetCallbackNumber):
+WRONG (UpdateContactCallbackNumber):
 ```json
 {
   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error"}]
@@ -198,7 +198,7 @@ Before deploying a Contact Flow, verify:
 - DisconnectParticipant
 - Loop Block
 - GetParticipantInput
-- SetCallbackNumber
+- UpdateContactCallbackNumber
 
 ---
 **Metadata**

--- a/knowledge-base-docs/contact-flow/blocks/branch/check-hours-of-operation.md
+++ b/knowledge-base-docs/contact-flow/blocks/branch/check-hours-of-operation.md
@@ -95,7 +95,7 @@ arn:aws:connect:us-east-1:123456789012:instance/xxx/operating-hours/yyy
 ### Without HoursOfOperationId (Using Queue's Hours)
 If you omit the HoursOfOperationId, it uses the hours configured on the working queue:
 ```json
-{"Identifier": "set-queue", "Type": "SetWorkingQueue",
+{"Identifier": "set-queue", "Type": "UpdateContactTargetQueue",
  "Parameters": {"QueueId": "{{QUEUE_ARN}}"},
  "Transitions": {"NextAction": "check-queue-hours",
    "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]}}
@@ -112,9 +112,9 @@ If you omit the HoursOfOperationId, it uses the hours configured on the working 
 ```
 
 ## Related Topics
-- SetWorkingQueue
+- UpdateContactTargetQueue
 - GetParticipantInput
-- SetCallbackNumber
+- UpdateContactCallbackNumber
 
 ---
 **Metadata**

--- a/knowledge-base-docs/contact-flow/blocks/branch/check-staffing.md
+++ b/knowledge-base-docs/contact-flow/blocks/branch/check-staffing.md
@@ -25,7 +25,7 @@ The CheckStaffing block checks if agents are available in the working queue. Use
 ```
 
 ### Required Parameters
-None - uses the working queue set by SetWorkingQueue
+None - uses the working queue set by UpdateContactTargetQueue
 
 ### Condition Values
 - **True**: At least one agent is available in the queue
@@ -35,7 +35,7 @@ None - uses the working queue set by SetWorkingQueue
 - **NoMatchingError**: Unable to check staffing (no working queue set, permissions issue)
 
 ### CRITICAL Requirements
-1. MUST call `SetWorkingQueue` before using CheckStaffing
+1. MUST call `UpdateContactTargetQueue` before using CheckStaffing
 2. MUST have `Conditions` array with both "True" and "False" conditions
 3. MUST have `Errors` array with `NoMatchingError`
 4. Condition values are strings: `"True"` and `"False"` (not booleans)
@@ -71,7 +71,7 @@ None - uses the working queue set by SetWorkingQueue
 
 ### Complete Pattern: Staffing Check with Fallback
 ```json
-{"Identifier": "set-queue", "Type": "SetWorkingQueue",
+{"Identifier": "set-queue", "Type": "UpdateContactTargetQueue",
  "Parameters": {"QueueId": "{{QUEUE_ARN}}"},
  "Transitions": {"NextAction": "check-staffing",
    "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]}}
@@ -113,10 +113,10 @@ None - uses the working queue set by SetWorkingQueue
 - **GetQueueMetrics**: Need queue size, wait times, or other details
 
 ## Related Topics
-- SetWorkingQueue
+- UpdateContactTargetQueue
 - TransferContactToQueue
 - GetQueueMetrics
-- SetCallbackNumber
+- UpdateContactCallbackNumber
 
 ---
 **Metadata**

--- a/knowledge-base-docs/contact-flow/blocks/branch/check-staffing.md
+++ b/knowledge-base-docs/contact-flow/blocks/branch/check-staffing.md
@@ -1,28 +1,40 @@
-# CheckStaffing Block
+# Check Staffing / Queue Metrics (CheckMetricData)
+
+> ⛔ **API-verified correction (2026-06-08):** there is **NO `CheckStaffing`
+> Type** — it fails import with "Invalid Action type". The real block is
+> **`CheckMetricData`** (console "Check staffing" / "Get metrics").
 
 ## Question
-How do I use the CheckStaffing block to check agent availability in Amazon Connect Contact Flow?
+How do I check agent availability / queue metrics in Amazon Connect Contact Flow?
 
 ## Answer
-The CheckStaffing block checks if agents are available in the working queue. Use this before TransferContactToQueue to provide better customer experience when no agents are available.
+Use **`CheckMetricData`**: it reads a real-time metric (`MetricType`) for the
+working queue and branches via `Conditions`. Use before `TransferContactToQueue`
+to handle the no-agents case.
 
-### JSON Structure
+### JSON Structure (API-verified)
 ```json
 {
   "Identifier": "check-staffing",
-  "Type": "CheckStaffing",
-  "Parameters": {},
+  "Type": "CheckMetricData",
+  "Parameters": {
+    "MetricType": "AgentsAvailable"
+  },
   "Transitions": {
+    "NextAction": "agents-available",
     "Conditions": [
-      {"Condition": {"Operator": "Equals", "Operands": ["True"]}, "NextAction": "agents-available"},
-      {"Condition": {"Operator": "Equals", "Operands": ["False"]}, "NextAction": "no-agents"}
+      {"Condition": {"Operator": "NumberGreaterThan", "Operands": ["0"]}, "NextAction": "agents-available"}
     ],
     "Errors": [
+      {"ErrorType": "NoMatchingCondition", "NextAction": "no-agents"},
       {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
     ]
   }
 }
 ```
+
+Real `MetricType` values: `AgentsAvailable`, `OldestContactInQueueAgeSeconds`,
+`ContactsInQueue`. Required errors: `NoMatchingCondition` + `NoMatchingError`.
 
 ### Required Parameters
 None - uses the working queue set by UpdateContactTargetQueue

--- a/knowledge-base-docs/contact-flow/blocks/control/loop.md
+++ b/knowledge-base-docs/contact-flow/blocks/control/loop.md
@@ -16,8 +16,8 @@ The Loop block repeats a section of the flow a specified number of times. It's u
   },
   "Transitions": {
     "Conditions": [
-      {"Condition": {"Operator": "Equals", "Operands": ["Looping"]}, "NextAction": "action-to-retry"},
-      {"Condition": {"Operator": "Equals", "Operands": ["Complete"]}, "NextAction": "max-retries-reached"}
+      {"Condition": {"Operator": "Equals", "Operands": ["ContinueLooping"]}, "NextAction": "action-to-retry"},
+      {"Condition": {"Operator": "Equals", "Operands": ["DoneLooping"]}, "NextAction": "max-retries-reached"}
     ],
     "Errors": [
       {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
@@ -31,19 +31,22 @@ The Loop block repeats a section of the flow a specified number of times. It's u
 |-----------|------|-------------|
 | LoopCount | String | Number of iterations (e.g., "3") |
 
+> ✅ **API-verified (2026-06-08):** operands are `ContinueLooping` / `DoneLooping`.
+> The names `Looping`/`Complete` are WRONG and make the flow fail import.
+
 ### Condition Values
-- **Looping**: Loop is still iterating (hasn't reached LoopCount)
-- **Complete**: Loop has completed all iterations
+- **ContinueLooping**: Loop is still iterating (hasn't reached LoopCount)
+- **DoneLooping**: Loop has completed all iterations
 
 ### Error Types
 - **NoMatchingError**: General error
 
 ### CRITICAL Requirements
-1. MUST have `Conditions` for both "Looping" and "Complete"
+1. MUST have `Conditions` for both "ContinueLooping" and "DoneLooping"
 2. `LoopCount` must be a string ("3"), not a number
 3. MUST have `Errors` with `NoMatchingError`
-4. The "Looping" path should eventually return to the Loop block
-5. The "Complete" path handles max retries exceeded
+4. The "ContinueLooping" path should eventually return to the Loop block
+5. The "DoneLooping" path handles max retries exceeded
 
 ### Loop Counter Access
 You can access the current loop index:
@@ -56,7 +59,7 @@ You can access the current loop index:
 {
   "Transitions": {
     "Conditions": [
-      {"Condition": {"Operator": "Equals", "Operands": ["Looping"]}, "NextAction": "retry-action"}
+      {"Condition": {"Operator": "Equals", "Operands": ["ContinueLooping"]}, "NextAction": "retry-action"}
     ]
   }
 }
@@ -67,8 +70,8 @@ You can access the current loop index:
 {
   "Transitions": {
     "Conditions": [
-      {"Condition": {"Operator": "Equals", "Operands": ["Looping"]}, "NextAction": "retry-action"},
-      {"Condition": {"Operator": "Equals", "Operands": ["Complete"]}, "NextAction": "max-retries"}
+      {"Condition": {"Operator": "Equals", "Operands": ["ContinueLooping"]}, "NextAction": "retry-action"},
+      {"Condition": {"Operator": "Equals", "Operands": ["DoneLooping"]}, "NextAction": "max-retries"}
     ],
     "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]
   }
@@ -81,8 +84,8 @@ You can access the current loop index:
  "Parameters": {"LoopCount": "3"},
  "Transitions": {
    "Conditions": [
-     {"Condition": {"Operator": "Equals", "Operands": ["Looping"]}, "NextAction": "get-input"},
-     {"Condition": {"Operator": "Equals", "Operands": ["Complete"]}, "NextAction": "max-attempts"}
+     {"Condition": {"Operator": "Equals", "Operands": ["ContinueLooping"]}, "NextAction": "get-input"},
+     {"Condition": {"Operator": "Equals", "Operands": ["DoneLooping"]}, "NextAction": "max-attempts"}
    ],
    "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]
  }}
@@ -138,8 +141,8 @@ You can access the current loop index:
  "Parameters": {"LoopCount": "5"},
  "Transitions": {
    "Conditions": [
-     {"Condition": {"Operator": "Equals", "Operands": ["Looping"]}, "NextAction": "wait-30s"},
-     {"Condition": {"Operator": "Equals", "Operands": ["Complete"]}, "NextAction": "offer-callback"}
+     {"Condition": {"Operator": "Equals", "Operands": ["ContinueLooping"]}, "NextAction": "wait-30s"},
+     {"Condition": {"Operator": "Equals", "Operands": ["DoneLooping"]}, "NextAction": "offer-callback"}
    ],
    "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]
  }}

--- a/knowledge-base-docs/contact-flow/blocks/integrate/connect-participant-with-lex-bot.md
+++ b/knowledge-base-docs/contact-flow/blocks/integrate/connect-participant-with-lex-bot.md
@@ -52,7 +52,10 @@ The ConnectParticipantWithLexBot block connects the contact to a Lex V2 bot for 
 3. MUST include `Errors` with `NoMatchingError`. Include `NoMatchingCondition` when you
    branch on Intent, and `InputTimeLimitExceeded` when using `LexTimeoutSeconds`.
 4. For voice, set up `UpdateContactTextToSpeechVoice` BEFORE this block.
-5. For voice, enable Contact Lens RealTime for Q in Connect.
+5. For voice, set `UpdateContactRecordingBehavior` with Voice `AnalyticsModes: ["PostContact"]`
+   (do NOT use `RealTime` — Connect rejects it on import unless real-time Contact Lens
+   preconditions are met; Q in Connect assistance is driven by the Lex/Wisdom session, not
+   by real-time voice analytics in this block).
 
 ### Lex V2 Bot Alias ARN Format
 ```
@@ -106,8 +109,9 @@ After the Lex interaction, these attributes are available:
 
 {"Identifier": "set-recording", "Type": "UpdateContactRecordingBehavior",
  "Parameters": {
-   "RecordingBehavior": {"RecordedParticipants": ["Agent", "Customer"]},
-   "AnalyticsBehavior": {"Enabled": "True", "AnalyticsMode": "RealTime"}
+   "RecordingBehavior": {"RecordedParticipants": ["Agent", "Customer"], "IVRRecordingBehavior": "Enabled"},
+   "AnalyticsBehavior": {"Enabled": "True", "AnalyticsLanguage": "en-US",
+     "ChannelConfiguration": {"Chat": {"AnalyticsModes": []}, "Voice": {"AnalyticsModes": ["PostContact"]}}}
  },
  "Transitions": {"NextAction": "lex-bot"}}
 

--- a/knowledge-base-docs/contact-flow/blocks/interact/get-participant-input.md
+++ b/knowledge-base-docs/contact-flow/blocks/interact/get-participant-input.md
@@ -6,18 +6,23 @@ How do I use the GetParticipantInput block to collect DTMF input in Amazon Conne
 ## Answer
 The GetParticipantInput block plays a message and collects DTMF (touch-tone) input from the customer. Use this for menu selections, account numbers, and other numeric input.
 
-### JSON Structure
+> ✅ **API-verified (2026-06-08).** `GetParticipantInput` has TWO DISTINCT modes
+> with different required schemas. Mixing them fails import (often with a
+> misleading "Invalid Action type" message).
+
+### MODE 1 — MENU (branch on the pressed key via Conditions)
+- `StoreInput` MUST be `"False"`.
+- MUST NOT include `DTMFConfiguration`.
+- Required errors: `NoMatchingCondition` + `InputTimeLimitExceeded` + `NoMatchingError`.
+
 ```json
 {
   "Identifier": "get-menu-input",
   "Type": "GetParticipantInput",
   "Parameters": {
     "Text": "Press 1 for sales, press 2 for support, or press 3 to speak with an agent.",
-    "InputTimeLimitSeconds": "5",
-    "DTMFConfiguration": {
-      "InputTerminationSequence": "#",
-      "DisableCancelKey": false
-    }
+    "StoreInput": "False",
+    "InputTimeLimitSeconds": "5"
   },
   "Transitions": {
     "NextAction": "invalid-input",
@@ -27,31 +32,42 @@ The GetParticipantInput block plays a message and collects DTMF (touch-tone) inp
       {"Condition": {"Operator": "Equals", "Operands": ["3"]}, "NextAction": "agent-transfer"}
     ],
     "Errors": [
-      {"ErrorType": "InputTimeLimitExceeded", "NextAction": "timeout-handler"},
       {"ErrorType": "NoMatchingCondition", "NextAction": "invalid-input"},
+      {"ErrorType": "InputTimeLimitExceeded", "NextAction": "timeout-handler"},
       {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
     ]
   }
 }
 ```
 
-### Required Parameters
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| Text | String | Message to play before collecting input |
-| InputTimeLimitSeconds | String | Seconds to wait for input (1-180) |
-| DTMFConfiguration | Object | DTMF input settings |
+### MODE 2 — STORE (capture digits to a contact attribute)
+- `StoreInput` MUST be `"True"`.
+- Requires `InputValidation.CustomValidation.MaximumLength`.
+- `DTMFConfiguration` may carry `DisableCancelKey` only — NEVER `InputTerminationSequence`.
+- Only error: `NoMatchingError`. No Conditions.
 
-### DTMFConfiguration Options
-| Parameter | Type | Description | Default |
-|-----------|------|-------------|---------|
-| InputTerminationSequence | String | Key to end input (e.g., "#") | None |
-| DisableCancelKey | Boolean | Disable * key cancel | false |
+```json
+{
+  "Identifier": "collect-account",
+  "Type": "GetParticipantInput",
+  "Parameters": {
+    "Text": "Please enter your 6-digit account number.",
+    "StoreInput": "True",
+    "InputTimeLimitSeconds": "8",
+    "DTMFConfiguration": {"DisableCancelKey": "False"},
+    "InputValidation": {"CustomValidation": {"MaximumLength": "6"}}
+  },
+  "Transitions": {
+    "NextAction": "lookup-account",
+    "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]
+  }
+}
+```
 
 ### Error Types
-- **InputTimeLimitExceeded**: Customer didn't provide input within timeout
-- **NoMatchingCondition**: Input didn't match any condition
-- **NoMatchingError**: General error (playback failed, etc.)
+- **InputTimeLimitExceeded**: no input within timeout (menu mode)
+- **NoMatchingCondition**: input matched no condition (menu mode)
+- **NoMatchingError**: general error (both modes)
 
 ### CRITICAL Requirements
 1. MUST have all THREE error types for production flows

--- a/knowledge-base-docs/contact-flow/blocks/set/set-callback-number.md
+++ b/knowledge-base-docs/contact-flow/blocks/set/set-callback-number.md
@@ -1,16 +1,16 @@
-# SetCallbackNumber Block
+# UpdateContactCallbackNumber Block
 
 ## Question
-How do I use the SetCallbackNumber block for queue callbacks in Amazon Connect Contact Flow?
+How do I use the UpdateContactCallbackNumber block for queue callbacks in Amazon Connect Contact Flow?
 
 ## Answer
-The SetCallbackNumber block sets the phone number to use when creating a callback contact. This is used with TransferContactToQueue to implement queue callback functionality.
+The UpdateContactCallbackNumber block sets the phone number to use when creating a callback contact. This is used with TransferContactToQueue to implement queue callback functionality.
 
 ### JSON Structure
 ```json
 {
   "Identifier": "set-callback",
-  "Type": "SetCallbackNumber",
+  "Type": "UpdateContactCallbackNumber",
   "Parameters": {
     "CallbackNumber": "$.CustomerEndpoint.Address"
   },
@@ -75,7 +75,7 @@ The SetCallbackNumber block sets the phone number to use when creating a callbac
  "Transitions": {"NextAction": "set-callback",
    "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "set-callback"}]}}
 
-{"Identifier": "set-callback", "Type": "SetCallbackNumber",
+{"Identifier": "set-callback", "Type": "UpdateContactCallbackNumber",
  "Parameters": {"CallbackNumber": "$.CustomerEndpoint.Address"},
  "Transitions": {"NextAction": "transfer-callback",
    "Errors": [
@@ -105,7 +105,7 @@ The SetCallbackNumber block sets the phone number to use when creating a callbac
 
 ### NON-EXISTENT Block Warning
 There is NO `CreateCallbackContact` block type. Callbacks are created by:
-1. SetCallbackNumber (set the number)
+1. UpdateContactCallbackNumber (set the number)
 2. TransferContactToQueue (creates the callback in queue)
 
 #### WRONG
@@ -115,18 +115,18 @@ There is NO `CreateCallbackContact` block type. Callbacks are created by:
 
 #### CORRECT
 ```json
-{"Type": "SetCallbackNumber"}
+{"Type": "UpdateContactCallbackNumber"}
 // followed by
 {"Type": "TransferContactToQueue"}
 ```
 
 ## Related Topics
 - TransferContactToQueue
-- SetWorkingQueue
+- UpdateContactTargetQueue
 - Queue Overflow Handling Pattern
 
 ---
 **Metadata**
 - Category: Set
-- BlockType: SetCallbackNumber
+- BlockType: UpdateContactCallbackNumber
 - Keywords: callback, queue callback, InvalidNumber, NotDialable, phone number

--- a/knowledge-base-docs/contact-flow/blocks/set/set-working-queue.md
+++ b/knowledge-base-docs/contact-flow/blocks/set/set-working-queue.md
@@ -1,16 +1,16 @@
-# SetWorkingQueue Block
+# UpdateContactTargetQueue Block
 
 ## Question
-How do I use the SetWorkingQueue block in Amazon Connect Contact Flow?
+How do I use the UpdateContactTargetQueue block in Amazon Connect Contact Flow?
 
 ## Answer
-The SetWorkingQueue block sets the active queue for subsequent queue-related operations like TransferContactToQueue and CheckStaffing.
+The UpdateContactTargetQueue block sets the active queue for subsequent queue-related operations like TransferContactToQueue and CheckStaffing.
 
 ### JSON Structure
 ```json
 {
   "Identifier": "set-queue",
-  "Type": "SetWorkingQueue",
+  "Type": "UpdateContactTargetQueue",
   "Parameters": {
     "QueueId": "{{QUEUE_ARN}}"
   },
@@ -57,7 +57,7 @@ arn:aws:connect:us-east-1:123456789012:instance/xxx/queue/yyy
 
 ### Common Pattern: Queue with Staffing Check
 ```json
-{"Identifier": "set-queue", "Type": "SetWorkingQueue",
+{"Identifier": "set-queue", "Type": "UpdateContactTargetQueue",
  "Parameters": {"QueueId": "{{QUEUE_ARN}}"},
  "Transitions": {"NextAction": "check-staffing", "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]}}
 
@@ -86,5 +86,5 @@ arn:aws:connect:us-east-1:123456789012:instance/xxx/queue/yyy
 ---
 **Metadata**
 - Category: Set
-- BlockType: SetWorkingQueue
+- BlockType: UpdateContactTargetQueue
 - Keywords: queue, working queue, routing, set queue

--- a/knowledge-base-docs/contact-flow/blocks/transfer/transfer-contact-to-queue.md
+++ b/knowledge-base-docs/contact-flow/blocks/transfer/transfer-contact-to-queue.md
@@ -27,7 +27,7 @@ The TransferContactToQueue block transfers the contact to a queue for agent hand
 ### Required Parameters
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| QueueId | String | The ARN or ID of the target queue (optional if SetWorkingQueue was called first) |
+| QueueId | String | The ARN or ID of the target queue (optional if UpdateContactTargetQueue was called first) |
 
 ### Error Types
 - **QueueAtCapacity**: The queue has reached its maximum contact limit
@@ -37,14 +37,14 @@ The TransferContactToQueue block transfers the contact to a queue for agent hand
 1. MUST have `NextAction` in Transitions - this is where the flow continues after successful transfer
 2. MUST handle `QueueAtCapacity` error for production flows
 3. MUST handle `NoMatchingError` for robustness
-4. If `QueueId` is not specified, you MUST call `SetWorkingQueue` before this block
+4. If `QueueId` is not specified, you MUST call `UpdateContactTargetQueue` before this block
 5. The `NextAction` typically points to a `DisconnectParticipant` block
 
 ### Common Patterns
 
-#### With SetWorkingQueue (Recommended)
+#### With UpdateContactTargetQueue (Recommended)
 ```json
-{"Identifier": "set-queue", "Type": "SetWorkingQueue",
+{"Identifier": "set-queue", "Type": "UpdateContactTargetQueue",
  "Parameters": {"QueueId": "{{QUEUE_ARN}}"},
  "Transitions": {"NextAction": "transfer-queue", "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]}}
 
@@ -65,10 +65,10 @@ The TransferContactToQueue block transfers the contact to a queue for agent hand
 ```
 
 ## Related Topics
-- SetWorkingQueue
+- UpdateContactTargetQueue
 - CheckStaffing
 - GetQueueMetrics
-- SetCallbackNumber (for callback when queue is full)
+- UpdateContactCallbackNumber (for callback when queue is full)
 
 ---
 **Metadata**

--- a/knowledge-base-docs/contact-flow/patterns/callback-pattern.md
+++ b/knowledge-base-docs/contact-flow/patterns/callback-pattern.md
@@ -8,11 +8,11 @@ The callback pattern allows customers to receive a callback instead of waiting o
 
 ## Key Components
 
-1. **SetCallbackNumber** - Sets the phone number for callback
+1. **UpdateContactCallbackNumber** - Sets the phone number for callback
 2. **TransferContactToQueue** - Creates the callback contact in the queue
 
 ## CRITICAL: There is NO CreateCallbackContact Block!
-Callbacks are created by calling SetCallbackNumber followed by TransferContactToQueue.
+Callbacks are created by calling UpdateContactCallbackNumber followed by TransferContactToQueue.
 
 ## Complete Pattern Implementation
 
@@ -116,7 +116,7 @@ Callbacks are created by calling SetCallbackNumber followed by TransferContactTo
     },
     {
       "Identifier": "set-callback",
-      "Type": "SetCallbackNumber",
+      "Type": "UpdateContactCallbackNumber",
       "Parameters": {"CallbackNumber": "$.CustomerEndpoint.Address"},
       "Transitions": {
         "NextAction": "create-callback",
@@ -176,9 +176,9 @@ Callbacks are created by calling SetCallbackNumber followed by TransferContactTo
 }
 ```
 
-## SetCallbackNumber Error Handling
+## UpdateContactCallbackNumber Error Handling
 
-CRITICAL: SetCallbackNumber requires handling THREE error types:
+CRITICAL: UpdateContactCallbackNumber requires handling THREE error types:
 
 ```json
 {
@@ -205,7 +205,7 @@ WRONG:
 
 CORRECT:
 ```json
-{"Type": "SetCallbackNumber"}  // Step 1: Set the number
+{"Type": "UpdateContactCallbackNumber"}  // Step 1: Set the number
 // followed by
 {"Type": "TransferContactToQueue"}  // Step 2: Creates the callback
 ```
@@ -235,7 +235,7 @@ If you want to allow customers to enter a different callback number:
 
 {
   "Identifier": "set-custom-callback",
-  "Type": "SetCallbackNumber",
+  "Type": "UpdateContactCallbackNumber",
   "Parameters": {"CallbackNumber": "$.StoredCustomerInput"},
   "Transitions": {
     "NextAction": "create-callback",
@@ -249,7 +249,7 @@ If you want to allow customers to enter a different callback number:
 ```
 
 ## Related Topics
-- SetCallbackNumber
+- UpdateContactCallbackNumber
 - TransferContactToQueue
 - CheckStaffing
 - GetParticipantInput
@@ -257,4 +257,4 @@ If you want to allow customers to enter a different callback number:
 ---
 **Metadata**
 - Category: Pattern
-- Keywords: callback, queue callback, SetCallbackNumber, InvalidNumber, NotDialable
+- Keywords: callback, queue callback, UpdateContactCallbackNumber, InvalidNumber, NotDialable

--- a/knowledge-base-docs/contact-flow/patterns/q-in-connect-self-service.md
+++ b/knowledge-base-docs/contact-flow/patterns/q-in-connect-self-service.md
@@ -105,8 +105,9 @@ This pattern implements AI-powered self-service using Amazon Q in Connect (forme
       "Identifier": "voice-recording",
       "Type": "UpdateContactRecordingBehavior",
       "Parameters": {
-        "RecordingBehavior": {"RecordedParticipants": ["Agent", "Customer"]},
-        "AnalyticsBehavior": {"Enabled": "True", "AnalyticsMode": "RealTime"}
+        "RecordingBehavior": {"RecordedParticipants": ["Agent", "Customer"], "IVRRecordingBehavior": "Enabled"},
+        "AnalyticsBehavior": {"Enabled": "True", "AnalyticsLanguage": "en-US",
+          "ChannelConfiguration": {"Chat": {"AnalyticsModes": []}, "Voice": {"AnalyticsModes": ["PostContact"]}}}
       },
       "Transitions": {"NextAction": "get-profile"}
     },
@@ -115,7 +116,8 @@ This pattern implements AI-powered self-service using Amazon Q in Connect (forme
       "Type": "UpdateContactRecordingBehavior",
       "Parameters": {
         "RecordingBehavior": {"RecordedParticipants": []},
-        "AnalyticsBehavior": {"Enabled": "True", "AnalyticsMode": "PostContact"}
+        "AnalyticsBehavior": {"Enabled": "True", "AnalyticsLanguage": "en-US",
+          "ChannelConfiguration": {"Chat": {"AnalyticsModes": ["ContactLens"]}, "Voice": {"AnalyticsModes": []}}}
       },
       "Transitions": {"NextAction": "get-profile"}
     },
@@ -292,8 +294,11 @@ This pattern implements AI-powered self-service using Amazon Q in Connect (forme
 | Feature | VOICE | CHAT |
 |---------|-------|------|
 | Recording | Agent + Customer | None |
-| Contact Lens | RealTime | PostContact |
+| Contact Lens (AnalyticsModes) | Voice: `["PostContact"]` | Chat: `["ContactLens"]` |
 | Profile Lookup | _phone | _email |
+
+> ⚠️ Do NOT use `RealTime` in Voice `AnalyticsModes` — Amazon Connect rejects it on
+> import unless real-time Contact Lens preconditions are met. Use `["PostContact"]`.
 
 ### Lex Session Attributes for Escalation
 The Lex bot should set these attributes:

--- a/knowledge-base-docs/contact-flow/troubleshooting/common-import-errors.md
+++ b/knowledge-base-docs/contact-flow/troubleshooting/common-import-errors.md
@@ -16,7 +16,7 @@ Contact Flow import failures are usually caused by incorrect JSON syntax, missin
 | Logging | SetLoggingBehavior | UpdateFlowLoggingBehavior |
 | Set Attributes | SetContactAttributes | UpdateContactAttributes |
 | Store Input | StoreCustomerInput | StoreUserInput |
-| Create Callback | CreateCallbackContact | SetCallbackNumber + TransferContactToQueue |
+| Create Callback | CreateCallbackContact | UpdateContactCallbackNumber + TransferContactToQueue |
 | Check Metrics | CheckMetricData | GetQueueMetrics + Compare |
 
 Fix: Use the correct block type names as listed in AWS documentation.
@@ -243,7 +243,7 @@ Before importing, verify:
 | Recording | UpdateContactRecordingBehavior |
 | Voice | UpdateContactTextToSpeechVoice |
 | Attributes | UpdateContactAttributes |
-| Queue | SetWorkingQueue |
+| Queue | UpdateContactTargetQueue |
 | Transfer | TransferContactToQueue |
 | Staffing | CheckStaffing |
 | Hours | CheckHoursOfOperation |
@@ -251,7 +251,7 @@ Before importing, verify:
 | Lambda | InvokeLambdaFunction |
 | Profile | GetCustomerProfile |
 | Associate | AssociateContactToCustomerProfile |
-| Callback | SetCallbackNumber |
+| Callback | UpdateContactCallbackNumber |
 | Input | GetParticipantInput |
 | Store | StoreUserInput |
 | Message | MessageParticipant |

--- a/knowledge-base-docs/contact-flow/troubleshooting/common-import-errors.md
+++ b/knowledge-base-docs/contact-flow/troubleshooting/common-import-errors.md
@@ -17,7 +17,11 @@ Contact Flow import failures are usually caused by incorrect JSON syntax, missin
 | Set Attributes | SetContactAttributes | UpdateContactAttributes |
 | Store Input | StoreCustomerInput | StoreUserInput |
 | Create Callback | CreateCallbackContact | UpdateContactCallbackNumber + TransferContactToQueue |
-| Check Metrics | CheckMetricData | GetQueueMetrics + Compare |
+| Queue metrics | GetQueueMetrics | CheckMetricData |
+| Staffing | CheckStaffing | CheckMetricData (MetricType: NumberOfAgentsAvailable) |
+| Entry/trigger | Trigger / EntryPoint | (none — flow starts at StartAction's target) |
+| AI agent | InvokeAgentAction / InvokeBedrockAgent | ConnectParticipantWithLexBot |
+| Condition | CheckCondition / CheckValue | Compare |
 
 Fix: Use the correct block type names as listed in AWS documentation.
 
@@ -79,6 +83,108 @@ CORRECT:
   "Parameters": {"FlowLoggingBehavior": "Enabled"}
 }
 ```
+
+### 2b. API-Validated Parameter Name Errors (exact property names)
+
+These are the EXACT `InvalidContactFlowException` problems Amazon Connect's
+`CreateContactFlow` API returns. The API validator is stricter than the console
+preview — a flow that looks fine can still be rejected for these. Each fix below
+was confirmed by a real successful import.
+
+#### UpdateContactRecordingBehavior — `Agent`/`Customer` are not valid
+**API error**: `Invalid Action property name. Path: …Parameters.Agent` /
+`Action is missing required property. Path: …Parameters.RecordingBehavior`
+
+WRONG:
+```json
+{"Type": "UpdateContactRecordingBehavior", "Parameters": {"Agent": "Enabled", "Customer": "Enabled"}}
+```
+CORRECT:
+```json
+{"Type": "UpdateContactRecordingBehavior",
+ "Parameters": {
+   "RecordingBehavior": {"RecordedParticipants": ["Agent", "Customer"], "IVRRecordingBehavior": "Enabled"},
+   "AnalyticsBehavior": {"Enabled": "True", "AnalyticsLanguage": "ko-KR",
+     "ChannelConfiguration": {"Chat": {"AnalyticsModes": ["ContactLens"]}, "Voice": {"AnalyticsModes": ["PostContact"]}}}}}
+```
+
+#### UpdateContactTextToSpeechVoice — `VoiceId`/`Engine`/`LanguageCode` are not valid
+**API error**: `Invalid Action property name. Path: …Parameters.VoiceId` /
+`Action is missing required property. Path: …Parameters.TextToSpeechVoice`
+
+WRONG: `{"VoiceId": "Seoyeon", "Engine": "Generative", "LanguageCode": "ko-KR"}`
+CORRECT: `{"TextToSpeechVoice": "Seoyeon", "TextToSpeechEngine": "Generative"}`
+(Set the language in `ActionMetadata`, not in Parameters.)
+
+#### UpdateContactTargetQueue — `QueueId` must be a string, not nested
+**API error**: `Invalid Action property value. Path: …Parameters.QueueId`
+
+WRONG: `{"Queue": "arn:…"}` or `{"QueueId": {"QueueId": "arn:…"}}`
+CORRECT: `{"QueueId": "arn:aws:connect:…:queue/…"}`
+
+#### InvokeLambdaFunction — `RequestAttributes` is not valid
+**API error**: `Invalid Action property name. Path: …Parameters.RequestAttributes`
+
+WRONG: `{"RequestAttributes": {"phone": "$.CustomerEndpoint.Address"}}`
+CORRECT: `{"LambdaInvocationAttributes": {"phone": "$.CustomerEndpoint.Address"}}`
+Also: `ResponseValidation.ResponseType` must be `STRING_MAP`.
+
+#### ConnectParticipantWithLexBot — only `LexV2Bot.AliasArn` + one message
+**API errors**: `Invalid Action property name. …Parameters.BotAliasArn` /
+`…ParticipantRole` / `…SessionAttributes`; `Action is missing required property.
+…Parameters.LexBot`; `At least one of [Text, SSML, PromptId, Media, LexInitializationData] must be set`.
+
+WRONG: `{"BotAliasArn": "arn:…", "ParticipantRole": "…", "SessionAttributes": {…}}`
+or `{"LexBot": {"AliasArn": "arn:…"}}`
+CORRECT:
+```json
+{"Type": "ConnectParticipantWithLexBot",
+ "Parameters": {"Text": "안녕하세요…", "LexV2Bot": {"AliasArn": "arn:aws:lex:…:bot-alias/…/…"},
+                "LexSessionAttributes": {"key": "value"}},
+ "Transitions": {"NextAction": "check-result",
+   "Errors": [{"ErrorType": "NoMatchingCondition", "NextAction": "check-result"},
+              {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]}}
+```
+Its valid Error types are `NoMatchingError` and `NoMatchingCondition` — NEVER `AgentError`.
+
+#### Compare — `NoMatchingError` is not a valid Error; ComparisonValue needs a real root
+**API errors**: `Invalid Action error. Error: NoMatchingError, Path: …` /
+`Invalid Action property value. Path: …Parameters.ComparisonValue`
+
+- `Compare` branches via `Conditions`; its ONLY Error is `NoMatchingCondition`.
+- `ComparisonValue` MUST use a real JSONPath root: `$.Attributes.X`, `$.Channel`,
+  `$.Lex.SessionAttributes.X`, `$.CustomerEndpoint.Address`, `$.External.X`,
+  `$.StoredCustomerInput`. There is NO `$.Agent.*` namespace — read AI/bot
+  results from `$.Lex.SessionAttributes.*` or a contact attribute you set.
+
+#### CheckHoursOfOperation — needs id + BOTH True/False branches
+**API errors**: `Invalid Action property value. …Transitions.Conditions` /
+`Action is missing required error. Error: NoMatchingError`
+
+- `HoursOfOperationId` must be a non-null ARN/id.
+- `Transitions.Conditions` MUST include BOTH a `True` and a `False` operand.
+- The only valid Error is `NoMatchingError` (NOT `NoMatchingCondition`).
+
+```json
+{"Type": "CheckHoursOfOperation",
+ "Parameters": {"HoursOfOperationId": "arn:aws:connect:…:operating-hours/…"},
+ "Transitions": {"NextAction": "after-hours",
+   "Conditions": [
+     {"Condition": {"Operator": "Equals", "Operands": ["True"]},  "NextAction": "open"},
+     {"Condition": {"Operator": "Equals", "Operands": ["False"]}, "NextAction": "after-hours"}],
+   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "after-hours"}]}}
+```
+
+#### Terminal blocks carry NOTHING but Parameters
+`DisconnectParticipant` / `EndFlowExecution` / `ReturnFromFlowModule` must NOT
+have `Transitions`, `Conditions`, OR `Errors` (not even empty ones as stray
+top-level keys). **API error**: `Action does not support transitions. Path: …`
+
+#### MessageParticipant — exactly ONE message property
+**API error**: `Only one of these properties may be defined. Properties: [Text, SSML]`
+
+Provide exactly ONE of `Text` / `SSML` / `PromptId` / `Media` — never both
+`Text` and `SSML` on the same block.
 
 ### 3. Transition Errors
 
@@ -245,9 +351,8 @@ Before importing, verify:
 | Attributes | UpdateContactAttributes |
 | Queue | UpdateContactTargetQueue |
 | Transfer | TransferContactToQueue |
-| Staffing | CheckStaffing |
+| Staffing / Metrics | CheckMetricData |
 | Hours | CheckHoursOfOperation |
-| Metrics | GetQueueMetrics |
 | Lambda | InvokeLambdaFunction |
 | Profile | GetCustomerProfile |
 | Associate | AssociateContactToCustomerProfile |


### PR DESCRIPTION
## Summary

Hardens Contact Flow generation to produce **import-safe** Amazon Connect flows, and fixes two session-state bugs surfaced during end-to-end testing. Every Contact Flow rule here was validated against the real `CreateContactFlow` API (stricter than the console preview).

## Contact Flow import hardening

Generated flows were failing `InvalidContactFlowException` on import. Root causes + fixes (all in the deterministic linter `asset_linters.py`, with prompt + RAG reinforcement):

- **Hallucinated block types** (`Trigger`, `EntryPoint`, `InvokeAgentAction`, `CheckCondition`) — auto-removed/renamed to real types; `StartAction` repointed past dropped `Trigger`.
- **Per-block parameter drift** — rebuilt to the exact API-accepted shapes:
  - `UpdateContactRecordingBehavior` `{Agent,Customer}` → `{RecordingBehavior,AnalyticsBehavior}`
  - `UpdateContactTextToSpeechVoice` `{VoiceId,Engine,LanguageCode}` → `{TextToSpeechVoice,TextToSpeechEngine}`
  - `UpdateFlowLoggingBehavior` `{LoggingBehavior}` → `{FlowLoggingBehavior}`
  - `UpdateContactTargetQueue` flattened nested/renamed `QueueId`
  - `ConnectParticipantWithLexBot` → `LexV2Bot.AliasArn` + one message; strip invalid `AgentError`
  - `InvokeLambdaFunction` `RequestAttributes` → `LambdaInvocationAttributes`; `ResponseType=STRING_MAP`
  - `Compare` strip invalid `NoMatchingError`; re-home invalid `ComparisonValue` JSONPath roots
  - `CheckHoursOfOperation` fill `HoursOfOperationId`; ensure True+False branches
  - terminal blocks strip stray `Transitions`/`Conditions`/`Errors`
  - `MessageParticipant`/`GetParticipantInput` keep exactly one of `Text`/`SSML`/`PromptId`/`Media`
- **Canonical AI-bot ↔ flow tool-result contract** (`_consistency_rules.py`, shared by prompt + contact_flow generators): the bot returns exactly `Complete`/`Escalate` via `$.Lex.SessionAttributes.Tool`; spec-driven extensions allowed but the base two are mandatory. Linter normalizes wrong synonyms (`END_CALL`/`END_CONVERSATION`/`ESCALATE` → `Complete`/`Escalate`).

## Generator robustness

- `build_field_schema_section` (shared by lambda + openapi generators) crashed with `'str' object has no attribute 'get'` on complex specs carrying bare-string or double-encoded JSON fields — now fault-tolerant. (This crashed all Lambda generations on a 6-operation spec.)

## Session-state fixes

- **Liveness probe** wrongly judged older sessions dead via a truncated top-10 `recent_sessions` list, rotating users onto fresh sessions and discarding work. `/api/debug/nfs` now returns an authoritative per-session `session_exists`; the probe uses it.
- **Workspace tree showed a different session's files** than the active chat (assets looked "missing"). `useWebSocket.switchSession` now syncs the zustand `sessionStore`, which `FileExplorer` reads.

## Verification

- All 5 sample flows + a fresh 34-block bank-card scenario (애니컴퍼니카드: 5 DynamoDB tables, 7 Lambdas, full business-rule branching) import cleanly via the Connect API.
- `tests/test_contact_flow_linter.py` (18 cases) + `tests/test_field_schema_section.py` (5 cases) pass; full backend suite 103 passing (4 pre-existing async-marker failures unrelated).

## Tests
- [x] Backend pytest
- [x] Real `CreateContactFlow` API import validation
- [x] cfn-lint / openapi-spec-validator gates green on generated assets