### PR TITLE
fix(infra): unique KB execution role name per region (multi-region deploy)

### DIFF
--- a/infrastructure/lib/app.ts
+++ b/infrastructure/lib/app.ts
@@ -51,6 +51,10 @@ if (enableKnowledgeBase) {
   new KnowledgeBaseStack(app, `AiccBuilderKnowledgeBase${suffix}`, {
     env,
     description: "AICC Builder Knowledge Base - RAG for Contact Flow generation",
+    // Pass the resolved region as a concrete string so the KB execution role
+    // name can be made unique per region (IAM roles are global; same stack name
+    // across regions would otherwise collide). See knowledge-base-stack.ts.
+    resolvedRegion: env.region,
   });
 }
 

--- a/infrastructure/lib/knowledge-base-stack.ts
+++ b/infrastructure/lib/knowledge-base-stack.ts
@@ -19,11 +19,21 @@ import { bedrock, s3vectors } from "@cdklabs/generative-ai-cdk-constructs";
  * source sync. The dimension (1024) must match the embeddings model
  * (TITAN_EMBED_TEXT_V2_1024).
  */
+export interface KnowledgeBaseStackProps extends cdk.StackProps {
+  /**
+   * The concrete deploy region (e.g. "ap-northeast-1"), passed from app.ts so the
+   * KB execution role name can be made unique per region. IAM roles are global,
+   * and the cdklabs construct derives the role name from the construct path only
+   * (no region), so identical stack names across regions would collide.
+   */
+  resolvedRegion?: string;
+}
+
 export class KnowledgeBaseStack extends cdk.Stack {
   public readonly docsBucketName: cdk.CfnOutput;
   public readonly agentCoreKbPolicyArn: cdk.CfnOutput;
 
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, props?: KnowledgeBaseStackProps) {
     super(scope, id, props);
 
     // S3 Bucket for Knowledge Base Documents
@@ -68,6 +78,21 @@ export class KnowledgeBaseStack extends cdk.Stack {
       description: "Curated Amazon Connect Contact Flow documentation for RAG-enhanced generation",
       instruction: "Use this knowledge base to answer questions about Amazon Connect contact flow blocks, patterns, and best practices.",
     });
+
+    // MULTI-REGION FIX: the cdklabs construct derives the KB execution role name
+    // from the construct path (stack id + construct id) only — NOT the region.
+    // Since the stack name is identical across regions (AiccBuilderKnowledgeBase-<stage>),
+    // Seoul and Tokyo would generate the SAME global IAM role name. IAM roles are
+    // global, so the second region collides with the first region's role — whose
+    // trust policy pins aws:SourceArn to the first region — and Bedrock then can't
+    // assume it ("unable to assume the given role"). Make the role name unique per
+    // region so each region owns its own correctly-scoped role.
+    const roleRegion = props?.resolvedRegion || cdk.Stack.of(this).region;
+    const cfnKbRole = kb.role.node.defaultChild as iam.CfnRole;
+    cfnKbRole.addPropertyOverride(
+      "RoleName",
+      `AmazonBedrockExecKB-${id}-${roleRegion}`.slice(0, 64),
+    );
 
     // The cdklabs construct grants the KB role PutVectors/GetVectors/QueryVectors
     // but NOT DeleteVectors. Re-ingestion (after docs change) must delete the old


### PR DESCRIPTION
## Problem

Deploying the `-prod` stacks to a **second region** (Tokyo `ap-northeast-1`, alongside the existing Seoul `ap-northeast-2`) failed:

> `Bedrock Knowledge Base was unable to assume the given role.`

## Root cause

IAM roles are **global**, but the cdklabs `VectorKnowledgeBase` construct derives the KB execution role name from the **construct path only** (stack id + construct id) — it does **not** include the region. With an identical stack name across regions (`AiccBuilderKnowledgeBase-prod`), Seoul and Tokyo generate the **same global role name**.

Seoul created it first, with a trust policy pinning `aws:SourceArn` to `arn:aws:bedrock:ap-northeast-2:…:knowledge-base/*`. Tokyo's KB (SourceArn `ap-northeast-1`) then cannot assume that role → 400.

(This also surfaced an orphaned `DELETE_UNSUCCESSFUL` KB in Tokyo whose backing OpenSearch collection was already gone — cleaned up out-of-band by setting the data source's `dataDeletionPolicy` to `RETAIN` and deleting.)

## Fix

Override the KB role name to include the region: `AmazonBedrockExecKB-<stackId>-<region>`. The region is passed explicitly from `app.ts` as `resolvedRegion` (= `env.region`, which `deploy.sh` sets authoritatively via `-c targetRegion=$AWS_DEFAULT_REGION`), so it does **not** depend on the ambient credential region at synth time.

Verified via `cdk synth`:
- Seoul → `AmazonBedrockExecKB-AiccBuilderKnowledgeBase-prod-ap-northeast-2`, trust SourceArn `bedrock:ap-northeast-2`
- Tokyo → `AmazonBedrockExecKB-AiccBuilderKnowledgeBase-prod-ap-northeast-1`, trust SourceArn `bedrock:ap-northeast-1`

## Note

Existing single-region stacks will **rename their KB role on the next deploy** (a role replacement — expected and safe; the new role carries the correct per-region trust). No data loss; the KB and vector store are unaffected.