### PR TITLE
docs(readme): tagline credits Amazon Bedrock + Strands SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-**Turn a ~1-hour AI conversation into a fully customized Amazon Connect PoC** · powered by Bedrock **Claude Opus 4.6**
+**Turn a ~1-hour AI conversation into a fully customized Amazon Connect PoC** · powered by Amazon Bedrock and Strands SDK 
 
 [![AWS CDK](https://img.shields.io/badge/AWS%20CDK-2.x-orange?style=flat&logo=amazonaws)](https://aws.amazon.com/cdk/)
 [![React](https://img.shields.io/badge/React-18.3-blue?style=flat&logo=react)](https://reactjs.org/)


### PR DESCRIPTION
## Summary

Small README header tweak: the tagline now credits **Amazon Bedrock and Strands SDK** instead of naming a specific model (`Claude Opus 4.6`).

The webapp now offers a model selector (Opus 4.8 default / 4.7 / 4.6), so pinning the tagline to one model was stale. This keeps the headline accurate and stable across model changes.

Single-line change.