### PR TITLE
fix(agents): raise faq/vision max_tokens to Bedrock 128K ceiling

### DIFF
--- a/backend/ecs/src/agents/contact_flow_generator/vision_import.py
+++ b/backend/ecs/src/agents/contact_flow_generator/vision_import.py
@@ -101,7 +101,7 @@ def draft_flow_from_image(
         model = BedrockModel(**build_model_kwargs(
             model_id,
             temperature=0,  # deterministic transcription (dropped for 4.7/4.8)
-            max_tokens=64000,
+            max_tokens=128000,  # Bedrock Opus-4.x output ceiling (transcription output is naturally far smaller)
             boto_client_config=BotocoreConfig(read_timeout=300),
         ))
         agent = Agent(model=model, system_prompt=VISION_IMPORT_SYSTEM_PROMPT)

--- a/backend/ecs/src/agents/faq_generator/agent.py
+++ b/backend/ecs/src/agents/faq_generator/agent.py
@@ -639,7 +639,7 @@ Cover these topics:
             resolve_model_id(override_env="FAQ_MODEL_ID"),
             region_name=region,
             # temperature omitted (None) — only applied on models that accept it
-            max_tokens=64000,
+            max_tokens=128000,  # Bedrock Opus-4.x output ceiling; streaming avoids HTTP timeout
             streaming=True,
             # cache_prompt removed - using cachePoint in system_prompt instead
             cache_tools="default",   # Cache tool definitions


### PR DESCRIPTION
Increased max output token for faq and vision import to MAX 