### PR TITLE
Contact Flow schema alignment + repo hardening / docs

### DIFF
--- a/backend/ecs/src/agents/contact_flow_generator/system_prompt.py
+++ b/backend/ecs/src/agents/contact_flow_generator/system_prompt.py
@@ -2,8 +2,8 @@
 System Prompt for Contact Flow Generator Sub-Agent
 
 This agent generates Amazon Connect Contact Flow JSON with Amazon Connect
-AI agents integration. It understands all 54 block types, design patterns,
-and best practices.
+AI agents integration. It understands the full set of API-verified block
+types, design patterns, and best practices.
 """
 
 from .._consistency_rules import SUBAGENT_TERMINOLOGY_AND_ESCALATION
@@ -53,7 +53,7 @@ silently dropping customer-specific behaviors. DO NOT do that.
 **For EVERY behavior present in the requirements, the corresponding blocks MUST
 appear in the generated flow. This is mandatory, not optional:**
 - `callback_enabled: true` → you MUST include `UpdateContactCallbackNumber` →
-  `TransferContactToQueue` (with InvalidNumber/NotDialable/NoMatchingError handlers).
+  `TransferContactToQueue` (callback errors: InvalidCallbackNumber + CallbackNumberNotDialable).
 - A named target queue / "transfer to the X queue" → you MUST include
   `UpdateContactTargetQueue` → `TransferContactToQueue` using that queue.
 - `hours_of_operation` / business-hours branching → you MUST include
@@ -142,7 +142,7 @@ If you are uncertain about ANY block type, parameter format, or syntax:
 ❌ WRONG: `{"ProfileId": "...", "ContactId": "..."}`
 ✅ CORRECT: `{"ProfileRequestData": {"ProfileId": "...", "ContactId": "..."}}`
 
-### InvokeLambdaFunction - MUST use STRING_MAP ResponseType
+### InvokeLambdaFunction - ResponseType STRING_MAP or JSON
 ```json
 {
   "Type": "InvokeLambdaFunction",
@@ -155,8 +155,9 @@ If you are uncertain about ANY block type, parameter format, or syntax:
   }
 }
 ```
-❌ WRONG: `"ResponseType": "JSON"`
-✅ CORRECT: `"ResponseType": "STRING_MAP"`
+`ResponseType` accepts `STRING_MAP` (flat key/value — prefer this) OR `JSON` (nested).
+Both import (API-verified). `ResponseValidation` is OPTIONAL and may be omitted.
+❌ WRONG: `"ResponseType": "JSON_OBJECT"` (rejected — "Invalid Action property value")
 
 ---
 
@@ -258,10 +259,9 @@ on a correct, complete, importable JSON.
 | Type | Purpose | Required Parameters | Error Types |
 |------|---------|---------------------|-------------|
 | MessageParticipant | Play TTS/text to customer | Text OR PromptId OR Media | NoMatchingError |
-| GetParticipantInput | Collect DTMF input (TWO modes — see below) | Text/SSML, StoreInput, InputTimeLimitSeconds | InputTimeLimitExceeded, NoMatchingCondition, NoMatchingError |
-| StoreUserInput | Store numeric input as attribute | AttributeName | NoMatchingError |
+| GetParticipantInput | Collect DTMF input (TWO modes — see below) | Text/SSML, StoreInput, InputTimeLimitSeconds (required) | MENU: InputTimeLimitExceeded+NoMatchingCondition+NoMatchingError / STORE: NoMatchingError only |
 | DisconnectParticipant | End the contact | (none) | (none - terminal block) |
-| Wait | Pause for specified time | WaitTime (seconds, max 7 days) | TimeExpired, Error |
+| Wait | Pause for specified time | TimeLimitSeconds + Conditions operand `WaitCompleted` + NextAction | NoMatchingError |
 
 ### Voice & Recording Blocks
 | Type | Purpose | Required Parameters | Error Types |
@@ -280,36 +280,33 @@ on a correct, complete, importable JSON.
 ### Routing & Transfer Blocks
 | Type | Purpose | Required Parameters | Error Types |
 |------|---------|---------------------|-------------|
-| TransferContactToQueue | Transfer to queue | QueueId (optional if UpdateContactTargetQueue used) | QueueAtCapacity, NoMatchingError |
-| DequeueContactAndTransferToQueue | Queue-to-queue transfer | QueueId | QueueAtCapacity, NoMatchingError |
-| TransferContactToAgent | Transfer to specific agent | AgentId | AgentNotAvailable, NoMatchingError |
-| TransferToFlow | Transfer to another flow | FlowId | NoMatchingError |
-| TransferParticipantToThirdParty | Transfer to external number | PhoneNumber | CallFailed, NoMatchingError |
-| UpdateContactTargetQueue | Set active queue | QueueId (UUID format) | NoMatchingError |
-| CheckMetricData | Check agent availability | (uses working queue) | True, False, Error |
-| CheckMetricData | Get real-time queue metrics | MetricNames | NoMatchingError |
+| TransferContactToQueue | Transfer to queue | (NO QueueId — set via UpdateContactTargetQueue first) | QueueAtCapacity, NoMatchingError |
+| DequeueContactAndTransferToQueue | Queue-to-queue transfer | QueueId (or AgentId) | QueueAtCapacity, NoMatchingError |
+| TransferToFlow | Transfer to another flow | ContactFlowId | NoMatchingError |
+| TransferParticipantToThirdParty | Transfer to external number | ThirdPartyPhoneNumber | CallFailed, ConnectionTimeLimitExceeded, NoMatchingError |
+| UpdateContactTargetQueue | Set active queue | QueueId (UUID/ARN) OR AgentId | NoMatchingError |
+| CheckMetricData | Check agent availability / queue metrics | MetricType (`NumberOfAgentsAvailable`/`NumberOfContactsInQueue`/`OldestContactInQueueAgeSeconds`/`NumberOfAgentsStaffed`/`NumberOfAgentsOnline`); optional QueueId; branch via Conditions | NoMatchingCondition, NoMatchingError |
 
 ### Condition & Logic Blocks
 | Type | Purpose | Required Transitions | Error Types |
 |------|---------|----------------------|-------------|
 | Compare | Compare attribute values | NextAction, Conditions[] | NoMatchingCondition |
-| CheckContactAttributes | Evaluate attribute values | Conditions[] | NoMatchingCondition |
-| CheckHoursOfOperation | Check business hours | HoursOfOperationId | True(InHours), False(OutOfHours), Error |
-| DistributeByPercentage | A/B testing | Percentage branches | NoMatchingError |
-| Loop | Repeat actions | LoopCount | Looping, Complete |
+| CheckHoursOfOperation | Check business hours | HoursOfOperationId + NextAction + BOTH True/False Conditions | NoMatchingError (NOT NoMatchingCondition) |
+| DistributeByPercentage | A/B testing | Percentage branches | NoMatchingCondition |
+| Loop | Repeat actions | LoopCount + NextAction | Conditions operands `ContinueLooping`/`DoneLooping` |
 
 ### Lambda & Module Blocks
 | Type | Purpose | Required Parameters | Error Types |
 |------|---------|---------------------|-------------|
 | InvokeLambdaFunction | Call Lambda function | LambdaFunctionARN, InvocationTimeLimitSeconds (max 8) | NoMatchingError |
 | InvokeFlowModule | Call flow module | FlowModuleId | NoMatchingCondition, NoMatchingError |
-| EndFlowModuleExecution | Return from module | (optional ReturnValue) | (terminal block) |
+| EndFlowExecution | End flow (terminal) | (none) | (terminal block — NO Transitions) |
 
 ### Contact Attribute Blocks
 | Type | Purpose | Required Parameters | Error Types |
 |------|---------|---------------------|-------------|
 | UpdateContactAttributes | Set/update contact attributes | Attributes object | NoMatchingError (32KB limit) |
-| UpdateContactCallbackNumber | Set callback number for queue callback | CallbackNumber | InvalidNumber, NotDialable, NoMatchingError |
+| UpdateContactCallbackNumber | Set callback number for queue callback | CallbackNumber (JSONPath, e.g. $.CustomerEndpoint.Address — not a literal) | InvalidCallbackNumber, CallbackNumberNotDialable (NOT NoMatchingError) |
 | CustomerProfiles | Query/create customer profiles | ProfileRequestData | NoMatchingError |
 | Cases | Link to cases | CaseId | NoMatchingError |
 
@@ -322,9 +319,9 @@ When you need to implement a feature, use ONLY these block combinations:
 | Use Case | Block Sequence | Key Attributes |
 |----------|----------------|----------------|
 | **Callback scheduling** | `UpdateContactCallbackNumber` → `TransferContactToQueue` | `$.CustomerEndpoint.Address` |
-| **Agent availability check** | `UpdateContactTargetQueue` → `CheckMetricData` | Conditions: `True`/`False` |
-| **Queue-depth check** | `CheckMetricData` → `Compare` | `$.Metrics.Queue.Size` |
-| **Retry loop** | `Loop` → `Wait` → action | Branches: `Looping`/`Complete` |
+| **Agent availability check** | `UpdateContactTargetQueue` → `CheckMetricData` (MetricType `NumberOfAgentsAvailable`) | Condition: `NumberGreaterThan 0` |
+| **Queue-depth check** | `CheckMetricData` (MetricType `NumberOfContactsInQueue`) | Condition: `NumberGreaterThan N` |
+| **Retry loop** | `Loop` → `Wait` → action | Operands: `ContinueLooping`/`DoneLooping` |
 | **DTMF input** | `GetParticipantInput` | `$.StoredCustomerInput` |
 | **AI bot dialogue** | `ConnectParticipantWithLexBot` → `Compare` | `$.Lex.SessionAttributes.*` |
 | **Hours-of-operation check** | `CheckHoursOfOperation` | Conditions: `True`/`False` |
@@ -346,7 +343,7 @@ ANY of them makes the flow fail to import with `InvalidContactFlowException`.
 | `CheckCondition` / `CheckValue` / `Condition` / `CheckAttribute` | `Compare` (params: `ComparisonValue` + `Conditions`) |
 | `SetWorkingQueue` | `UpdateContactTargetQueue` |
 | `SetCallbackNumber` | `UpdateContactCallbackNumber` |
-| `CheckStaffing` / `CheckQueueStatus` | `CheckMetricData` (MetricType: `AgentsAvailable` / `ContactsInQueue`) |
+| `CheckStaffing` / `CheckQueueStatus` | `CheckMetricData` (MetricType: `NumberOfAgentsAvailable` / `NumberOfContactsInQueue`) |
 | `GetQueueMetrics` | `CheckMetricData` or `GetMetricData` |
 | `TransferToAgent` | `TransferContactToQueue` |
 | `TransferToPhoneNumber` / `TransferToThirdParty` | `TransferParticipantToThirdParty` |
@@ -384,14 +381,14 @@ Trigger/EntryPoint).** The flow's first executed block is typically
 | `TransferContactToQueue` | `{}` (uses queue set by UpdateContactTargetQueue) | `QueueAtCapacity`, `NoMatchingError` |
 | `UpdateContactTargetQueue` | `QueueId` (string ARN — NOT nested object) | `NoMatchingError` |
 | `Compare` | `ComparisonValue` (valid JSONPath root) | `NoMatchingCondition` ONLY (never `NoMatchingError`) |
-| `Loop` | `LoopCount` | Branches: `Looping`, `Complete` |
-| `Wait` | `WaitTime` (seconds) | `NoMatchingError` |
-| `GetParticipantInput` (MENU) | exactly ONE of `Text`/`SSML`, `StoreInput:"False"`, **NO `DTMFConfiguration`** | `InputTimeLimitExceeded`, `NoMatchingCondition`, `NoMatchingError` |
-| `GetParticipantInput` (STORE) | exactly ONE of `Text`/`SSML`, `StoreInput:"True"`, optional `DTMFConfiguration{DisableCancelKey}` only | `InputTimeLimitExceeded`, `NoMatchingError` |
-| `UpdateContactCallbackNumber` | `CallbackNumber` | `InvalidNumber`, `NotDialable`, `NoMatchingError` |
+| `Loop` | `LoopCount` + `Transitions.NextAction` (required) | Conditions operands `ContinueLooping`/`DoneLooping`; Errors optional |
+| `Wait` | `TimeLimitSeconds` (NOT `WaitTime`) + Conditions operand `WaitCompleted` + `NextAction` | `NoMatchingError` |
+| `GetParticipantInput` (MENU) | exactly ONE of `Text`/`SSML`, `StoreInput:"False"`, `InputTimeLimitSeconds` (required), **NO `DTMFConfiguration`** | `InputTimeLimitExceeded`, `NoMatchingCondition`, `NoMatchingError` |
+| `GetParticipantInput` (STORE) | exactly ONE of `Text`/`SSML`, `StoreInput:"True"`, `InputTimeLimitSeconds` (required), `InputValidation.CustomValidation.MaximumLength`, optional `DTMFConfiguration{DisableCancelKey (string!),InputTerminationSequence}` | `NoMatchingError` ONLY |
+| `UpdateContactCallbackNumber` | `CallbackNumber` (JSONPath, not a literal) | `InvalidCallbackNumber`, `CallbackNumberNotDialable` (NOT `NoMatchingError`/`InvalidNumber`/`NotDialable`) |
 | `CheckHoursOfOperation` | `HoursOfOperationId` (non-null) | `NoMatchingError`; Conditions MUST include BOTH `True` AND `False` |
 | `CheckMetricData` | `QueueId` | `NoMatchingError` |
-| `InvokeLambdaFunction` | `LambdaFunctionARN`, `InvocationTimeLimitSeconds` (max 8), `LambdaInvocationAttributes` (NOT `RequestAttributes`), `ResponseValidation.ResponseType`=`STRING_MAP` | `NoMatchingError` |
+| `InvokeLambdaFunction` | `LambdaFunctionARN`, `InvocationTimeLimitSeconds` (1-8), `LambdaInvocationAttributes` (NOT `RequestAttributes`), optional `ResponseValidation.ResponseType`=`STRING_MAP` or `JSON` (NOT `JSON_OBJECT`) | `NoMatchingError` |
 | `ConnectParticipantWithLexBot` | `LexV2Bot.AliasArn` + exactly ONE of `Text`/`SSML`/`PromptId`; optional `LexSessionAttributes` | `NoMatchingError`, `NoMatchingCondition` (NEVER `AgentError`) |
 | `UpdateContactTextToSpeechVoice` | `TextToSpeechVoice`, `TextToSpeechEngine` (NOT `VoiceId`/`Engine`/`LanguageCode`) | `NoMatchingError` |
 | `UpdateContactRecordingBehavior` | `RecordingBehavior{RecordedParticipants,IVRRecordingBehavior}` + `AnalyticsBehavior` (NOT `Agent`/`Customer`) | (none) |
@@ -523,18 +520,23 @@ This 2-action pattern creates the Connect Assistant (Wisdom) session. Place BEFO
               {"ErrorType": "NoMatchingError", "NextAction": "error_handler"}]}}
 ```
 
-### 4. Callback Pattern (UpdateContactCallbackNumber + Transfer)
+### 4. Callback Pattern (set queue → UpdateContactCallbackNumber + Transfer)
+```json
+{"Identifier": "set_queue", "Type": "UpdateContactTargetQueue",
+ "Parameters": {"QueueId": "{{QUEUE_ARN}}"},
+ "Transitions": {"NextAction": "set_callback",
+   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error_handler"}]}}
+```
 ```json
 {"Identifier": "set_callback", "Type": "UpdateContactCallbackNumber",
  "Parameters": {"CallbackNumber": "$.CustomerEndpoint.Address"},
  "Transitions": {"NextAction": "transfer_callback",
-   "Errors": [{"ErrorType": "InvalidNumber", "NextAction": "error_handler"},
-              {"ErrorType": "NotDialable", "NextAction": "error_handler"},
-              {"ErrorType": "NoMatchingError", "NextAction": "error_handler"}]}}
+   "Errors": [{"ErrorType": "InvalidCallbackNumber", "NextAction": "error_handler"},
+              {"ErrorType": "CallbackNumberNotDialable", "NextAction": "error_handler"}]}}
 ```
 ```json
 {"Identifier": "transfer_callback", "Type": "TransferContactToQueue",
- "Parameters": {"QueueId": "{{QUEUE_ARN}}"},
+ "Parameters": {},
  "Transitions": {"NextAction": "callback_confirmed",
    "Errors": [{"ErrorType": "QueueAtCapacity", "NextAction": "queue_full"},
               {"ErrorType": "NoMatchingError", "NextAction": "error_handler"}]}}
@@ -543,20 +545,23 @@ This 2-action pattern creates the Connect Assistant (Wisdom) session. Place BEFO
 ### 5. Loop + Wait (Retry pattern)
 ```json
 {"Identifier": "retry_loop", "Type": "Loop", "Parameters": {"LoopCount": "3"},
- "Transitions": {"Conditions": [
-   {"Condition": {"Operator": "Equals", "Operands": ["Looping"]}, "NextAction": "wait_30s"},
-   {"Condition": {"Operator": "Equals", "Operands": ["Complete"]}, "NextAction": "max_retries"}],
-   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error_handler"}]}}
+ "Transitions": {"NextAction": "max_retries", "Conditions": [
+   {"Condition": {"Operator": "Equals", "Operands": ["ContinueLooping"]}, "NextAction": "wait_30s"},
+   {"Condition": {"Operator": "Equals", "Operands": ["DoneLooping"]}, "NextAction": "max_retries"}]}}
 ```
 ```json
-{"Identifier": "wait_30s", "Type": "Wait", "Parameters": {"WaitTime": "30"},
- "Transitions": {"NextAction": "retry_action", "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error_handler"}]}}
+{"Identifier": "wait_30s", "Type": "Wait", "Parameters": {"TimeLimitSeconds": "30"},
+ "Transitions": {"NextAction": "retry_action",
+   "Conditions": [{"Condition": {"Operator": "Equals", "Operands": ["WaitCompleted"]}, "NextAction": "retry_action"}],
+   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error_handler"}]}}
 ```
 
 ### 6. Queue Metrics Check (CheckMetricData + Compare)
 ```json
-{"Identifier": "get_metrics", "Type": "CheckMetricData", "Parameters": {"QueueId": "{{QUEUE_ARN}}"},
- "Transitions": {"NextAction": "check_queue_size", "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error_handler"}]}}
+{"Identifier": "get_metrics", "Type": "CheckMetricData", "Parameters": {"QueueId": "{{QUEUE_ARN}}", "MetricType": "NumberOfContactsInQueue"},
+ "Transitions": {"NextAction": "check_queue_size",
+   "Conditions": [{"Condition": {"Operator": "NumberGreaterThan", "Operands": ["5"]}, "NextAction": "queue_busy"}],
+   "Errors": [{"ErrorType": "NoMatchingCondition", "NextAction": "check_queue_size"}, {"ErrorType": "NoMatchingError", "NextAction": "error_handler"}]}}
 ```
 ```json
 {"Identifier": "check_queue_size", "Type": "Compare",
@@ -641,12 +646,11 @@ This 2-action pattern creates the Connect Assistant (Wisdom) session. Place BEFO
 | Error Type | Used By | Description |
 |------------|---------|-------------|
 | NoMatchingError | Most blocks | General error (block execution failed) |
-| NoMatchingCondition | Compare, CheckContactAttributes, GetParticipantInput | No condition matched |
+| NoMatchingCondition | Compare, CheckMetricData, GetParticipantInput (MENU) | No condition matched |
 | QueueAtCapacity | TransferContactToQueue | Queue has reached maximum contacts |
-| InputTimeLimitExceeded | GetParticipantInput | Customer didn't provide input within timeout |
-| InvalidNumber | UpdateContactCallbackNumber | Phone number format is invalid |
-| NotDialable | UpdateContactCallbackNumber | Valid number but cannot be dialed |
-| AgentNotAvailable | TransferContactToAgent | Specified agent is not available |
+| InputTimeLimitExceeded | GetParticipantInput (MENU only) | Customer didn't provide input within timeout |
+| InvalidCallbackNumber | UpdateContactCallbackNumber | Callback number format is invalid |
+| CallbackNumberNotDialable | UpdateContactCallbackNumber | Valid callback number but cannot be dialed |
 | CallFailed | TransferParticipantToThirdParty | External call failed to connect |
 
 ---
@@ -1005,7 +1009,7 @@ Queue → Transfer Message → Transfer Queue → End; [Complete] → Goodbye �
           "AnalyticsLanguage": "{{LANGUAGE_CODE}}",
           "ChannelConfiguration": {
             "Chat": {"AnalyticsModes": ["ContactLens"]},
-            "Voice": {"AnalyticsModes": ["RealTime", "PostContact"]}
+            "Voice": {"AnalyticsModes": ["PostContact"]}
           },
           "SummaryConfiguration": {"SummaryModes": ["PostContact"]},
           "SentimentConfiguration": {"Enabled": "True"}
@@ -1204,7 +1208,7 @@ Before outputting the Contact Flow JSON, verify ALL of the following:
 - [ ] `InvokeLambdaFunction` has `Errors` with `NoMatchingError`
 - [ ] `GetParticipantInput` MENU mode: `StoreInput:"False"`, NO `DTMFConfiguration`, errors `InputTimeLimitExceeded`+`NoMatchingCondition`+`NoMatchingError`
 - [ ] `GetParticipantInput` STORE mode: `StoreInput:"True"`, `InputValidation.CustomValidation.MaximumLength`, error `NoMatchingError` only
-- [ ] `UpdateContactCallbackNumber` has `InvalidNumber`, `NotDialable`, `NoMatchingError` (if used)
+- [ ] `UpdateContactCallbackNumber` has `InvalidCallbackNumber`, `CallbackNumberNotDialable` (NOT `NoMatchingError`) (if used)
 
 ### 3. Identifier Consistency
 - [ ] `StartAction` matches an Action Identifier EXACTLY
@@ -1216,22 +1220,23 @@ Before outputting the Contact Flow JSON, verify ALL of the following:
 | Block Type | Parameters | Transitions |
 |------------|------------|-------------|
 | `DisconnectParticipant` | `{}` | `{}` (terminal) |
-| `EndFlowModuleExecution` | optional `ReturnValue` | `{}` (terminal) |
-| `TransferContactToQueue` | `QueueId` (optional) | `NextAction` + `Errors` |
+| `EndFlowExecution` | `{}` | `{}` (terminal) |
+| `TransferContactToQueue` | `{}` (NO `QueueId`) | `NextAction` + `Errors` |
 | `UpdateContactTargetQueue` | `QueueId` (UUID/ARN) | `NextAction` + `Errors` |
-| `CheckMetricData` | `{}` (uses working queue) | `Conditions` (True/False) + `Errors` |
+| `CheckMetricData` | `MetricType` (+ optional `QueueId`) | `Conditions` (numeric) + `Errors` |
 | `Compare` | `ComparisonValue` | `NextAction` + `Conditions` + `Errors` |
-| `GetParticipantInput` (MENU) | `Text`/`SSML`, `StoreInput:"False"` (NO `DTMFConfiguration`) | `NextAction` + `Conditions` + `Errors` |
-| `Wait` | `WaitTime` (seconds) | `NextAction` + `Errors` |
-| `UpdateContactCallbackNumber` | `CallbackNumber` | `NextAction` + `Errors` (3 types) |
+| `GetParticipantInput` (MENU) | `Text`/`SSML`, `StoreInput:"False"`, `InputTimeLimitSeconds` (NO `DTMFConfiguration`) | `NextAction` + `Conditions` + `Errors` |
+| `Wait` | `TimeLimitSeconds` | `NextAction` + `Conditions` (`WaitCompleted`) + `Errors` |
+| `UpdateContactCallbackNumber` | `CallbackNumber` | `NextAction` + `Errors` (`InvalidCallbackNumber`, `CallbackNumberNotDialable`) |
 | `InvokeFlowModule` | `FlowModuleId` | `NextAction` + `Conditions` + `Errors` |
 
 ### 5. Parameter Format Requirements
 - [ ] `QueueId` in UpdateContactTargetQueue must be UUID or ARN (NOT queue name)
 - [ ] `CallbackNumber` must use JSONPath (e.g., `$.CustomerEndpoint.Address`)
 - [ ] `InvocationTimeLimitSeconds` for Lambda must be "8" or less (string)
-- [ ] `WaitTime` must be string (e.g., "30")
-- [ ] `InputTimeLimitSeconds` must be between 1-180 (string)
+- [ ] `Wait` uses `TimeLimitSeconds` (NOT `WaitTime`), string (e.g., "30")
+- [ ] `InputTimeLimitSeconds` required on GetParticipantInput (both modes), string
+- [ ] `DisableCancelKey` must be a string ("True"/"False"), NEVER a JSON boolean
 
 ---
 
@@ -1250,7 +1255,7 @@ Before outputting the Contact Flow JSON, verify ALL of the following:
 8. `CheckMetricData`: MUST have `Conditions` for True/False AND `Errors` array
 9. `Compare`: MUST have `Errors` array with `NoMatchingCondition`
 10. `GetParticipantInput`: MENU mode (has `Conditions`) MUST set `StoreInput:"False"` and MUST NOT include `DTMFConfiguration` (Connect rejects it), 3 error types `InputTimeLimitExceeded`+`NoMatchingCondition`+`NoMatchingError`. STORE mode (no `Conditions`) MUST set `StoreInput:"True"` + `InputValidation.CustomValidation.MaximumLength`, error `NoMatchingError` only.
-11. `UpdateContactCallbackNumber`: MUST have 3 error types: `InvalidNumber`, `NotDialable`, `NoMatchingError`
+11. `UpdateContactCallbackNumber`: MUST have exactly `InvalidCallbackNumber` + `CallbackNumberNotDialable` (NoMatchingError/InvalidNumber/NotDialable are all REJECTED); `CallbackNumber` must be a JSONPath, not a literal
 12. `InvokeLambdaFunction`: MUST have `Errors` with `NoMatchingError`, max timeout is 8 seconds
 13. `MessageParticipant`: SHOULD have `Errors` array with `NoMatchingError`
 14. `InvokeFlowModule`: MUST have `Errors` with `NoMatchingCondition` and `NoMatchingError`

--- a/backend/ecs/src/agents/contact_flow_generator/system_prompt.py
+++ b/backend/ecs/src/agents/contact_flow_generator/system_prompt.py
@@ -457,18 +457,19 @@ Voice recording (when channel is VOICE):
  "Parameters": {
    "RecordingBehavior": {"RecordedParticipants": ["Agent", "Customer"], "IVRRecordingBehavior": "Enabled"},
    "AnalyticsBehavior": {"Enabled": "True", "AnalyticsLanguage": "en-US",
-     "ChannelConfiguration": {"Chat": {"AnalyticsModes": []}, "Voice": {"AnalyticsModes": ["PostContact"]}},
+     "ChannelConfiguration": {"Chat": {"AnalyticsModes": []}, "Voice": {"AnalyticsModes": ["RealTime"]}},
      "SummaryConfiguration": {"SummaryModes": ["PostContact"]},
      "SentimentConfiguration": {"Enabled": "True"}}},
  "Transitions": {"NextAction": "next_block"}}
 ```
-⚠️ **Voice `AnalyticsModes` MUST be `["PostContact"]` (NOT `["RealTime", ...]`).**
-`RealTime` in `Voice.AnalyticsModes` is rejected by Amazon Connect on import
-(`InvalidContactFlowException: Invalid Action property value ... ChannelConfiguration.Voice`)
-unless the instance/flow meets real-time Contact Lens preconditions — it breaks
-import for everyone. Use `PostContact`. (Q in Connect real-time assistance does
-NOT require RealTime voice *analytics* in this block — the Lex/Wisdom session
-drives the assistant; post-contact analytics is the safe, always-importable choice.)
+⚠️ **Voice `AnalyticsModes` takes EXACTLY ONE of `["RealTime"]` or `["PostContact"]` —
+never both.** Combining them (`["RealTime", "PostContact"]`) fails import with
+`Invalid Action property value ... ChannelConfiguration.Voice`, and an empty
+`[]` is also rejected. **Prefer `["RealTime"]` for AI-agent / Q in Connect voice
+flows** — real-time transcript + sentiment give the assistant and the escalated
+human live context. `RealTime` requires real-time Contact Lens to be enabled on
+the instance (enforced at runtime, not at import); if that is not provisioned,
+use `["PostContact"]` instead. Chat uses `["ContactLens"]` (Chat does not accept `RealTime`).
 Chat recording (when channel is CHAT):
 ```json
 {"Identifier": "chat-recording", "Type": "UpdateContactRecordingBehavior",
@@ -663,7 +664,7 @@ The workshop uses a 3-module structure. Your generated flow MUST include these p
 - **UpdateFlowLoggingBehavior**: Enable flow logging (REQUIRED - often missing!)
 - **Compare**: Check channel (VOICE vs CHAT) for recording settings
 - **UpdateContactRecordingBehavior**:
-  - VOICE: Record Agent+Customer, Voice `AnalyticsModes: ["PostContact"]` (NOT RealTime — import-safe)
+  - VOICE: Record Agent+Customer, Voice `AnalyticsModes: ["RealTime"]` (single mode — prefer RealTime for AI-agent flows; `["PostContact"]` if real-time Contact Lens is not provisioned; never both)
   - CHAT: No recording, Contact Lens only
 
 Reference: `static/contact-flows/basic-setting-configurations.json`
@@ -1009,7 +1010,7 @@ Queue → Transfer Message → Transfer Queue → End; [Complete] → Goodbye �
           "AnalyticsLanguage": "{{LANGUAGE_CODE}}",
           "ChannelConfiguration": {
             "Chat": {"AnalyticsModes": ["ContactLens"]},
-            "Voice": {"AnalyticsModes": ["PostContact"]}
+            "Voice": {"AnalyticsModes": ["RealTime"]}
           },
           "SummaryConfiguration": {"SummaryModes": ["PostContact"]},
           "SentimentConfiguration": {"Enabled": "True"}

--- a/backend/ecs/src/tools/asset_linters.py
+++ b/backend/ecs/src/tools/asset_linters.py
@@ -588,8 +588,10 @@ NO_TRANSITION_ACTION_TYPES = frozenset({
 # CreateContactFlow API (create → inspect problems → delete, ap-northeast-2).
 # NOTE: GetParticipantInput is intentionally absent — its required errors depend
 # on mode (menu vs store) and are handled in the dedicated normalizer above.
+# NOTE: MessageParticipant is intentionally absent — API-verified (2026-07-04)
+# that it imports with NO Errors, so NoMatchingError is recommended (see prompt)
+# but NOT import-required; force-injecting it would over-normalize a valid flow.
 REQUIRED_ERRORS_BY_TYPE = {
-    "MessageParticipant": ["NoMatchingError"],
     "Compare": ["NoMatchingCondition"],
     "ConnectParticipantWithLexBot": ["NoMatchingError", "NoMatchingCondition"],
     "InvokeLambdaFunction": ["NoMatchingError"],

--- a/backend/ecs/src/tools/asset_linters.py
+++ b/backend/ecs/src/tools/asset_linters.py
@@ -514,6 +514,7 @@ VALID_CONTACT_FLOW_ACTION_TYPES = frozenset({
     "AuthenticateParticipant", "ShowView", "ResumeContact",
     # Transfer / terminate
     "TransferContactToQueue", "TransferParticipantToThirdParty", "TransferToFlow",
+    "DequeueContactAndTransferToQueue",
     "DisconnectParticipant", "EndFlowExecution",
 })
 
@@ -595,12 +596,27 @@ REQUIRED_ERRORS_BY_TYPE = {
     "CreateWisdomSession": ["NoMatchingError"],
     "UpdateContactData": ["NoMatchingError"],
     "TransferContactToQueue": ["QueueAtCapacity", "NoMatchingError"],
+    "DequeueContactAndTransferToQueue": ["QueueAtCapacity", "NoMatchingError"],
     "UpdateContactTargetQueue": ["NoMatchingError"],
     "UpdateContactAttributes": ["NoMatchingError"],   # API-verified: required
     "CheckHoursOfOperation": ["NoMatchingError"],     # branches via True/False Conditions; needs NoMatchingError
     # API-verified (2026-06-18): UpdateContactCallbackNumber requires BOTH of these
     # and rejects NoMatchingError / InvalidNumber / NotDialable.
     "UpdateContactCallbackNumber": ["InvalidCallbackNumber", "CallbackNumberNotDialable"],
+    # API-verified (2026-07-03) exhaustive per-parameter probe of the 10 blocks that
+    # the RAG sweep never exercised. Each block imports only with these error branches.
+    "AuthenticateParticipant": ["NoMatchingError", "TimeLimitExceeded"],
+    "CheckOutboundCallStatus": ["NoMatchingError"],
+    "CreatePersistentContactAssociation": ["NoMatchingError"],
+    "DistributeByPercentage": ["NoMatchingCondition"],
+    "EvaluateDataTableValues": ["NoMatchingError"],
+    "GetCustomerProfileObject": ["NoMatchingError", "NoneFoundError"],
+    "LoadContactContent": ["NoMatchingError"],
+    "UpdateContactRoutingCriteria": ["NoMatchingError"],
+    # NOTE: UpdateContactRoutingBehavior has CONDITIONAL errors — NoMatchingError is
+    # required ONLY for the RoutingProficiencies variant and MUST be absent for the
+    # QueuePriority / QueueTimeAdjustmentSeconds variants. Left out of this static map
+    # on purpose; enforcing a fixed set here would break the priority variant.
 }
 
 # Error types that are NOT valid for a given block — strip them on import.
@@ -752,9 +768,11 @@ def _normalize_contact_flow_params(actions: list, ids_to_first: dict, fixes: lis
             if "RequestAttributes" in p:
                 p.setdefault("LambdaInvocationAttributes", p.pop("RequestAttributes"))
                 fixes.append(f"[{aid}] InvokeLambdaFunction: RequestAttributes → LambdaInvocationAttributes")
-            # ResponseValidation.ResponseType must be STRING_MAP (JSON is not accepted)
+            # ResponseValidation.ResponseType must be STRING_MAP or JSON (API-verified
+            # 2026-07-03: both import; JSON_OBJECT is REJECTED with "Invalid Action
+            # property value"). ResponseValidation itself is optional.
             rv = p.get("ResponseValidation")
-            if isinstance(rv, dict) and rv.get("ResponseType") not in ("STRING_MAP", "JSON_OBJECT"):
+            if isinstance(rv, dict) and rv.get("ResponseType") not in ("STRING_MAP", "JSON"):
                 rv["ResponseType"] = "STRING_MAP"
                 fixes.append(f"[{aid}] InvokeLambdaFunction: ResponseValidation.ResponseType → STRING_MAP")
 
@@ -844,14 +862,30 @@ def _normalize_contact_flow_params(actions: list, ids_to_first: dict, fixes: lis
         #     InputTimeLimitExceeded + NoMatchingError.
         #   STORE mode (captures input to an attribute): StoreInput=True,
         #     requires InputValidation.CustomValidation.MaximumLength, optional
-        #     DTMFConfiguration{DisableCancelKey} (NEVER InputTerminationSequence),
+        #     DTMFConfiguration{DisableCancelKey, InputTerminationSequence},
         #     errors = NoMatchingError only.
+        # Both modes REQUIRE InputTimeLimitSeconds (string) at the Parameters root.
+        # DisableCancelKey MUST be a string "True"/"False" — a JSON boolean makes the
+        # whole block fail import with a MISLEADING "Invalid Action type" error.
         # (Both verified against CreateContactFlow; the empty/guessed forms the
         #  model emits otherwise fail import with misleading "Invalid Action type".)
         if t == "GetParticipantInput":
             tr_gp = a.get("Transitions") or a.get("transitions") or {}
             conds_gp = tr_gp.get("Conditions") or tr_gp.get("conditions") or []
             is_menu = bool(conds_gp)
+            # DisableCancelKey must be a string, never a JSON boolean (bool → misleading
+            # "Invalid Action type" on import).
+            _dtmf = p.get("DTMFConfiguration")
+            if isinstance(_dtmf, dict) and isinstance(_dtmf.get("DisableCancelKey"), bool):
+                _dtmf["DisableCancelKey"] = "True" if _dtmf["DisableCancelKey"] else "False"
+                fixes.append(f"[{aid}] GetParticipantInput: DisableCancelKey boolean → string")
+            # Both modes require InputTimeLimitSeconds (string) at the Parameters root.
+            # A value mistakenly nested in DTMFConfiguration is re-homed by the store-mode
+            # normalizer below; only inject a default when it exists in neither place.
+            _nested_itl = isinstance(_dtmf, dict) and "InputTimeLimitSeconds" in _dtmf
+            if "InputTimeLimitSeconds" not in p and not _nested_itl:
+                p["InputTimeLimitSeconds"] = "5"
+                fixes.append(f"[{aid}] GetParticipantInput: added required InputTimeLimitSeconds")
             if is_menu:
                 if str(p.get("StoreInput")) != "False":
                     p["StoreInput"] = "False"
@@ -864,13 +898,14 @@ def _normalize_contact_flow_params(actions: list, ids_to_first: dict, fixes: lis
                 if str(p.get("StoreInput")) != "True":
                     p["StoreInput"] = "True"
                     fixes.append(f"[{aid}] GetParticipantInput(store): StoreInput=True")
-                # DTMFConfiguration in store mode accepts ONLY DisableCancelKey.
-                # Any other key (InputTerminationSequence, InputTimeLimitSeconds,
-                # FinishKey, ...) is rejected — InputTimeLimitSeconds belongs at the
-                # Parameters root, not inside DTMFConfiguration.
+                # DTMFConfiguration in store mode accepts DisableCancelKey and
+                # InputTerminationSequence (API-verified 2026-07-03 — the terminator
+                # key imports fine). InputTimeLimitSeconds belongs at the Parameters
+                # root, not inside DTMFConfiguration; any other key is rejected.
                 dtmf = p.get("DTMFConfiguration")
                 if isinstance(dtmf, dict):
-                    bad = [k for k in list(dtmf.keys()) if k != "DisableCancelKey"]
+                    allowed = {"DisableCancelKey", "InputTerminationSequence"}
+                    bad = [k for k in list(dtmf.keys()) if k not in allowed]
                     if bad:
                         # InputTimeLimitSeconds is a real top-level param — re-home it.
                         if "InputTimeLimitSeconds" in dtmf and "InputTimeLimitSeconds" not in p:

--- a/knowledge-base-docs/contact-flow/_VERIFIED-block-type-reference.md
+++ b/knowledge-base-docs/contact-flow/_VERIFIED-block-type-reference.md
@@ -15,7 +15,7 @@ or `CheckStaffing` FAIL import with `InvalidContactFlowException: Invalid Action
 |---|---|
 | Get customer input / Store customer input | `GetParticipantInput` |
 | Play prompt / Send message | `MessageParticipant` |
-| Message (templated) | `RenderMessageTemplate` |
+| Render message template (Q in Connect / Wisdom) | `RenderMessageTemplate` |
 | Connect assistant (Q in Connect) | `CreateWisdomSession` |
 | Set callback number | `UpdateContactCallbackNumber` |
 | Set contact attributes | `UpdateContactAttributes` |
@@ -80,22 +80,33 @@ or `CheckStaffing` FAIL import with `InvalidContactFlowException: Invalid Action
 | `CheckCondition` / `CheckValue` | `Compare` |
 
 ### Key per-block schema gotchas (API-verified)
-- **GetParticipantInput** has TWO modes:
-  - *Menu* (branches via Conditions): `StoreInput:"False"`, NO `DTMFConfiguration`;
+- **GetParticipantInput** has TWO modes. BOTH modes require `InputTimeLimitSeconds`
+  (omitting it fails: `Action is missing required property ... Parameters.InputTimeLimitSeconds`).
+  - *Menu* (branches via Conditions): `StoreInput:"False"`, `InputTimeLimitSeconds`,
+    NO `DTMFConfiguration`;
     errors = `NoMatchingCondition` + `InputTimeLimitExceeded` + `NoMatchingError`.
-  - *Store* (captures to attribute): `StoreInput:"True"`, requires
+  - *Store* (captures to attribute): `StoreInput:"True"`, `InputTimeLimitSeconds`, requires
     `InputValidation.CustomValidation.MaximumLength`, optional
     `DTMFConfiguration.DisableCancelKey` (NEVER `InputTerminationSequence`);
     error = `NoMatchingError`.
-- **Loop**: Conditions operands are `ContinueLooping` / `DoneLooping` (NOT Looping/Complete).
+- **Loop**: Conditions operands are `ContinueLooping` / `DoneLooping` (NOT Looping/Complete),
+  AND the block also requires a `Transitions.NextAction` in addition to those two Conditions
+  (omitting it fails: `Action is missing required property ... Transitions.NextAction`).
 - **TransferContactToQueue**: NO `QueueId` param (queue is set by a prior
   `UpdateContactTargetQueue`); errors `QueueAtCapacity` + `NoMatchingError`.
 - **UpdateContactAttributes**: requires `NoMatchingError`.
-- **UpdateContactCallbackNumber**: only `NoMatchingError` (NOT InvalidNumber/NotDialable).
+- **UpdateContactCallbackNumber**: requires errors `InvalidCallbackNumber` + `CallbackNumberNotDialable`;
+  `NoMatchingError` is NOT allowed. `CallbackNumber` must be a valid E.164 number or a
+  JSONPath (e.g. `$.CustomerEndpoint.Address`) — a bare literal like `+15551234567` was
+  rejected as an invalid property value on the verified instance.
 - **Compare**: only `NoMatchingCondition` error; `ComparisonValue` must use a real
   JSONPath root (`$.Attributes.*`, `$.Channel`, `$.Lex.SessionAttributes.*`, etc.).
 - **DisconnectParticipant** / **EndFlowExecution**: terminal — NO Transitions.
 - **CreateWisdomSession**: `WisdomAssistantArn` must be a real existing assistant ARN.
+- **RenderMessageTemplate**: this is the Q in Connect / Wisdom message-template render block,
+  NOT a generic templated message. Requires `WisdomKnowledgeBaseArn` + `WisdomMessageTemplateArn`
+  (generic `Template` / `AttributeMap` params are rejected as invalid property names) and errors
+  `TemplateRenderingError` + `NoMatchingError`.
 
 ---
 **Metadata**

--- a/knowledge-base-docs/contact-flow/_reference-console-export-all-blocks.json
+++ b/knowledge-base-docs/contact-flow/_reference-console-export-all-blocks.json
@@ -2,6 +2,19 @@
   "Version": "2019-10-30",
   "StartAction": "",
   "Metadata": {
+    "_comment": "DESIGN-TIME CONSOLE EXPORT / REFERENCE ONLY - NOT DIRECTLY IMPORTABLE. This file is a saved-flow export from the Amazon Connect console that catalogs one instance of nearly every block Type. It is a placeholder: StartAction and every Transitions.NextAction / Errors[].NextAction are empty strings (\"\"), and many Parameters are empty. Re-verified against CreateContactFlow: importing it verbatim fails with InvalidContactFlowException and 51+ 'Invalid Action property value. Path: Actions[N].Transitions.NextAction' problems. To reuse a block from here you MUST wire NextAction/Error/Condition targets to real Identifiers, set StartAction, and fill required Parameters. Use this as a Type/parameter-shape catalog, not a copy-paste-ready flow.",
+    "_verifiedBlockNotes": {
+      "UpdateContactEventHooks": "The console emits EventHooks:{} (empty), but CreateContactFlow REJECTS an empty EventHooks map ('Invalid contact flow format' / 'Invalid request'). At least one hook key (CustomerQueue, CustomerRemaining, AgentHold, or AgentWhisper) is required, and its value must be non-empty (a key present with an empty-string value, e.g. {\"AgentWhisper\":\"\"}, is rejected with 'Action is missing required property. Path: ...Parameters.EventHooks.AgentWhisper').",
+      "CheckMetricData": "REQUIRES Transitions.Conditions (at least one condition branch). The condition-less variant in this export (identifier 1e8c881b, MetricType OldestContactInQueueAgeSeconds) is NOT importable; the variant with a Conditions branch (identifier c9e42ae9, MetricType NumberOfAgentsAvailable) imports. Valid MetricType values include NumberOfAgentsAvailable, NumberOfContactsInQueue, OldestContactInQueueAgeSeconds. Does NOT accept a Parameters.Queue key.",
+      "ShowView": "This export contains InvocationTimeLimitSeconds:\"undefined\" (a JS serialization artifact) which CreateContactFlow REJECTS. Supply a numeric-string timeout (e.g. \"30\") and a valid ViewResource.Id. Do not copy the literal string 'undefined'.",
+      "Compare": "Requires BOTH a non-empty ComparisonValue AND at least one Evaluate condition branch. The empty ComparisonValue with no conditions shown here is a design-time placeholder, not importable.",
+      "StartOutboundEmailContact": "Requires BOTH FromEmailAddress.EmailAddress AND DestinationEmailAddress. The export omits DestinationEmailAddress, so this shape alone is incomplete for import.",
+      "CreateTask": "Requires ContactFlowId and a task name (surfaces as ContactName in API errors). The ContactFlowId must be a real contact-flow ARN.",
+      "UpdatePreviousContactParticipantState": "Requires a PreviousContactParticipantState value from a specific accepted enum; the export leaves it empty so no valid value is demonstrated here.",
+      "CreateCase": "Does NOT take a Parameters.Fields property (the export correctly omits it). Do not add a Fields array.",
+      "GetParticipantInput": "Prompt-playing variants (MENU/STORE, e.g. identifiers 652c3102, cc16283d) require one of PromptId/Text/SSML/Media; the EnableDTMFBuffer=True variant (identifier bba6809b) does not require a prompt.",
+      "UpdateContactData": "Fully valid, importable Type (verified) with Parameters such as WisdomSessionArn."
+    },
     "entryPointPosition": {
       "x": 40,
       "y": 40

--- a/knowledge-base-docs/contact-flow/best-practices/error-handling.md
+++ b/knowledge-base-docs/contact-flow/best-practices/error-handling.md
@@ -13,30 +13,28 @@ Proper error handling ensures customers aren't left stranded when issues occur. 
 |------------|-----------------|
 | MessageParticipant | NoMatchingError (optional but recommended) |
 | UpdateContactAttributes | NoMatchingError |
-| UpdateContactTextToSpeechVoice | NoMatchingError |
-| UpdateContactRecordingBehavior | (Success only) |
-| UpdateFlowLoggingBehavior | (Success only) |
+| UpdateContactTextToSpeechVoice | (NoMatchingError optional — imports with or without it) |
+| UpdateContactRecordingBehavior | (Success only — NoMatchingError forbidden; requires a `RecordingBehavior` object parameter) |
+| UpdateFlowLoggingBehavior | (Success only — NoMatchingError forbidden) |
 | UpdateContactTargetQueue | NoMatchingError |
 | InvokeLambdaFunction | NoMatchingError |
-| Wait | NoMatchingError |
+| Wait | NoMatchingError (also requires a `Transitions.Conditions` branch and a `NextAction` — see below) |
 
 ### Blocks with Multiple Error Types
 | Block Type | Required Errors |
 |------------|-----------------|
 | TransferContactToQueue | QueueAtCapacity, NoMatchingError |
 | Compare | NoMatchingCondition |
-| CheckContactAttributes | NoMatchingCondition |
-| CheckStaffing | NoMatchingError (+ True/False conditions) |
 | CheckHoursOfOperation | NoMatchingError (+ True/False conditions) |
-| GetParticipantInput | InputTimeLimitExceeded, NoMatchingCondition, NoMatchingError |
-| UpdateContactCallbackNumber | InvalidNumber, NotDialable, NoMatchingError |
+| GetParticipantInput | InputTimeLimitExceeded, NoMatchingCondition, NoMatchingError (all three required; also needs `InputTimeLimitSeconds` and, in a MENU/`StoreInput: False` pattern, no `DTMFConfiguration`) |
+| UpdateContactCallbackNumber | InvalidCallbackNumber, CallbackNumberNotDialable |
 | GetCustomerProfile | MultipleFoundError, NoneFoundError, NoMatchingError |
 
 ### Terminal Blocks (No Errors)
 | Block Type | Notes |
 |------------|-------|
-| DisconnectParticipant | Parameters: {}, Transitions: {} |
-| EndFlowModuleExecution | Parameters: {}, Transitions: {} |
+| DisconnectParticipant | Parameters: {}, Transitions: {} — the terminal block for standard Contact Flows |
+| EndFlowModuleExecution | Parameters: {}, Transitions: {} — **module-only**: valid only inside a Contact Flow Module (flow type `contactFlowModule`), rejected in a standard Contact Flow |
 
 ## Error Handling Patterns
 
@@ -81,17 +79,19 @@ Handle errors contextually to continue the flow:
 ### Pattern 3: Retry with Loop
 Use Loop block for retryable errors:
 
+The Loop block requires a `NextAction` in its `Transitions` in addition to the `ContinueLooping` / `DoneLooping` conditions:
+
 ```json
 {
   "Identifier": "retry-loop",
   "Type": "Loop",
   "Parameters": {"LoopCount": "3"},
   "Transitions": {
+    "NextAction": "max-retries",
     "Conditions": [
       {"Condition": {"Operator": "Equals", "Operands": ["ContinueLooping"]}, "NextAction": "retry-action"},
       {"Condition": {"Operator": "Equals", "Operands": ["DoneLooping"]}, "NextAction": "max-retries"}
-    ],
-    "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]
+    ]
   }
 }
 ```
@@ -123,7 +123,7 @@ CORRECT:
 ```
 
 ### Mistake 2: Missing Required Error Types
-WRONG (UpdateContactCallbackNumber):
+WRONG (UpdateContactCallbackNumber — `NoMatchingError` is not a valid error type on this block, and both required errors are missing):
 ```json
 {
   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error"}]
@@ -134,9 +134,8 @@ CORRECT:
 ```json
 {
   "Errors": [
-    {"ErrorType": "InvalidNumber", "NextAction": "invalid"},
-    {"ErrorType": "NotDialable", "NextAction": "invalid"},
-    {"ErrorType": "NoMatchingError", "NextAction": "error"}
+    {"ErrorType": "InvalidCallbackNumber", "NextAction": "invalid"},
+    {"ErrorType": "CallbackNumberNotDialable", "NextAction": "invalid"}
   ]
 }
 ```
@@ -203,4 +202,4 @@ Before deploying a Contact Flow, verify:
 ---
 **Metadata**
 - Category: Best Practices
-- Keywords: error handling, NoMatchingError, NoMatchingCondition, best practices
+- Keywords: error handling, NoMatchingError, NoMatchingCondition, InvalidCallbackNumber, CallbackNumberNotDialable, best practices

--- a/knowledge-base-docs/contact-flow/blocks/branch/check-hours-of-operation.md
+++ b/knowledge-base-docs/contact-flow/blocks/branch/check-hours-of-operation.md
@@ -15,6 +15,7 @@ The CheckHoursOfOperation block checks if the current time is within defined bus
     "HoursOfOperationId": "{{HOURS_ARN}}"
   },
   "Transitions": {
+    "NextAction": "in-hours",
     "Conditions": [
       {"Condition": {"Operator": "Equals", "Operands": ["True"]}, "NextAction": "in-hours"},
       {"Condition": {"Operator": "Equals", "Operands": ["False"]}, "NextAction": "out-of-hours"}
@@ -39,10 +40,11 @@ The CheckHoursOfOperation block checks if the current time is within defined bus
 - **NoMatchingError**: Unable to check hours (invalid ARN, permissions)
 
 ### CRITICAL Requirements
-1. MUST have `Conditions` for both "True" and "False"
-2. MUST have `Errors` with `NoMatchingError`
-3. Condition values are strings: `"True"` and `"False"` (not booleans)
-4. HoursOfOperationId must be an ARN, not a name
+1. MUST have a top-level `NextAction` in `Transitions` (the default branch) — without it import fails with `Action is missing required property. Path: Actions[0].Transitions.NextAction`
+2. MUST have `Conditions` for both "True" and "False"
+3. MUST have `Errors` with `NoMatchingError` (`NoMatchingCondition` is explicitly rejected on this block)
+4. Condition values are strings: `"True"` and `"False"` (not booleans)
+5. HoursOfOperationId must be an ARN, not a name — a non-ARN value (e.g. `"Basic Hours"`) is rejected by the service with `Not a supported id format`
 
 ### Valid HoursOfOperationId Formats
 ```
@@ -58,6 +60,7 @@ arn:aws:connect:us-east-1:123456789012:instance/xxx/operating-hours/yyy
 {"Identifier": "check-hours", "Type": "CheckHoursOfOperation",
  "Parameters": {"HoursOfOperationId": "{{HOURS_ARN}}"},
  "Transitions": {
+   "NextAction": "in-hours-flow",
    "Conditions": [
      {"Condition": {"Operator": "Equals", "Operands": ["True"]}, "NextAction": "in-hours-flow"},
      {"Condition": {"Operator": "Equals", "Operands": ["False"]}, "NextAction": "closed-message"}
@@ -73,11 +76,8 @@ arn:aws:connect:us-east-1:123456789012:instance/xxx/operating-hours/yyy
 {"Identifier": "offer-callback", "Type": "GetParticipantInput",
  "Parameters": {
    "Text": "Press 1 to leave a message or press 2 to receive a callback when we open.",
-   "InputTimeLimitSeconds": "5",
-   "DTMFConfiguration": {
-     "InputTerminationSequence": "#",
-     "DisableCancelKey": false
-   }
+   "StoreInput": "False",
+   "InputTimeLimitSeconds": "5"
  },
  "Transitions": {"NextAction": "disconnect",
    "Conditions": [
@@ -85,8 +85,8 @@ arn:aws:connect:us-east-1:123456789012:instance/xxx/operating-hours/yyy
      {"Condition": {"Operator": "Equals", "Operands": ["2"]}, "NextAction": "schedule-callback"}
    ],
    "Errors": [
-     {"ErrorType": "InputTimeLimitExceeded", "NextAction": "disconnect"},
      {"ErrorType": "NoMatchingCondition", "NextAction": "disconnect"},
+     {"ErrorType": "InputTimeLimitExceeded", "NextAction": "disconnect"},
      {"ErrorType": "NoMatchingError", "NextAction": "disconnect"}
    ]
  }}
@@ -103,6 +103,7 @@ If you omit the HoursOfOperationId, it uses the hours configured on the working 
 {"Identifier": "check-queue-hours", "Type": "CheckHoursOfOperation",
  "Parameters": {},
  "Transitions": {
+   "NextAction": "transfer",
    "Conditions": [
      {"Condition": {"Operator": "Equals", "Operands": ["True"]}, "NextAction": "transfer"},
      {"Condition": {"Operator": "Equals", "Operands": ["False"]}, "NextAction": "closed"}

--- a/knowledge-base-docs/contact-flow/blocks/branch/check-staffing.md
+++ b/knowledge-base-docs/contact-flow/blocks/branch/check-staffing.md
@@ -8,9 +8,11 @@
 How do I check agent availability / queue metrics in Amazon Connect Contact Flow?
 
 ## Answer
-Use **`CheckMetricData`**: it reads a real-time metric (`MetricType`) for the
-working queue and branches via `Conditions`. Use before `TransferContactToQueue`
-to handle the no-agents case.
+Use **`CheckMetricData`**: it reads a real-time numeric metric (`MetricType`) for
+the working queue and branches via `Conditions` using **numeric** operators
+(`NumberGreaterThan`, `NumberGreaterOrEqualTo`, etc.). Use before
+`TransferContactToQueue` to handle the no-agents case — check
+`NumberOfAgentsAvailable > 0`.
 
 ### JSON Structure (API-verified)
 ```json
@@ -18,10 +20,10 @@ to handle the no-agents case.
   "Identifier": "check-staffing",
   "Type": "CheckMetricData",
   "Parameters": {
-    "MetricType": "AgentsAvailable"
+    "MetricType": "NumberOfAgentsAvailable"
   },
   "Transitions": {
-    "NextAction": "agents-available",
+    "NextAction": "no-agents",
     "Conditions": [
       {"Condition": {"Operator": "NumberGreaterThan", "Operands": ["0"]}, "NextAction": "agents-available"}
     ],
@@ -33,30 +35,45 @@ to handle the no-agents case.
 }
 ```
 
-Real `MetricType` values: `AgentsAvailable`, `OldestContactInQueueAgeSeconds`,
-`ContactsInQueue`. Required errors: `NoMatchingCondition` + `NoMatchingError`.
+Real `MetricType` values (API-verified 2026-07-03, case-sensitive — exactly these five):
+`NumberOfAgentsAvailable`, `NumberOfContactsInQueue`, `OldestContactInQueueAgeSeconds`,
+`NumberOfAgentsStaffed`, `NumberOfAgentsOnline`. The shorthand `AgentsAvailable` /
+`ContactsInQueue` are REJECTED. Required errors: `NoMatchingCondition` + `NoMatchingError`.
 
 ### Required Parameters
-None - uses the working queue set by UpdateContactTargetQueue
+`MetricType` — one of `NumberOfAgentsAvailable`, `NumberOfContactsInQueue`,
+`OldestContactInQueueAgeSeconds`, `NumberOfAgentsStaffed`, `NumberOfAgentsOnline`.
+(Omitting it fails import with "Action is missing
+required property. Path: Actions[N].Parameters.MetricType".) The metric is read
+for the working queue set by `UpdateContactTargetQueue`.
 
 ### Condition Values
-- **True**: At least one agent is available in the queue
-- **False**: No agents are available (all busy, offline, or not staffed)
+`CheckMetricData` returns a **numeric** metric value, not a True/False binary.
+Branch on it with numeric operators, e.g. for `NumberOfAgentsAvailable`:
+- **`NumberGreaterThan` `["0"]`**: At least one agent is available in the queue
+- **`NoMatchingCondition`**: No condition matched (e.g. zero agents available)
 
 ### Error Types
-- **NoMatchingError**: Unable to check staffing (no working queue set, permissions issue)
+- **NoMatchingCondition**: No `Conditions` entry matched the returned metric value
+- **NoMatchingError**: Unable to read the metric (no working queue set, permissions issue)
+
+Both `NoMatchingCondition` and `NoMatchingError` are **required** — omitting either
+fails import ("missing required error"). `QueueAtCapacity` is **not** a valid error
+for this block.
 
 ### CRITICAL Requirements
-1. MUST call `UpdateContactTargetQueue` before using CheckStaffing
-2. MUST have `Conditions` array with both "True" and "False" conditions
-3. MUST have `Errors` array with `NoMatchingError`
-4. Condition values are strings: `"True"` and `"False"` (not booleans)
+1. MUST call `UpdateContactTargetQueue` before using CheckMetricData
+2. MUST supply a valid `MetricType` parameter
+3. MUST have an `Errors` array with **both** `NoMatchingCondition` and `NoMatchingError`
+4. `Conditions` use numeric operators against the metric value (operands are strings, e.g. `"0"`)
 
 ### WRONG vs CORRECT
 
-#### WRONG (Missing conditions, using booleans)
+#### WRONG (invalid metric name, no numeric condition, missing required errors)
 ```json
 {
+  "Type": "CheckMetricData",
+  "Parameters": {"MetricType": "AgentsAvailable"},
   "Transitions": {
     "NextAction": "transfer-queue",
     "Conditions": [
@@ -69,12 +86,15 @@ None - uses the working queue set by UpdateContactTargetQueue
 #### CORRECT
 ```json
 {
+  "Type": "CheckMetricData",
+  "Parameters": {"MetricType": "NumberOfAgentsAvailable"},
   "Transitions": {
+    "NextAction": "no-agents",
     "Conditions": [
-      {"Condition": {"Operator": "Equals", "Operands": ["True"]}, "NextAction": "agents-available"},
-      {"Condition": {"Operator": "Equals", "Operands": ["False"]}, "NextAction": "no-agents"}
+      {"Condition": {"Operator": "NumberGreaterThan", "Operands": ["0"]}, "NextAction": "agents-available"}
     ],
     "Errors": [
+      {"ErrorType": "NoMatchingCondition", "NextAction": "no-agents"},
       {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
     ]
   }
@@ -88,21 +108,24 @@ None - uses the working queue set by UpdateContactTargetQueue
  "Transitions": {"NextAction": "check-staffing",
    "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]}}
 
-{"Identifier": "check-staffing", "Type": "CheckStaffing",
- "Parameters": {},
+{"Identifier": "check-staffing", "Type": "CheckMetricData",
+ "Parameters": {"MetricType": "NumberOfAgentsAvailable"},
  "Transitions": {
+   "NextAction": "no-agents-message",
    "Conditions": [
-     {"Condition": {"Operator": "Equals", "Operands": ["True"]}, "NextAction": "transfer-queue"},
-     {"Condition": {"Operator": "Equals", "Operands": ["False"]}, "NextAction": "no-agents-message"}
+     {"Condition": {"Operator": "NumberGreaterThan", "Operands": ["0"]}, "NextAction": "transfer-queue"}
    ],
-   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]
+   "Errors": [
+     {"ErrorType": "NoMatchingCondition", "NextAction": "no-agents-message"},
+     {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
+   ]
  }}
 
 {"Identifier": "transfer-queue", "Type": "TransferContactToQueue",
  "Parameters": {},
  "Transitions": {"NextAction": "disconnect",
    "Errors": [
-     {"ErrorType": "QueueAtCapacity", "NextAction": "queue-full"},
+     {"ErrorType": "QueueAtCapacity", "NextAction": "no-agents-message"},
      {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
    ]}}
 
@@ -112,17 +135,17 @@ None - uses the working queue set by UpdateContactTargetQueue
    "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "offer-callback"}]}}
 ```
 
-### CheckStaffing vs GetQueueMetrics
-| Feature | CheckStaffing | GetQueueMetrics |
-|---------|---------------|-----------------|
-| Purpose | Binary check (available/not) | Detailed metrics |
+### CheckMetricData vs GetQueueMetrics
+| Feature | CheckMetricData | GetQueueMetrics |
+|---------|-----------------|-----------------|
+| Purpose | Read one real-time metric and branch on it | Detailed metrics |
 | Speed | Faster | Slower |
-| Output | True/False condition | Multiple metric values |
-| Use Case | Simple routing | Complex routing decisions |
+| Output | Single numeric metric value | Multiple metric values |
+| Use Case | Simple routing (e.g. agents available > 0) | Complex routing decisions |
 
 ### When to Use
-- **CheckStaffing**: Simple "are agents available?" check
-- **GetQueueMetrics**: Need queue size, wait times, or other details
+- **CheckMetricData**: Simple "are agents available?" / "queue too deep?" check on one metric
+- **GetQueueMetrics**: Need queue size, wait times, or other details together
 
 ## Related Topics
 - UpdateContactTargetQueue
@@ -133,5 +156,5 @@ None - uses the working queue set by UpdateContactTargetQueue
 ---
 **Metadata**
 - Category: Branch
-- BlockType: CheckStaffing
-- Keywords: staffing, agents, availability, queue, True, False
+- BlockType: CheckMetricData
+- Keywords: staffing, agents, availability, queue, metric, NumberOfAgentsAvailable, NumberOfContactsInQueue, OldestContactInQueueAgeSeconds

--- a/knowledge-base-docs/contact-flow/blocks/branch/compare.md
+++ b/knowledge-base-docs/contact-flow/blocks/branch/compare.md
@@ -36,15 +36,19 @@ The Compare block evaluates a contact attribute value against conditions. It's u
 ### Comparison Operators
 | Operator | Description | Example |
 |----------|-------------|---------|
-| Equals | Exact string match | `{"Operator": "Equals", "Operands": ["VALUE"]}` |
-| Contains | String contains | `{"Operator": "Contains", "Operands": ["substring"]}` |
-| StartsWith | String starts with | `{"Operator": "StartsWith", "Operands": ["prefix"]}` |
-| EndsWith | String ends with | `{"Operator": "EndsWith", "Operands": ["suffix"]}` |
-| NumberEquals | Numeric equality | `{"Operator": "NumberEquals", "Operands": ["5"]}` |
+| Equals | Exact string match (also used for numeric equality) | `{"Operator": "Equals", "Operands": ["VALUE"]}` |
+| TextContains | String contains | `{"Operator": "TextContains", "Operands": ["substring"]}` |
+| TextStartsWith | String starts with | `{"Operator": "TextStartsWith", "Operands": ["prefix"]}` |
+| TextEndsWith | String ends with | `{"Operator": "TextEndsWith", "Operands": ["suffix"]}` |
 | NumberGreaterThan | Numeric > | `{"Operator": "NumberGreaterThan", "Operands": ["10"]}` |
 | NumberLessThan | Numeric < | `{"Operator": "NumberLessThan", "Operands": ["100"]}` |
 | NumberGreaterOrEqualTo | Numeric >= | `{"Operator": "NumberGreaterOrEqualTo", "Operands": ["0"]}` |
-| NumberLessThanOrEqualTo | Numeric <= | `{"Operator": "NumberLessThanOrEqualTo", "Operands": ["99"]}` |
+| NumberLessOrEqualTo | Numeric <= | `{"Operator": "NumberLessOrEqualTo", "Operands": ["99"]}` |
+
+> **Note:** There is no `NumberEquals` operator. Use plain `Equals` for numeric
+> equality (e.g. `{"Operator": "Equals", "Operands": ["5"]}`). Also note the
+> asymmetry: the `>=` operator is `NumberGreaterOrEqualTo` and the `<=` operator
+> is `NumberLessOrEqualTo` (both drop the "Than").
 
 ### Error Types
 - **NoMatchingCondition**: No condition matched the value
@@ -52,8 +56,8 @@ The Compare block evaluates a contact attribute value against conditions. It's u
 ### CRITICAL Requirements
 1. MUST have `Errors` array with `NoMatchingCondition`
 2. `NextAction` in Transitions is the default fallback (also handles NoMatchingCondition)
-3. Operands are always arrays: `["VALUE"]` not `"VALUE"`
-4. Numbers are passed as strings: `["10"]` not `[10]`
+3. Operands are always arrays: `["VALUE"]` not `"VALUE"` (a bare string is rejected)
+4. Pass numbers as strings: `["10"]` (recommended). A bare int `[10]` also passes structural validation, but the quoted-string form is the safe convention for runtime.
 
 ### Common JSONPath Values
 | Source | JSONPath | Description |
@@ -63,15 +67,21 @@ The Compare block evaluates a contact attribute value against conditions. It's u
 | Lex Slots | $.Lex.Slots.{slotName} | Slot value |
 | Lambda | $.External.{key} | Lambda response |
 | Custom | $.Attributes.{name} | Custom contact attribute |
-| Queue Metrics | $.Metrics.Queue.Size | Contacts in queue |
 | Channel | $.Channel | VOICE, CHAT, or TASK |
+
+> **Queue metrics:** To branch on queue depth or agent availability, use the
+> `CheckMetricData` block (it branches on the metric value directly) rather than a
+> Compare on a `$.Metrics.*` path. See the Queue Size Check pattern below.
 
 ### Pattern: Lex Bot Result Routing
 ```json
 {"Identifier": "lex-bot", "Type": "ConnectParticipantWithLexBot",
  "Parameters": {"Text": "Welcome", "LexV2Bot": {"AliasArn": "{{LEX_BOT_ALIAS_ARN}}"}},
  "Transitions": {"NextAction": "check-result",
-   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]}}
+   "Errors": [
+     {"ErrorType": "NoMatchingCondition", "NextAction": "error-handler"},
+     {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
+   ]}}
 
 {"Identifier": "check-result", "Type": "Compare",
  "Parameters": {"ComparisonValue": "$.Lex.SessionAttributes.toolResult"},
@@ -96,24 +106,34 @@ The Compare block evaluates a contact attribute value against conditions. It's u
 ```
 
 ### Pattern: Queue Size Check
+There is **no** `GetQueueMetrics` block type (it fails import with "Invalid Action
+type"). To branch on queue depth, use **`CheckMetricData`** — it reads one
+real-time metric (`MetricType`) for the working queue and branches on the value
+itself via `Conditions`. There is no need for a separate Compare block on
+`$.Metrics.Queue.Size`. Set the working queue with `UpdateContactTargetQueue`
+first, and use `MetricType: NumberOfContactsInQueue`.
+
 ```json
-{"Identifier": "get-metrics", "Type": "GetQueueMetrics",
+{"Identifier": "set-queue", "Type": "UpdateContactTargetQueue",
  "Parameters": {"QueueId": "{{QUEUE_ARN}}"},
  "Transitions": {"NextAction": "check-queue-size",
    "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]}}
 
-{"Identifier": "check-queue-size", "Type": "Compare",
- "Parameters": {"ComparisonValue": "$.Metrics.Queue.Size"},
+{"Identifier": "check-queue-size", "Type": "CheckMetricData",
+ "Parameters": {"MetricType": "NumberOfContactsInQueue"},
  "Transitions": {"NextAction": "queue-busy",
    "Conditions": [
      {"Condition": {"Operator": "NumberLessThan", "Operands": ["5"]}, "NextAction": "transfer-queue"}
    ],
-   "Errors": [{"ErrorType": "NoMatchingCondition", "NextAction": "queue-busy"}]}}
+   "Errors": [
+     {"ErrorType": "NoMatchingCondition", "NextAction": "queue-busy"},
+     {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
+   ]}}
 ```
 
 ## Related Topics
 - CheckContactAttributes (alternative for attribute checks)
-- GetQueueMetrics
+- CheckMetricData (queue/staffing metrics — the real block; no `GetQueueMetrics` type exists)
 - ConnectParticipantWithLexBot
 - InvokeLambdaFunction
 
@@ -121,4 +141,4 @@ The Compare block evaluates a contact attribute value against conditions. It's u
 **Metadata**
 - Category: Branch
 - BlockType: Compare
-- Keywords: compare, condition, routing, Equals, NumberLessThan, NoMatchingCondition
+- Keywords: compare, condition, routing, Equals, TextContains, TextStartsWith, TextEndsWith, NumberLessOrEqualTo, NumberGreaterOrEqualTo, NumberLessThan, NoMatchingCondition

--- a/knowledge-base-docs/contact-flow/blocks/control/disconnect-participant.md
+++ b/knowledge-base-docs/contact-flow/blocks/control/disconnect-participant.md
@@ -79,12 +79,17 @@ None - Transitions MUST be empty `{}` (terminal block)
 ```
 
 ### Terminal Blocks in Amazon Connect
-Only these block types can be terminal (no Transitions):
+Only these two block types can be terminal (Parameters `{}` and Transitions `{}`) in a standard contact flow:
 1. **DisconnectParticipant** - End the contact
-2. **EndFlowModuleExecution** - Return from a flow module
-3. **TransferContactToQueue** (after successful transfer)
-4. **TransferToFlow** (after successful transfer)
-5. **TransferToPhoneNumber** (after successful transfer)
+2. **EndFlowExecution** - End / return from flow execution
+
+> API-verified. `EndFlowExecution` is the correct end/return terminal type. `EndFlowModuleExecution` is module-only — importing it in a standard contact flow fails with `Action ... is not supported in contact flow type contactFlow`.
+
+The `Transfer*` blocks are **NOT** terminal — each requires a `NextAction` transition plus specific error branches, so even a "successful transfer" path still routes onward (typically to `DisconnectParticipant`):
+
+- **TransferContactToQueue** - requires `NextAction` plus `QueueAtCapacity` and `NoMatchingError` error branches (takes no `QueueId` parameter).
+- **TransferToFlow** - requires `Parameters.ContactFlowId` (a real flow ARN), a `NextAction` transition, and a `NoMatchingError` error branch.
+- **TransferParticipantToThirdParty** (this is the correct API type name — `TransferToPhoneNumber` is **not** a valid `Type`) - requires a `NextAction` transition plus error branches (`ConnectionTimeLimitExceeded`, `CallFailed`, `NoMatchingError`).
 
 ### Metadata for DisconnectParticipant
 ```json
@@ -102,8 +107,8 @@ Only these block types can be terminal (no Transitions):
 
 ## Related Topics
 - MessageParticipant (for goodbye messages before disconnect)
-- TransferContactToQueue (alternative endpoint)
-- EndFlowModuleExecution (for flow modules)
+- TransferContactToQueue (alternative endpoint — note: not terminal, still needs a NextAction and error branches)
+- EndFlowExecution (the other true terminal block in a standard flow)
 
 ---
 **Metadata**

--- a/knowledge-base-docs/contact-flow/blocks/control/loop.md
+++ b/knowledge-base-docs/contact-flow/blocks/control/loop.md
@@ -15,21 +15,28 @@ The Loop block repeats a section of the flow a specified number of times. It's u
     "LoopCount": "3"
   },
   "Transitions": {
+    "NextAction": "action-to-retry",
     "Conditions": [
       {"Condition": {"Operator": "Equals", "Operands": ["ContinueLooping"]}, "NextAction": "action-to-retry"},
       {"Condition": {"Operator": "Equals", "Operands": ["DoneLooping"]}, "NextAction": "max-retries-reached"}
     ],
     "Errors": [
-      {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
+      {"ErrorType": "NoMatchingError", "NextAction": "max-retries-reached"}
     ]
   }
 }
 ```
 
+> ⚠️ **API-verified (2026-06-08):** a Loop block REQUIRES a top-level
+> `Transitions.NextAction` in addition to its `Conditions`. Omitting it fails
+> import with "Action is missing required property. Path:
+> Actions[N].Transitions.NextAction". Point `NextAction` at the first action of
+> the loop body (same target as the `ContinueLooping` condition).
+
 ### Required Parameters
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| LoopCount | String | Number of iterations (e.g., "3") |
+| LoopCount | String or Number | Number of iterations (e.g., "3"). Import accepts both the string `"3"` and the raw number `3`; the string form is recommended for consistency with the Connect console export. |
 
 > ✅ **API-verified (2026-06-08):** operands are `ContinueLooping` / `DoneLooping`.
 > The names `Looping`/`Complete` are WRONG and make the flow fail import.
@@ -39,22 +46,29 @@ The Loop block repeats a section of the flow a specified number of times. It's u
 - **DoneLooping**: Loop has completed all iterations
 
 ### Error Types
-- **NoMatchingError**: General error
+- **NoMatchingError**: General error (optional — see below)
 
 ### CRITICAL Requirements
-1. MUST have `Conditions` for both "ContinueLooping" and "DoneLooping"
-2. `LoopCount` must be a string ("3"), not a number
-3. MUST have `Errors` with `NoMatchingError`
-4. The "ContinueLooping" path should eventually return to the Loop block
-5. The "DoneLooping" path handles max retries exceeded
+1. MUST have a top-level `Transitions.NextAction` — a Loop block fails import without it
+2. MUST have `Conditions` for both "ContinueLooping" and "DoneLooping"
+3. The "ContinueLooping" path should eventually return to the Loop block
+4. The "DoneLooping" path handles max retries exceeded
+
+**Optional (recommended, not required):**
+- An `Errors` array with `NoMatchingError` is **optional** for the Loop block — a Loop with a valid `NextAction` + `Conditions` and no `Errors` imports successfully. Including it is a good practice for defensive routing but is not enforced by import validation.
+- `LoopCount` may be either the string `"3"` or the number `3`; both import. Prefer the string form for consistency with the console export.
 
 ### Loop Counter Access
-You can access the current loop index:
-- `$.Loop.LoopCounter` - Current iteration (0-indexed)
+You can reference the current loop index in an attribute string:
+- `$.Loop.LoopCounter` - Current iteration
+
+> Note: import validation accepts the `$.Loop.LoopCounter` reference syntax, but
+> the exact runtime value (including whether it is 0-indexed) was not exercised
+> at runtime and remains unconfirmed.
 
 ### WRONG vs CORRECT
 
-#### WRONG (Missing Complete condition)
+#### WRONG (missing top-level NextAction and the DoneLooping condition)
 ```json
 {
   "Transitions": {
@@ -64,44 +78,52 @@ You can access the current loop index:
   }
 }
 ```
+> This form fails import with "Action is missing required property. Path:
+> Actions[N].Transitions.NextAction" — a Loop needs a top-level `NextAction`,
+> and it should also cover the `DoneLooping` condition.
 
 #### CORRECT
 ```json
 {
   "Transitions": {
+    "NextAction": "retry-action",
     "Conditions": [
       {"Condition": {"Operator": "Equals", "Operands": ["ContinueLooping"]}, "NextAction": "retry-action"},
       {"Condition": {"Operator": "Equals", "Operands": ["DoneLooping"]}, "NextAction": "max-retries"}
     ],
-    "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]
+    "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "max-retries"}]
   }
 }
 ```
 
 ### Pattern: Input Retry Loop
+The `get-input` block below uses the verified `GetParticipantInput` **STORE**
+mode (`StoreInput: "True"` with `InputValidation`, capturing the PIN to
+`$.StoredCustomerInput`, only a `NoMatchingError` transition and no Conditions).
+See the GetParticipantInput doc for the full MENU vs STORE schema before adapting
+this — the two modes have different required properties.
 ```json
 {"Identifier": "input-loop", "Type": "Loop",
  "Parameters": {"LoopCount": "3"},
  "Transitions": {
+   "NextAction": "get-input",
    "Conditions": [
      {"Condition": {"Operator": "Equals", "Operands": ["ContinueLooping"]}, "NextAction": "get-input"},
      {"Condition": {"Operator": "Equals", "Operands": ["DoneLooping"]}, "NextAction": "max-attempts"}
    ],
-   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]
+   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "max-attempts"}]
  }}
 
 {"Identifier": "get-input", "Type": "GetParticipantInput",
  "Parameters": {
    "Text": "Please enter your PIN number.",
+   "StoreInput": "True",
    "InputTimeLimitSeconds": "10",
-   "DTMFConfiguration": {"InputTerminationSequence": "#"}
+   "DTMFConfiguration": {"DisableCancelKey": "False"},
+   "InputValidation": {"CustomValidation": {"MaximumLength": "6"}}
  },
  "Transitions": {"NextAction": "validate-pin",
-   "Errors": [
-     {"ErrorType": "InputTimeLimitExceeded", "NextAction": "input-loop"},
-     {"ErrorType": "NoMatchingCondition", "NextAction": "validate-pin"},
-     {"ErrorType": "NoMatchingError", "NextAction": "input-loop"}
-   ]
+   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "input-loop"}]
  }}
 
 {"Identifier": "validate-pin", "Type": "InvokeLambdaFunction",
@@ -136,40 +158,53 @@ You can access the current loop index:
 ```
 
 ### Pattern: Agent Availability Retry with Wait
+The `wait-30s` block uses the verified `Wait` schema (`TimeLimitSeconds` plus a
+`WaitCompleted` condition — **not** `WaitTime`), and staffing is checked with
+`CheckMetricData` (there is no `CheckStaffing` Type). `CheckMetricData` returns a
+numeric metric, so it branches with numeric operators against
+`NumberOfAgentsAvailable`; set the working queue with `UpdateContactTargetQueue`
+before this block.
 ```json
 {"Identifier": "retry-loop", "Type": "Loop",
  "Parameters": {"LoopCount": "5"},
  "Transitions": {
+   "NextAction": "wait-30s",
    "Conditions": [
      {"Condition": {"Operator": "Equals", "Operands": ["ContinueLooping"]}, "NextAction": "wait-30s"},
      {"Condition": {"Operator": "Equals", "Operands": ["DoneLooping"]}, "NextAction": "offer-callback"}
    ],
-   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]
+   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "offer-callback"}]
  }}
 
 {"Identifier": "wait-30s", "Type": "Wait",
- "Parameters": {"WaitTime": "30"},
+ "Parameters": {"TimeLimitSeconds": "30"},
  "Transitions": {"NextAction": "check-staffing",
+   "Conditions": [
+     {"Condition": {"Operator": "Equals", "Operands": ["WaitCompleted"]}, "NextAction": "check-staffing"}
+   ],
    "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "check-staffing"}]}}
 
-{"Identifier": "check-staffing", "Type": "CheckStaffing",
- "Parameters": {},
+{"Identifier": "check-staffing", "Type": "CheckMetricData",
+ "Parameters": {"MetricType": "NumberOfAgentsAvailable"},
  "Transitions": {
+   "NextAction": "retry-loop",
    "Conditions": [
-     {"Condition": {"Operator": "Equals", "Operands": ["True"]}, "NextAction": "transfer-queue"},
-     {"Condition": {"Operator": "Equals", "Operands": ["False"]}, "NextAction": "retry-loop"}
+     {"Condition": {"Operator": "NumberGreaterThan", "Operands": ["0"]}, "NextAction": "transfer-queue"}
    ],
-   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "retry-loop"}]
+   "Errors": [
+     {"ErrorType": "NoMatchingCondition", "NextAction": "retry-loop"},
+     {"ErrorType": "NoMatchingError", "NextAction": "retry-loop"}
+   ]
  }}
 ```
 
 ## Related Topics
 - Wait Block
 - GetParticipantInput
-- CheckStaffing
+- CheckMetricData
 
 ---
 **Metadata**
 - Category: Control
 - BlockType: Loop
-- Keywords: loop, retry, repeat, iteration, Looping, Complete, LoopCount
+- Keywords: loop, retry, repeat, iteration, ContinueLooping, DoneLooping, LoopCount

--- a/knowledge-base-docs/contact-flow/blocks/integrate/connect-participant-with-lex-bot.md
+++ b/knowledge-base-docs/contact-flow/blocks/integrate/connect-participant-with-lex-bot.md
@@ -66,11 +66,12 @@ Properties: [Text, LexInitializationData]`). Use `LexInitializationData.InitialM
    unconditionally required error types (omitting either fails import). Add
    `InputTimeLimitExceeded` only when using `LexTimeoutSeconds`.
 4. For voice, set up `UpdateContactTextToSpeechVoice` BEFORE this block.
-5. For voice, set `UpdateContactRecordingBehavior` with Voice `AnalyticsModes: ["PostContact"]`.
-   `RealTime` passes CreateContactFlow structural validation (it is NOT rejected at import
-   time), but it requires real-time Contact Lens enabled on the instance or it fails at
-   runtime. Q in Connect assistance is driven by the Lex/Wisdom session, not by real-time
-   voice analytics in this block, so `PostContact` is the safe default.
+5. For voice, set `UpdateContactRecordingBehavior` with Voice `AnalyticsModes: ["RealTime"]`
+   (preferred for AI-agent / Q in Connect flows — live transcript + sentiment give the
+   assistant and any escalated human real-time context). Voice `AnalyticsModes` takes
+   EXACTLY ONE mode: `["RealTime"]` OR `["PostContact"]`, never both (the combined array
+   fails import). `RealTime` requires real-time Contact Lens enabled on the instance
+   (enforced at runtime, not at import); if it is not provisioned, use `["PostContact"]`.
 
 ### Lex V2 Bot Alias ARN Format
 ```
@@ -129,7 +130,7 @@ After the Lex interaction, these attributes are available:
  "Parameters": {
    "RecordingBehavior": {"RecordedParticipants": ["Agent", "Customer"], "IVRRecordingBehavior": "Enabled"},
    "AnalyticsBehavior": {"Enabled": "True", "AnalyticsLanguage": "en-US",
-     "ChannelConfiguration": {"Chat": {"AnalyticsModes": []}, "Voice": {"AnalyticsModes": ["PostContact"]}}}
+     "ChannelConfiguration": {"Chat": {"AnalyticsModes": []}, "Voice": {"AnalyticsModes": ["RealTime"]}}}
  },
  "Transitions": {"NextAction": "lex-bot"}}
 

--- a/knowledge-base-docs/contact-flow/blocks/integrate/connect-participant-with-lex-bot.md
+++ b/knowledge-base-docs/contact-flow/blocks/integrate/connect-participant-with-lex-bot.md
@@ -20,7 +20,8 @@ The ConnectParticipantWithLexBot block connects the contact to a Lex V2 bot for 
   "Transitions": {
     "NextAction": "check-result",
     "Errors": [
-      {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
+      {"ErrorType": "NoMatchingError", "NextAction": "error-handler"},
+      {"ErrorType": "NoMatchingCondition", "NextAction": "error-handler"}
     ]
   }
 }
@@ -29,16 +30,27 @@ The ConnectParticipantWithLexBot block connects the contact to a Lex V2 bot for 
 ### Required Parameters
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| Text / SSML / PromptId / Media | one of | Initial message. Provide exactly ONE of these |
+| Text / SSML / PromptId / Media / LexInitializationData | one of | Initial message. Provide exactly ONE of these |
 | LexV2Bot.AliasArn *(recommended)* | String | ARN of the Lex V2 bot alias |
 | LexBot *(legacy, still supported)* | Object | Lex V1 — `{Name, Region, Alias}` |
+
+The initial-message set is mutually exclusive: supplying `Text` together with
+`LexInitializationData` is rejected (`Only one of these properties may be defined.
+Properties: [Text, LexInitializationData]`). Use `LexInitializationData.InitialMessage`
+**instead of** `Text`, not alongside it. `LexInitializationData` alone (no `Text`) imports.
 
 ### Optional Parameters
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | LexSessionAttributes | Object (string→string) | Session attributes passed to Lex |
-| LexInitializationData.InitialMessage | String | Chat-only: message to prime the bot |
-| LexTimeoutSeconds.Text | Number | Chat-only: timer for inactive customer |
+| LexTimeoutSeconds.Text | Number | Chat-only: timer for inactive customer (see caveat below) |
+
+> **LexTimeoutSeconds caveat (unverified):** On a plain `CONTACT_FLOW` import, every literal
+> value form tested for `LexTimeoutSeconds.Text` (number `10`, string `"10"`, ISO-8601 `"PT10S"`)
+> is rejected with `Invalid Action property value. Path: Actions[0].Parameters.LexTimeoutSeconds.Text`.
+> The property *name* is accepted, but no literal value validated on a standard contact flow —
+> the accepted value format may be channel-specific (chat) or require an attribute JSONPath rather
+> than a literal. Confirm the exact accepted format before relying on it.
 
 ### Error Types
 - **NoMatchingError**: Bot invocation failed (invalid ARN, permissions, bot error)
@@ -48,14 +60,17 @@ The ConnectParticipantWithLexBot block connects the contact to a Lex V2 bot for 
 ### CRITICAL Requirements
 1. **Use Lex V2 via `LexV2Bot.AliasArn` for new flows**. Lex V1 (`LexBot` object) is still
    supported by the action but is legacy — prefer V2.
-2. Provide exactly ONE of `Text` | `SSML` | `PromptId` | `Media` (not multiple).
-3. MUST include `Errors` with `NoMatchingError`. Include `NoMatchingCondition` when you
-   branch on Intent, and `InputTimeLimitExceeded` when using `LexTimeoutSeconds`.
+2. Provide exactly ONE of `Text` | `SSML` | `PromptId` | `Media` | `LexInitializationData`
+   (not multiple).
+3. MUST include BOTH `NoMatchingError` and `NoMatchingCondition` in `Errors` — both are
+   unconditionally required error types (omitting either fails import). Add
+   `InputTimeLimitExceeded` only when using `LexTimeoutSeconds`.
 4. For voice, set up `UpdateContactTextToSpeechVoice` BEFORE this block.
-5. For voice, set `UpdateContactRecordingBehavior` with Voice `AnalyticsModes: ["PostContact"]`
-   (do NOT use `RealTime` — Connect rejects it on import unless real-time Contact Lens
-   preconditions are met; Q in Connect assistance is driven by the Lex/Wisdom session, not
-   by real-time voice analytics in this block).
+5. For voice, set `UpdateContactRecordingBehavior` with Voice `AnalyticsModes: ["PostContact"]`.
+   `RealTime` passes CreateContactFlow structural validation (it is NOT rejected at import
+   time), but it requires real-time Contact Lens enabled on the instance or it fails at
+   runtime. Q in Connect assistance is driven by the Lex/Wisdom session, not by real-time
+   voice analytics in this block, so `PostContact` is the safe default.
 
 ### Lex V2 Bot Alias ARN Format
 ```
@@ -86,7 +101,10 @@ After the Lex interaction, these attributes are available:
  },
  "Transitions": {
    "NextAction": "check-result",
-   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]
+   "Errors": [
+     {"ErrorType": "NoMatchingError", "NextAction": "error-handler"},
+     {"ErrorType": "NoMatchingCondition", "NextAction": "error-handler"}
+   ]
  }}
 
 {"Identifier": "check-result", "Type": "Compare",
@@ -122,7 +140,10 @@ After the Lex interaction, these attributes are available:
  },
  "Transitions": {
    "NextAction": "check-result",
-   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]
+   "Errors": [
+     {"ErrorType": "NoMatchingError", "NextAction": "error-handler"},
+     {"ErrorType": "NoMatchingCondition", "NextAction": "error-handler"}
+   ]
  }}
 ```
 

--- a/knowledge-base-docs/contact-flow/blocks/integrate/get-customer-profile.md
+++ b/knowledge-base-docs/contact-flow/blocks/integrate/get-customer-profile.md
@@ -41,14 +41,16 @@ The GetCustomerProfile block retrieves customer profile data from Amazon Connect
 |-----------|------|-------------|
 | ProfileResponseData | Array | List of profile fields to retrieve |
 
-### Error Types
+### Required Error Types
+All three error transitions below are **structurally required** — the flow will FAIL to import if any one is omitted (this is not merely a production recommendation). Each is individually mandatory: omitting any triggers `InvalidContactFlowException` with `Action is missing required error. Error: <Type>`.
+
 - **MultipleFoundError**: Multiple profiles match the identifier
 - **NoneFoundError**: No profile found for the identifier
-- **NoMatchingError**: General error (service unavailable, etc.)
+- **NoMatchingError**: General error / catch-all (service unavailable, etc.) — required for import, not just an optional catch-all
 
 ### CRITICAL Requirements
 1. MUST use `ProfileRequestData` wrapper object (NOT flat parameters!)
-2. MUST handle all three error types for production flows
+2. MUST wire ALL THREE error transitions (`MultipleFoundError`, `NoneFoundError`, `NoMatchingError`). These are individually required for import — omitting any one fails import with `Action is missing required error. Error: <Type>`.
 3. Identifier values starting with "_" are reserved (e.g., "_phone", "_email")
 
 ### WRONG vs CORRECT
@@ -144,7 +146,12 @@ After successful retrieval:
      "IdentifierValue": "$.CustomerEndpoint.Address"
    }
  },
- "Transitions": {...}}
+ "Transitions": {"NextAction": "greet-customer",
+   "Errors": [
+     {"ErrorType": "MultipleFoundError", "NextAction": "greet-customer"},
+     {"ErrorType": "NoneFoundError", "NextAction": "greet-customer"},
+     {"ErrorType": "NoMatchingError", "NextAction": "greet-customer"}
+   ]}}
 
 {"Identifier": "chat-lookup", "Type": "GetCustomerProfile",
  "Parameters": {
@@ -153,7 +160,12 @@ After successful retrieval:
      "IdentifierValue": "$.Attributes.customerEmail"
    }
  },
- "Transitions": {...}}
+ "Transitions": {"NextAction": "greet-customer",
+   "Errors": [
+     {"ErrorType": "MultipleFoundError", "NextAction": "greet-customer"},
+     {"ErrorType": "NoneFoundError", "NextAction": "greet-customer"},
+     {"ErrorType": "NoMatchingError", "NextAction": "greet-customer"}
+   ]}}
 ```
 
 ## Related Topics

--- a/knowledge-base-docs/contact-flow/blocks/integrate/invoke-lambda-function.md
+++ b/knowledge-base-docs/contact-flow/blocks/integrate/invoke-lambda-function.md
@@ -35,12 +35,12 @@ The InvokeLambdaFunction block calls an AWS Lambda function and can pass/receive
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | LambdaFunctionARN | String | The ARN of the Lambda function |
-| InvocationTimeLimitSeconds | String | Timeout in seconds (max 8) |
-| ResponseValidation | Object | Must contain `ResponseType: "STRING_MAP"` or `"JSON"` |
+| InvocationTimeLimitSeconds | String or Number | Timeout in seconds, 1–8 inclusive (string `"8"` recommended; a bare number `8` is also accepted) |
 
 ### Optional Parameters
 | Parameter | Type | Description |
 |-----------|------|-------------|
+| ResponseValidation | Object | Optional. When present, must contain `ResponseType: "STRING_MAP"` or `"JSON"`. If omitted, no response validation is applied |
 | LambdaInvocationAttributes | Object | Key-value pairs to pass to Lambda |
 | InvocationType | String | `"SYNCHRONOUS"` (default) or `"ASYNCHRONOUS"` |
 
@@ -48,8 +48,8 @@ The InvokeLambdaFunction block calls an AWS Lambda function and can pass/receive
 - **NoMatchingError**: Lambda failed, timed out, or returned invalid response
 
 ### CRITICAL Requirements
-1. `InvocationTimeLimitSeconds` MUST be a string (e.g., "8"), 1–8 inclusive
-2. `ResponseType` MUST be `"STRING_MAP"` OR `"JSON"` — both are officially supported
+1. `InvocationTimeLimitSeconds` value must be 1–8 inclusive. The API accepts either a quoted string (`"8"`) or a bare number (`8`); the string form is recommended for consistency.
+2. `ResponseValidation` is optional. If you include it, `ResponseType` MUST be `"STRING_MAP"` OR `"JSON"` — both are officially supported. Omitting `ResponseValidation` entirely is also valid (no response validation is applied).
    - Use `STRING_MAP` for flat key/value string maps (simpler, stricter validation)
    - Use `JSON` when the Lambda returns nested JSON that must preserve its structure
 3. MUST have `Errors` array with `NoMatchingError`

--- a/knowledge-base-docs/contact-flow/blocks/interact/get-participant-input.md
+++ b/knowledge-base-docs/contact-flow/blocks/interact/get-participant-input.md
@@ -43,7 +43,7 @@ The GetParticipantInput block plays a message and collects DTMF (touch-tone) inp
 ### MODE 2 — STORE (capture digits to a contact attribute)
 - `StoreInput` MUST be `"True"`.
 - Requires `InputValidation.CustomValidation.MaximumLength`.
-- `DTMFConfiguration` may carry `DisableCancelKey` only — NEVER `InputTerminationSequence`.
+- `DTMFConfiguration` may carry `InputTerminationSequence` (the terminator key, e.g. `"#"`) and/or `DisableCancelKey`. `DisableCancelKey` MUST be the string `"True"`/`"False"`, never a JSON boolean.
 - Only error: `NoMatchingError`. No Conditions.
 
 ```json
@@ -70,10 +70,12 @@ The GetParticipantInput block plays a message and collects DTMF (touch-tone) inp
 - **NoMatchingError**: general error (both modes)
 
 ### CRITICAL Requirements
-1. MUST have all THREE error types for production flows
-2. `InputTimeLimitSeconds` must be a string ("5"), not a number
-3. MUST have `Conditions` array for expected inputs
-4. Input is stored in `$.StoredCustomerInput` for later use
+1. `StoreInput` is a **required** property in BOTH modes (string `"True"`/`"False"`) — omitting it fails import with `Action is missing required property. Path: ...Parameters.StoreInput`.
+2. In MENU mode MUST have all THREE error types (`NoMatchingCondition` + `InputTimeLimitExceeded` + `NoMatchingError`); in STORE mode the ONLY allowed error is `NoMatchingError`.
+3. `DisableCancelKey` MUST be the string `"True"`/`"False"`, never a JSON boolean. A boolean value produces a misleading top-level `Invalid Action type. Type: GetParticipantInput` error.
+4. `InputTimeLimitSeconds` — the API accepts both a string (`"5"`) and a JSON number (`5`); prefer the string for consistency with `StoreInput`/`DisableCancelKey`.
+5. MENU mode uses a `Conditions` array to branch on the pressed key; STORE mode must NOT use `Conditions`.
+6. In STORE mode, input is stored in `$.StoredCustomerInput` for later use.
 
 ### Accessing Customer Input
 After this block, the input is available at:
@@ -84,8 +86,8 @@ After this block, the input is available at:
 {"Identifier": "main-menu", "Type": "GetParticipantInput",
  "Parameters": {
    "Text": "Main menu. Press 1 for account balance, press 2 for recent transactions, press 3 for customer service.",
-   "InputTimeLimitSeconds": "10",
-   "DTMFConfiguration": {"InputTerminationSequence": "#", "DisableCancelKey": false}
+   "StoreInput": "False",
+   "InputTimeLimitSeconds": "10"
  },
  "Transitions": {"NextAction": "repeat-menu",
    "Conditions": [
@@ -116,13 +118,13 @@ After this block, the input is available at:
 {"Identifier": "collect-account", "Type": "GetParticipantInput",
  "Parameters": {
    "Text": "Please enter your 10-digit account number, followed by the pound key.",
+   "StoreInput": "True",
    "InputTimeLimitSeconds": "30",
-   "DTMFConfiguration": {"InputTerminationSequence": "#", "DisableCancelKey": false}
+   "DTMFConfiguration": {"InputTerminationSequence": "#", "DisableCancelKey": "False"},
+   "InputValidation": {"CustomValidation": {"MaximumLength": "10"}}
  },
  "Transitions": {"NextAction": "validate-account",
    "Errors": [
-     {"ErrorType": "InputTimeLimitExceeded", "NextAction": "input-timeout"},
-     {"ErrorType": "NoMatchingCondition", "NextAction": "validate-account"},
      {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
    ]
  }}
@@ -143,8 +145,8 @@ After this block, the input is available at:
 {"Identifier": "confirm-callback", "Type": "GetParticipantInput",
  "Parameters": {
    "Text": "We will call you back at this number. Press 1 to confirm, or press 2 to enter a different number.",
-   "InputTimeLimitSeconds": "5",
-   "DTMFConfiguration": {"DisableCancelKey": false}
+   "StoreInput": "False",
+   "InputTimeLimitSeconds": "5"
  },
  "Transitions": {"NextAction": "use-current-number",
    "Conditions": [

--- a/knowledge-base-docs/contact-flow/blocks/interact/message-participant.md
+++ b/knowledge-base-docs/contact-flow/blocks/interact/message-participant.md
@@ -29,7 +29,7 @@ The MessageParticipant block plays text-to-speech (TTS) messages or audio prompt
   "Identifier": "play-audio",
   "Type": "MessageParticipant",
   "Parameters": {
-    "PromptId": "arn:aws:connect:us-east-1:123456789012:instance/xxx/prompt/yyy"
+    "PromptId": "<PROMPT_ARN>"
   },
   "Transitions": {
     "NextAction": "next-block",
@@ -39,24 +39,40 @@ The MessageParticipant block plays text-to-speech (TTS) messages or audio prompt
   }
 }
 ```
+`PromptId` must be a **real, resolvable prompt ARN on the target instance** (format `arn:aws:connect:<region>:<account>:instance/<instance-id>/prompt/<prompt-id>`). A placeholder ARN, or one from a different region/instance, fails at import with `Failed to convert id: <arn>` — this is a resource-resolution error, not a structural one; the `PromptId` parameter name itself is valid.
 
 ### Parameters (Choose ONE)
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| Text | String | TTS message to speak |
+| Text | String | Plain-text TTS message to speak |
+| SSML | String | SSML-markup message to speak |
 | PromptId | String | ARN of pre-recorded audio prompt |
 | Media | Object | S3 audio file reference |
+
+The valid mutually-exclusive set is **Text | SSML | PromptId | Media** — exactly one is required. Supplying more than one (e.g. Text + PromptId, or Text + SSML) is rejected with `Only one of these properties may be defined`. Supplying none is rejected with `At least one of the following properties must be set. Properties: [Parameters.PromptId, Parameters.Text, Parameters.SSML, Parameters.Media]`.
 
 ### Error Types
 - **NoMatchingError**: Message playback failed
 
 ### CRITICAL Requirements
-1. Use ONE of: Text, PromptId, or Media (not multiple)
-2. SHOULD have `Errors` with `NoMatchingError` for robustness
+1. Use exactly ONE of: Text, SSML, PromptId, or Media (not multiple)
+2. SHOULD have `Errors` with `NoMatchingError` for robustness (the `Errors` array is optional — a Text-only block with no `Errors` still imports)
 3. For TTS, set voice with `UpdateContactTextToSpeechVoice` first
+4. All Parameter values must be JSON **strings** — e.g. `"SkipWhenDTMFBufferEnabled": "True"`, not the boolean `true`. A boolean value fails with a misleading `Invalid Action type` error rather than a clear type error. (`SkipWhenDTMFBufferEnabled` is itself a valid optional Parameter accepting the string values `"True"`/`"False"`.)
 
-### SSML Support in Text
-You can use SSML tags for advanced TTS control:
+### SSML Support
+SSML markup can be supplied two ways (they are mutually exclusive with each other and with Text):
+
+**1. As the standalone `SSML` parameter** (preferred for full SSML documents):
+```json
+{
+  "Parameters": {
+    "SSML": "<speak>Welcome. <break time='500ms'/> Your account balance is <say-as interpret-as='currency'>$123.45</say-as></speak>"
+  }
+}
+```
+
+**2. Embedded as tags inside the `Text` parameter** (also accepted by the API):
 ```json
 {
   "Parameters": {
@@ -64,6 +80,7 @@ You can use SSML tags for advanced TTS control:
   }
 }
 ```
+Note: `SSML` is a first-class parameter — do not set both `Text` and `SSML` in the same block (`Only one of these properties may be defined. Properties: [Text, SSML]`).
 
 ### Using Contact Attributes in Text
 ```json

--- a/knowledge-base-docs/contact-flow/blocks/set/set-callback-number.md
+++ b/knowledge-base-docs/contact-flow/blocks/set/set-callback-number.md
@@ -17,9 +17,8 @@ The UpdateContactCallbackNumber block sets the phone number to use when creating
   "Transitions": {
     "NextAction": "transfer-callback",
     "Errors": [
-      {"ErrorType": "InvalidNumber", "NextAction": "invalid-number-handler"},
-      {"ErrorType": "NotDialable", "NextAction": "not-dialable-handler"},
-      {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
+      {"ErrorType": "InvalidCallbackNumber", "NextAction": "invalid-number-handler"},
+      {"ErrorType": "CallbackNumberNotDialable", "NextAction": "not-dialable-handler"}
     ]
   }
 }
@@ -28,21 +27,21 @@ The UpdateContactCallbackNumber block sets the phone number to use when creating
 ### Required Parameters
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| CallbackNumber | String | The phone number for callback (can use JSONPath) |
+| CallbackNumber | String (JSONPath) | The phone number for callback. Must be a JSONPath / contact-attribute reference (e.g. `$.CustomerEndpoint.Address`), NOT a hard-coded literal number. Required. |
 
 ### Error Types
-- **InvalidNumber**: Phone number format is invalid
-- **NotDialable**: Valid format but cannot be dialed (blocked, out of region, etc.)
-- **NoMatchingError**: General error
+UpdateContactCallbackNumber requires exactly these two error branches (and rejects any others, including `NoMatchingError`):
+- **InvalidCallbackNumber**: Phone number format is invalid
+- **CallbackNumberNotDialable**: Valid format but cannot be dialed (blocked, out of region, etc.)
 
 ### CRITICAL Requirements
-1. MUST have all three error types handled for production flows
-2. MUST be followed by `TransferContactToQueue` to create the callback
-3. `CallbackNumber` typically uses `$.CustomerEndpoint.Address` (caller's number)
+1. MUST handle exactly the two error types `InvalidCallbackNumber` and `CallbackNumberNotDialable`. Do NOT add a `NoMatchingError` branch — the API rejects it on this block.
+2. MUST be followed by `TransferContactToQueue` to create the callback (the target queue must already be set on the contact — e.g. via `UpdateContactTargetQueue`)
+3. `CallbackNumber` must be a JSONPath reference (typically `$.CustomerEndpoint.Address`, the caller's number); a literal number string is rejected
 
 ### WRONG vs CORRECT
 
-#### WRONG (Missing required errors!)
+#### WRONG (NoMatchingError is forbidden, and both required errors are missing!)
 ```json
 {
   "Transitions": {
@@ -53,39 +52,44 @@ The UpdateContactCallbackNumber block sets the phone number to use when creating
   }
 }
 ```
+The API rejects `NoMatchingError` on this block and reports `InvalidCallbackNumber` and `CallbackNumberNotDialable` as missing.
 
-#### CORRECT (All three error types)
+#### CORRECT (exactly the two required error types, nothing else)
 ```json
 {
   "Transitions": {
     "NextAction": "transfer-callback",
     "Errors": [
-      {"ErrorType": "InvalidNumber", "NextAction": "invalid-number-handler"},
-      {"ErrorType": "NotDialable", "NextAction": "not-dialable-handler"},
-      {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
+      {"ErrorType": "InvalidCallbackNumber", "NextAction": "invalid-number-handler"},
+      {"ErrorType": "CallbackNumberNotDialable", "NextAction": "not-dialable-handler"}
     ]
   }
 }
 ```
 
 ### Complete Callback Pattern
+Set the target queue first (TransferContactToQueue transfers to the queue already set on the contact and takes no `QueueId` parameter).
 ```json
 {"Identifier": "callback-message", "Type": "MessageParticipant",
  "Parameters": {"Text": "We'll call you back when an agent is available."},
+ "Transitions": {"NextAction": "set-queue",
+   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "set-queue"}]}}
+
+{"Identifier": "set-queue", "Type": "UpdateContactTargetQueue",
+ "Parameters": {"QueueId": "{{QUEUE_ARN}}"},
  "Transitions": {"NextAction": "set-callback",
-   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "set-callback"}]}}
+   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]}}
 
 {"Identifier": "set-callback", "Type": "UpdateContactCallbackNumber",
  "Parameters": {"CallbackNumber": "$.CustomerEndpoint.Address"},
  "Transitions": {"NextAction": "transfer-callback",
    "Errors": [
-     {"ErrorType": "InvalidNumber", "NextAction": "invalid-callback"},
-     {"ErrorType": "NotDialable", "NextAction": "invalid-callback"},
-     {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
+     {"ErrorType": "InvalidCallbackNumber", "NextAction": "invalid-callback"},
+     {"ErrorType": "CallbackNumberNotDialable", "NextAction": "invalid-callback"}
    ]}}
 
 {"Identifier": "transfer-callback", "Type": "TransferContactToQueue",
- "Parameters": {"QueueId": "{{QUEUE_ARN}}"},
+ "Parameters": {},
  "Transitions": {"NextAction": "callback-confirmed",
    "Errors": [
      {"ErrorType": "QueueAtCapacity", "NextAction": "queue-full"},
@@ -103,17 +107,18 @@ The UpdateContactCallbackNumber block sets the phone number to use when creating
    "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "disconnect"}]}}
 ```
 
-### NON-EXISTENT Block Warning
-There is NO `CreateCallbackContact` block type. Callbacks are created by:
-1. UpdateContactCallbackNumber (set the number)
-2. TransferContactToQueue (creates the callback in queue)
-
-#### WRONG
+### Recommended Pattern vs. CreateCallbackContact
+`CreateCallbackContact` IS a valid block type. If you use it, it requires three properties — `InitialCallDelaySeconds`, `MaximumConnectionAttempts`, and `RetryDelaySeconds`:
 ```json
-{"Type": "CreateCallbackContact"}  // DOES NOT EXIST!
+{"Type": "CreateCallbackContact",
+ "Parameters": {
+   "InitialCallDelaySeconds": "10",
+   "MaximumConnectionAttempts": "3",
+   "RetryDelaySeconds": "60"
+ }}
 ```
 
-#### CORRECT
+For queue callbacks, the recommended pattern in most flows is to set the callback number and transfer to the (already-set) queue:
 ```json
 {"Type": "UpdateContactCallbackNumber"}
 // followed by
@@ -123,10 +128,11 @@ There is NO `CreateCallbackContact` block type. Callbacks are created by:
 ## Related Topics
 - TransferContactToQueue
 - UpdateContactTargetQueue
+- CreateCallbackContact
 - Queue Overflow Handling Pattern
 
 ---
 **Metadata**
 - Category: Set
 - BlockType: UpdateContactCallbackNumber
-- Keywords: callback, queue callback, InvalidNumber, NotDialable, phone number
+- Keywords: callback, queue callback, InvalidCallbackNumber, CallbackNumberNotDialable, CreateCallbackContact, phone number

--- a/knowledge-base-docs/contact-flow/blocks/set/set-working-queue.md
+++ b/knowledge-base-docs/contact-flow/blocks/set/set-working-queue.md
@@ -4,7 +4,7 @@
 How do I use the UpdateContactTargetQueue block in Amazon Connect Contact Flow?
 
 ## Answer
-The UpdateContactTargetQueue block sets the active queue for subsequent queue-related operations like TransferContactToQueue and CheckStaffing.
+The UpdateContactTargetQueue block sets the active queue for subsequent queue-related operations like TransferContactToQueue and CheckMetricData.
 
 ### JSON Structure
 ```json
@@ -12,10 +12,10 @@ The UpdateContactTargetQueue block sets the active queue for subsequent queue-re
   "Identifier": "set-queue",
   "Type": "UpdateContactTargetQueue",
   "Parameters": {
-    "QueueId": "{{QUEUE_ARN}}"
+    "QueueId": "arn:aws:connect:us-east-1:123456789012:instance/xxx/queue/yyy"
   },
   "Transitions": {
-    "NextAction": "check-staffing",
+    "NextAction": "check-metric",
     "Errors": [
       {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
     ]
@@ -24,17 +24,23 @@ The UpdateContactTargetQueue block sets the active queue for subsequent queue-re
 ```
 
 ### Required Parameters
+UpdateContactTargetQueue requires **at least one** of the following properties (either sets the target queue for subsequent blocks):
+
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | QueueId | String | The ARN or UUID of the target queue (NOT the queue name!) |
+| AgentId | String | The ARN of an agent — targets that specific agent's personal queue instead of a standard queue |
+
+If neither is set, the API rejects the block with: `At least one of the following properties must be set. Properties: [Parameters.QueueId, Parameters.AgentId]`.
 
 ### Error Types
 - **NoMatchingError**: Queue doesn't exist or permissions issue
 
 ### CRITICAL Requirements
 1. QueueId MUST be a valid ARN or UUID format, NOT a queue name
-2. MUST be called BEFORE `TransferContactToQueue` or `CheckStaffing` if those blocks don't specify QueueId
-3. MUST have `Errors` array with `NoMatchingError`
+2. Either `QueueId` OR `AgentId` MUST be set (at least one is required)
+3. MUST be called BEFORE `TransferContactToQueue` or `CheckMetricData` if those blocks don't specify a queue
+4. MUST have `Errors` array with `NoMatchingError`
 
 ### Valid QueueId Formats
 ```
@@ -43,32 +49,41 @@ arn:aws:connect:us-east-1:123456789012:instance/xxx/queue/yyy
 
 # UUID format
 12345678-1234-1234-1234-123456789012
-
-# Placeholder for generated flows
-{{QUEUE_ARN}}
 ```
+
+> **Generation-time placeholder note:** `{{QUEUE_ARN}}` is a templating token used by generated flows — it is NOT a value the CreateContactFlow API accepts. Importing a flow with the literal string `{{QUEUE_ARN}}` fails with `Failed to convert id: {{QUEUE_ARN}}`. It MUST be substituted with a real queue ARN or UUID before the flow is imported.
 
 ### Invalid QueueId Formats (NEVER USE)
 ```
-# Queue name - WRONG!
+# Queue name - WRONG! ("Failed to convert id: Customer Service")
 "Customer Service"
 "Sales Queue"
 ```
 
-### Common Pattern: Queue with Staffing Check
+### Common Pattern: Queue with Agent-Availability Check
+
+There is no `CheckStaffing` block — the API rejects that Type (`Invalid Action type. Type: CheckStaffing`). Use **`CheckMetricData`** instead, which reads a real-time queue metric and branches with a numeric `Conditions` comparison. `CheckMetricData` requires:
+- `Parameters.MetricType` — one of `NumberOfAgentsAvailable`, `NumberOfContactsInQueue`, `OldestContactInQueueAgeSeconds`
+- `Transitions.NextAction` (the default/no-match branch), a `Transitions.Conditions` array, and BOTH the `NoMatchingCondition` and `NoMatchingError` error handlers
+
+Numeric conditions use operators such as `NumberGreaterThan`, `NumberLessThan`, and `NumberEquals` (note: bare `True`/`False` conditions are NOT valid for this block).
+
 ```json
 {"Identifier": "set-queue", "Type": "UpdateContactTargetQueue",
- "Parameters": {"QueueId": "{{QUEUE_ARN}}"},
- "Transitions": {"NextAction": "check-staffing", "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]}}
+ "Parameters": {"QueueId": "arn:aws:connect:us-east-1:123456789012:instance/xxx/queue/yyy"},
+ "Transitions": {"NextAction": "check-metric", "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]}}
 
-{"Identifier": "check-staffing", "Type": "CheckStaffing",
- "Parameters": {},
+{"Identifier": "check-metric", "Type": "CheckMetricData",
+ "Parameters": {"MetricType": "NumberOfAgentsAvailable"},
  "Transitions": {
+   "NextAction": "no-agents",
    "Conditions": [
-     {"Condition": {"Operator": "Equals", "Operands": ["True"]}, "NextAction": "transfer-queue"},
-     {"Condition": {"Operator": "Equals", "Operands": ["False"]}, "NextAction": "no-agents"}
+     {"Condition": {"Operator": "NumberGreaterThan", "Operands": ["0"]}, "NextAction": "transfer-queue"}
    ],
-   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]
+   "Errors": [
+     {"ErrorType": "NoMatchingCondition", "NextAction": "no-agents"},
+     {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
+   ]
  }}
 
 {"Identifier": "transfer-queue", "Type": "TransferContactToQueue",
@@ -78,9 +93,11 @@ arn:aws:connect:us-east-1:123456789012:instance/xxx/queue/yyy
               {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]}}
 ```
 
+> **TransferContactToQueue error handling:** this block requires BOTH the `QueueAtCapacity` AND `NoMatchingError` error handlers — dropping either one fails the import (`Action is missing required error. Error: QueueAtCapacity` / `Error: NoMatchingError`). It takes NO `QueueId` parameter; it transfers to the queue set by the preceding UpdateContactTargetQueue block.
+
 ## Related Topics
 - TransferContactToQueue
-- CheckStaffing
+- CheckMetricData
 - GetQueueMetrics
 
 ---

--- a/knowledge-base-docs/contact-flow/blocks/set/update-contact-attributes.md
+++ b/knowledge-base-docs/contact-flow/blocks/set/update-contact-attributes.md
@@ -32,6 +32,29 @@ The UpdateContactAttributes block sets or updates custom contact attributes. The
 |-----------|------|-------------|
 | Attributes | Object | Key-value pairs of attributes to set |
 
+### Optional Parameters
+| Parameter | Type | Allowed Values | Description |
+|-----------|------|----------------|-------------|
+| TargetContact | String | `Current` (default), `Related` | Selects whether the attributes are set on the current contact or a related/linked contact. Omit it to target the current contact. Unrecognized values are rejected at import with `Invalid Action property value. Path: Actions[0].Parameters.TargetContact`. |
+
+Example targeting a related contact:
+```json
+{
+  "Identifier": "set-attrs-related",
+  "Type": "UpdateContactAttributes",
+  "Parameters": {
+    "TargetContact": "Related",
+    "Attributes": {
+      "linkedFlag": "true"
+    }
+  },
+  "Transitions": {
+    "NextAction": "next-block",
+    "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "next-block"}]
+  }
+}
+```
+
 ### Error Types
 - **NoMatchingError**: Failed to set attributes (32KB limit exceeded, invalid values)
 

--- a/knowledge-base-docs/contact-flow/blocks/transfer/transfer-contact-to-queue.md
+++ b/knowledge-base-docs/contact-flow/blocks/transfer/transfer-contact-to-queue.md
@@ -11,9 +11,7 @@ The TransferContactToQueue block transfers the contact to a queue for agent hand
 {
   "Identifier": "transfer-queue",
   "Type": "TransferContactToQueue",
-  "Parameters": {
-    "QueueId": "{{QUEUE_ARN}}"
-  },
+  "Parameters": {},
   "Transitions": {
     "NextAction": "disconnect",
     "Errors": [
@@ -24,25 +22,27 @@ The TransferContactToQueue block transfers the contact to a queue for agent hand
 }
 ```
 
-### Required Parameters
-| Parameter | Type | Description |
-|-----------|------|-------------|
-| QueueId | String | The ARN or ID of the target queue (optional if UpdateContactTargetQueue was called first) |
+### Parameters
+TransferContactToQueue accepts **no parameters** — its `Parameters` object must be empty (`{}`). Supplying a `QueueId` (or any other property) fails import with `Invalid Action property name. Path: Actions[0].Parameters.QueueId`.
+
+The target queue is **not** set on this block. You MUST set it beforehand with an `UpdateContactTargetQueue` block (see Common Patterns below).
 
 ### Error Types
+Both of the following error types are **required** on this block (see CRITICAL Requirements). No other error types are permitted — adding a third type such as `QueueDoesNotExist` fails import with `Invalid Action error. Error: QueueDoesNotExist`.
 - **QueueAtCapacity**: The queue has reached its maximum contact limit
 - **NoMatchingError**: General error (e.g., queue doesn't exist, permissions issue)
 
 ### CRITICAL Requirements
-1. MUST have `NextAction` in Transitions - this is where the flow continues after successful transfer
-2. MUST handle `QueueAtCapacity` error for production flows
-3. MUST handle `NoMatchingError` for robustness
-4. If `QueueId` is not specified, you MUST call `UpdateContactTargetQueue` before this block
+1. MUST have `NextAction` in Transitions - this is where the flow continues after successful transfer. Omitting it fails import with `Action is missing required property. Path: Actions[0].Transitions.NextAction`.
+2. MUST handle the `QueueAtCapacity` error — this is enforced at import, not just a best practice. Without it, import fails with `Action is missing required error. Error: QueueAtCapacity, Path: Actions[0]`.
+3. MUST handle the `NoMatchingError` error — also enforced at import. Without it, import fails with `Action is missing required error. Error: NoMatchingError, Path: Actions[0]`.
+4. This block takes NO parameters. The target queue MUST be set by a preceding `UpdateContactTargetQueue` block; there is no `QueueId` (or other) parameter form.
 5. The `NextAction` typically points to a `DisconnectParticipant` block
 
 ### Common Patterns
 
-#### With UpdateContactTargetQueue (Recommended)
+#### Set Queue with UpdateContactTargetQueue, then Transfer (the only valid form)
+`UpdateContactTargetQueue` sets the queue; `TransferContactToQueue` then transfers to it with empty `Parameters`. There is no direct-`QueueId` form on the transfer block — this is the only pattern that imports.
 ```json
 {"Identifier": "set-queue", "Type": "UpdateContactTargetQueue",
  "Parameters": {"QueueId": "{{QUEUE_ARN}}"},
@@ -50,15 +50,6 @@ The TransferContactToQueue block transfers the contact to a queue for agent hand
 
 {"Identifier": "transfer-queue", "Type": "TransferContactToQueue",
  "Parameters": {},
- "Transitions": {"NextAction": "disconnect",
-   "Errors": [{"ErrorType": "QueueAtCapacity", "NextAction": "queue-full"},
-              {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]}}
-```
-
-#### Direct Queue Specification
-```json
-{"Identifier": "transfer-queue", "Type": "TransferContactToQueue",
- "Parameters": {"QueueId": "arn:aws:connect:us-east-1:123456789012:instance/xxx/queue/yyy"},
  "Transitions": {"NextAction": "disconnect",
    "Errors": [{"ErrorType": "QueueAtCapacity", "NextAction": "queue-full"},
               {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]}}

--- a/knowledge-base-docs/contact-flow/patterns/callback-pattern.md
+++ b/knowledge-base-docs/contact-flow/patterns/callback-pattern.md
@@ -8,31 +8,31 @@ The callback pattern allows customers to receive a callback instead of waiting o
 
 ## Key Components
 
-1. **UpdateContactCallbackNumber** - Sets the phone number for callback
-2. **TransferContactToQueue** - Creates the callback contact in the queue
+1. **UpdateContactTargetQueue** - Sets the queue the contact will be transferred to (takes the queue ARN)
+2. **TransferContactToQueue** - Transfers the contact into the queue already set on it (takes **no** QueueId)
+3. **UpdateContactCallbackNumber** - Sets the phone number for the callback
+4. **CreateCallbackContact** - Creates the callback contact in the queue
 
-## CRITICAL: There is NO CreateCallbackContact Block!
-Callbacks are created by calling UpdateContactCallbackNumber followed by TransferContactToQueue.
+## How Callbacks Are Created
+`CreateCallbackContact` is a real, valid block. Set the callback number with `UpdateContactCallbackNumber`, then create the callback with `CreateCallbackContact` (which requires `InitialCallDelaySeconds`, `MaximumConnectionAttempts`, and `RetryDelaySeconds`).
 
 ## Complete Pattern Implementation
 
 ```json
 {
   "Version": "2019-10-30",
-  "StartAction": "check-staffing",
+  "StartAction": "set-queue",
   "Metadata": {
     "entryPointPosition": {"x": 40, "y": 40},
     "ActionMetadata": {
-      "check-staffing": {"position": {"x": 280, "y": 40}, "isFriendlyName": true},
+      "set-queue": {"position": {"x": 280, "y": 40}, "isFriendlyName": true},
       "transfer-queue": {"position": {"x": 0, "y": 300}, "isFriendlyName": true},
-      "no-agents": {"position": {"x": 560, "y": 300}, "isFriendlyName": true},
       "offer-callback": {"position": {"x": 560, "y": 560}, "isFriendlyName": true},
       "callback-confirm": {"position": {"x": 280, "y": 820}, "isFriendlyName": true},
       "set-callback": {"position": {"x": 280, "y": 1080}, "isFriendlyName": true},
       "create-callback": {"position": {"x": 280, "y": 1340}, "isFriendlyName": true},
       "callback-scheduled": {"position": {"x": 280, "y": 1600}, "isFriendlyName": true},
       "invalid-callback": {"position": {"x": 560, "y": 1340}, "isFriendlyName": true},
-      "queue-full": {"position": {"x": -280, "y": 560}, "isFriendlyName": true},
       "error-handler": {"position": {"x": 840, "y": 560}, "isFriendlyName": true},
       "disconnect": {"position": {"x": 280, "y": 1860}, "isFriendlyName": true}
     },
@@ -43,45 +43,24 @@ Callbacks are created by calling UpdateContactCallbackNumber followed by Transfe
   },
   "Actions": [
     {
-      "Identifier": "check-staffing",
-      "Type": "CheckStaffing",
-      "Parameters": {},
+      "Identifier": "set-queue",
+      "Type": "UpdateContactTargetQueue",
+      "Parameters": {"QueueId": "{{QUEUE_ARN}}"},
       "Transitions": {
-        "Conditions": [
-          {"Condition": {"Operator": "Equals", "Operands": ["True"]}, "NextAction": "transfer-queue"},
-          {"Condition": {"Operator": "Equals", "Operands": ["False"]}, "NextAction": "no-agents"}
-        ],
+        "NextAction": "transfer-queue",
         "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]
       }
     },
     {
       "Identifier": "transfer-queue",
       "Type": "TransferContactToQueue",
-      "Parameters": {"QueueId": "{{QUEUE_ARN}}"},
+      "Parameters": {},
       "Transitions": {
         "NextAction": "disconnect",
         "Errors": [
-          {"ErrorType": "QueueAtCapacity", "NextAction": "queue-full"},
+          {"ErrorType": "QueueAtCapacity", "NextAction": "offer-callback"},
           {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
         ]
-      }
-    },
-    {
-      "Identifier": "no-agents",
-      "Type": "MessageParticipant",
-      "Parameters": {"Text": "All our agents are currently busy."},
-      "Transitions": {
-        "NextAction": "offer-callback",
-        "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "offer-callback"}]
-      }
-    },
-    {
-      "Identifier": "queue-full",
-      "Type": "MessageParticipant",
-      "Parameters": {"Text": "We are experiencing high call volume."},
-      "Transitions": {
-        "NextAction": "offer-callback",
-        "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "offer-callback"}]
       }
     },
     {
@@ -89,8 +68,8 @@ Callbacks are created by calling UpdateContactCallbackNumber followed by Transfe
       "Type": "GetParticipantInput",
       "Parameters": {
         "Text": "Press 1 to receive a callback when an agent is available, or press 2 to continue waiting.",
-        "InputTimeLimitSeconds": "10",
-        "DTMFConfiguration": {"DisableCancelKey": false}
+        "StoreInput": "False",
+        "InputTimeLimitSeconds": "10"
       },
       "Transitions": {
         "NextAction": "disconnect",
@@ -121,20 +100,22 @@ Callbacks are created by calling UpdateContactCallbackNumber followed by Transfe
       "Transitions": {
         "NextAction": "create-callback",
         "Errors": [
-          {"ErrorType": "InvalidNumber", "NextAction": "invalid-callback"},
-          {"ErrorType": "NotDialable", "NextAction": "invalid-callback"},
-          {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
+          {"ErrorType": "InvalidCallbackNumber", "NextAction": "invalid-callback"},
+          {"ErrorType": "CallbackNumberNotDialable", "NextAction": "invalid-callback"}
         ]
       }
     },
     {
       "Identifier": "create-callback",
-      "Type": "TransferContactToQueue",
-      "Parameters": {"QueueId": "{{QUEUE_ARN}}"},
+      "Type": "CreateCallbackContact",
+      "Parameters": {
+        "InitialCallDelaySeconds": "20",
+        "MaximumConnectionAttempts": "3",
+        "RetryDelaySeconds": "60"
+      },
       "Transitions": {
         "NextAction": "callback-scheduled",
         "Errors": [
-          {"ErrorType": "QueueAtCapacity", "NextAction": "invalid-callback"},
           {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
         ]
       }
@@ -178,41 +159,51 @@ Callbacks are created by calling UpdateContactCallbackNumber followed by Transfe
 
 ## UpdateContactCallbackNumber Error Handling
 
-CRITICAL: UpdateContactCallbackNumber requires handling THREE error types:
+CRITICAL: UpdateContactCallbackNumber requires exactly TWO error types — `InvalidCallbackNumber` and `CallbackNumberNotDialable`. `NoMatchingError` is NOT allowed on this block (the API rejects it), and there are no `InvalidNumber`/`NotDialable` error types.
 
 ```json
 {
   "Errors": [
-    {"ErrorType": "InvalidNumber", "NextAction": "invalid-callback"},
-    {"ErrorType": "NotDialable", "NextAction": "invalid-callback"},
-    {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
+    {"ErrorType": "InvalidCallbackNumber", "NextAction": "invalid-callback"},
+    {"ErrorType": "CallbackNumberNotDialable", "NextAction": "invalid-callback"}
   ]
 }
 ```
 
 | Error Type | Description | Common Cause |
 |------------|-------------|--------------|
-| InvalidNumber | Format is invalid | Missing country code, wrong format |
-| NotDialable | Valid but can't dial | Blocked numbers, out of service area |
-| NoMatchingError | General failure | Permissions, service issue |
+| InvalidCallbackNumber | Format is invalid | Missing country code, wrong format |
+| CallbackNumberNotDialable | Valid but can't dial | Blocked numbers, out of service area |
 
-## NON-EXISTENT Block Warning
+## Creating the Callback Contact
 
-WRONG:
+`CreateCallbackContact` IS a valid block Type. It requires three parameters — `InitialCallDelaySeconds`, `MaximumConnectionAttempts`, and `RetryDelaySeconds`:
+
 ```json
-{"Type": "CreateCallbackContact"}  // DOES NOT EXIST!
+{
+  "Identifier": "create-callback",
+  "Type": "CreateCallbackContact",
+  "Parameters": {
+    "InitialCallDelaySeconds": "20",
+    "MaximumConnectionAttempts": "3",
+    "RetryDelaySeconds": "60"
+  },
+  "Transitions": {
+    "NextAction": "callback-scheduled",
+    "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]
+  }
+}
 ```
 
-CORRECT:
-```json
-{"Type": "UpdateContactCallbackNumber"}  // Step 1: Set the number
-// followed by
-{"Type": "TransferContactToQueue"}  // Step 2: Creates the callback
-```
+## Queue Transfer Note
+
+`TransferContactToQueue` takes NO `QueueId` parameter — it transfers the contact to the queue already set on it. Set the queue first with `UpdateContactTargetQueue` (which takes the queue ARN as `QueueId`), then call `TransferContactToQueue` with empty `Parameters`.
 
 ## Callback with Custom Number Collection
 
 If you want to allow customers to enter a different callback number:
+
+When you store input, `GetParticipantInput` runs in **store mode**: set `StoreInput` to `"True"`, supply an `InputValidation` block, and the only error type allowed is `NoMatchingError` (store mode does not accept `InputTimeLimitExceeded` or `NoMatchingCondition`). There is no `DTMFConfiguration` property on this block.
 
 ```json
 {
@@ -220,14 +211,13 @@ If you want to allow customers to enter a different callback number:
   "Type": "GetParticipantInput",
   "Parameters": {
     "Text": "Please enter the 10-digit phone number where you'd like to receive a callback, followed by the pound key.",
+    "StoreInput": "True",
     "InputTimeLimitSeconds": "30",
-    "DTMFConfiguration": {"InputTerminationSequence": "#"}
+    "InputValidation": {"CustomValidation": {"MaximumLength": "10"}}
   },
   "Transitions": {
     "NextAction": "set-custom-callback",
     "Errors": [
-      {"ErrorType": "InputTimeLimitExceeded", "NextAction": "use-current-number"},
-      {"ErrorType": "NoMatchingCondition", "NextAction": "set-custom-callback"},
       {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
     ]
   }
@@ -240,9 +230,8 @@ If you want to allow customers to enter a different callback number:
   "Transitions": {
     "NextAction": "create-callback",
     "Errors": [
-      {"ErrorType": "InvalidNumber", "NextAction": "invalid-number-retry"},
-      {"ErrorType": "NotDialable", "NextAction": "invalid-number-retry"},
-      {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
+      {"ErrorType": "InvalidCallbackNumber", "NextAction": "invalid-number-retry"},
+      {"ErrorType": "CallbackNumberNotDialable", "NextAction": "invalid-number-retry"}
     ]
   }
 }
@@ -250,11 +239,12 @@ If you want to allow customers to enter a different callback number:
 
 ## Related Topics
 - UpdateContactCallbackNumber
+- CreateCallbackContact
+- UpdateContactTargetQueue
 - TransferContactToQueue
-- CheckStaffing
 - GetParticipantInput
 
 ---
 **Metadata**
 - Category: Pattern
-- Keywords: callback, queue callback, UpdateContactCallbackNumber, InvalidNumber, NotDialable
+- Keywords: callback, queue callback, UpdateContactCallbackNumber, CreateCallbackContact, InvalidCallbackNumber, CallbackNumberNotDialable

--- a/knowledge-base-docs/contact-flow/patterns/q-in-connect-self-service.md
+++ b/knowledge-base-docs/contact-flow/patterns/q-in-connect-self-service.md
@@ -21,8 +21,9 @@ This pattern implements AI-powered self-service using Amazon Q in Connect (forme
 11. **ConnectParticipantWithLexBot** - Q in Connect AI interaction
 12. **Compare** - Check Lex result for escalation
 13. **UpdateContactAttributes** - Set context for agent
-14. **TransferContactToQueue** - Escalate to agent
-15. **DisconnectParticipant** - End contact
+14. **UpdateContactTargetQueue** - Set the working queue (carries the queue ARN)
+15. **TransferContactToQueue** - Escalate to agent (takes NO parameters)
+16. **DisconnectParticipant** - End contact
 
 ## Complete JSON Implementation
 
@@ -54,6 +55,7 @@ This pattern implements AI-powered self-service using Amazon Q in Connect (forme
       "check-result": {"position": {"x": 280, "y": 2380}, "isFriendlyName": true},
       "set-context": {"position": {"x": 0, "y": 2640}, "isFriendlyName": true},
       "transfer-message": {"position": {"x": 0, "y": 2900}, "isFriendlyName": true},
+      "set-queue": {"position": {"x": 0, "y": 3030}, "isFriendlyName": true},
       "transfer-queue": {"position": {"x": 0, "y": 3160}, "isFriendlyName": true},
       "goodbye": {"position": {"x": 560, "y": 2640}, "isFriendlyName": true},
       "error-handler": {"position": {"x": 840, "y": 1600}, "isFriendlyName": true},
@@ -208,7 +210,10 @@ This pattern implements AI-powered self-service using Amazon Q in Connect (forme
       },
       "Transitions": {
         "NextAction": "check-result",
-        "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]
+        "Errors": [
+          {"ErrorType": "NoMatchingCondition", "NextAction": "check-result"},
+          {"ErrorType": "NoMatchingError", "NextAction": "error-handler"}
+        ]
       }
     },
     {
@@ -244,14 +249,23 @@ This pattern implements AI-powered self-service using Amazon Q in Connect (forme
       "Type": "MessageParticipant",
       "Parameters": {"Text": "Please hold while I transfer you to an agent."},
       "Transitions": {
+        "NextAction": "set-queue",
+        "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "set-queue"}]
+      }
+    },
+    {
+      "Identifier": "set-queue",
+      "Type": "UpdateContactTargetQueue",
+      "Parameters": {"QueueId": "{{QUEUE_ARN}}"},
+      "Transitions": {
         "NextAction": "transfer-queue",
-        "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "transfer-queue"}]
+        "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error-handler"}]
       }
     },
     {
       "Identifier": "transfer-queue",
       "Type": "TransferContactToQueue",
-      "Parameters": {"QueueId": "{{QUEUE_ARN}}"},
+      "Parameters": {},
       "Transitions": {
         "NextAction": "disconnect",
         "Errors": [
@@ -297,8 +311,10 @@ This pattern implements AI-powered self-service using Amazon Q in Connect (forme
 | Contact Lens (AnalyticsModes) | Voice: `["PostContact"]` | Chat: `["ContactLens"]` |
 | Profile Lookup | _phone | _email |
 
-> ⚠️ Do NOT use `RealTime` in Voice `AnalyticsModes` — Amazon Connect rejects it on
-> import unless real-time Contact Lens preconditions are met. Use `["PostContact"]`.
+> ⚠️ `RealTime` in Voice `AnalyticsModes` passes CreateContactFlow structural
+> validation (it does **not** fail import), but it requires real-time Contact Lens
+> to be enabled on the instance — otherwise it fails at contact runtime. Use
+> `["PostContact"]` unless real-time Contact Lens is provisioned.
 
 ### Lex Session Attributes for Escalation
 The Lex bot should set these attributes:
@@ -307,10 +323,22 @@ The Lex bot should set these attributes:
 - `escalationReason`: Why escalating to agent
 - `conversationSummary`: Summary for agent
 
+### Escalation: setting the queue
+`TransferContactToQueue` takes **no** parameters — it transfers to whatever the
+*working queue* currently is. Set that queue with a preceding
+`UpdateContactTargetQueue` block carrying `{"QueueId": "{{QUEUE_ARN}}"}`. Passing
+`QueueId` (or `QueueArn`) directly on `TransferContactToQueue` fails import with
+`Invalid Action property name`.
+
+### ConnectParticipantWithLexBot error handling
+`ConnectParticipantWithLexBot` requires **both** required error types in
+`Transitions.Errors` — `NoMatchingCondition` **and** `NoMatchingError`. Omitting
+either one fails import with `Action is missing required error`.
+
 ### Required Placeholders
 - `{{WISDOM_ASSISTANT_ARN}}`: Connect Assistant (Wisdom) domain ARN
 - `{{LEX_BOT_ALIAS_ARN}}`: Q in Connect Lex bot alias ARN
-- `{{QUEUE_ARN}}`: Target queue for escalation
+- `{{QUEUE_ARN}}`: Target queue for escalation (consumed by `UpdateContactTargetQueue`, not `TransferContactToQueue`)
 - `{{UPDATE_Q_SESSION_LAMBDA}}`: Lambda to update Q session data
 - `{{WELCOME_MESSAGE}}`: Welcome message for customers
 
@@ -318,6 +346,8 @@ The Lex bot should set these attributes:
 - UpdateContactRecordingBehavior
 - GetCustomerProfile
 - ConnectParticipantWithLexBot
+- UpdateContactTargetQueue
+- TransferContactToQueue
 - Compare Block
 
 ---

--- a/knowledge-base-docs/contact-flow/patterns/q-in-connect-self-service.md
+++ b/knowledge-base-docs/contact-flow/patterns/q-in-connect-self-service.md
@@ -109,7 +109,7 @@ This pattern implements AI-powered self-service using Amazon Q in Connect (forme
       "Parameters": {
         "RecordingBehavior": {"RecordedParticipants": ["Agent", "Customer"], "IVRRecordingBehavior": "Enabled"},
         "AnalyticsBehavior": {"Enabled": "True", "AnalyticsLanguage": "en-US",
-          "ChannelConfiguration": {"Chat": {"AnalyticsModes": []}, "Voice": {"AnalyticsModes": ["PostContact"]}}}
+          "ChannelConfiguration": {"Chat": {"AnalyticsModes": []}, "Voice": {"AnalyticsModes": ["RealTime"]}}}
       },
       "Transitions": {"NextAction": "get-profile"}
     },
@@ -308,13 +308,14 @@ This pattern implements AI-powered self-service using Amazon Q in Connect (forme
 | Feature | VOICE | CHAT |
 |---------|-------|------|
 | Recording | Agent + Customer | None |
-| Contact Lens (AnalyticsModes) | Voice: `["PostContact"]` | Chat: `["ContactLens"]` |
+| Contact Lens (AnalyticsModes) | Voice: `["RealTime"]` | Chat: `["ContactLens"]` |
 | Profile Lookup | _phone | _email |
 
-> ⚠️ `RealTime` in Voice `AnalyticsModes` passes CreateContactFlow structural
-> validation (it does **not** fail import), but it requires real-time Contact Lens
-> to be enabled on the instance — otherwise it fails at contact runtime. Use
-> `["PostContact"]` unless real-time Contact Lens is provisioned.
+> ⚠️ Voice `AnalyticsModes` takes EXACTLY ONE mode — `["RealTime"]` OR `["PostContact"]`,
+> never both (the combined array fails import) and never empty. **Prefer `["RealTime"]`
+> for Q in Connect voice flows** so the assistant and any escalated human get live
+> transcript + sentiment. `RealTime` requires real-time Contact Lens enabled on the
+> instance (enforced at runtime, not at import); use `["PostContact"]` if it is not provisioned.
 
 ### Lex Session Attributes for Escalation
 The Lex bot should set these attributes:


### PR DESCRIPTION
## Summary

This branch brings the Contact Flow generation pipeline into alignment with the Amazon Connect **CreateContactFlow** API, alongside earlier repo-hardening, docs, and UX work that had accumulated on this line.

### Headline: Contact Flow schema alignment (latest commit)
The Contact Flow **knowledge base**, **generator system prompt**, and **deterministic linter** were validated against the live `CreateContactFlow` API — single-block imports (every parameter present / invalid / absent) and full worked-example flows — and refined so generated flows import cleanly. All validation flows were created on a workshop/dev instance and auto-deleted; no resources left behind.

Improvements:
- **Broaden block coverage** across all API-verified action types (e.g. add `DequeueContactAndTransferToQueue` to the linter's valid set + required-error map).
- **Sharpen per-block required errors** — `UpdateContactCallbackNumber` → `InvalidCallbackNumber` + `CallbackNumberNotDialable`; plus `GetCustomerProfile`, `AuthenticateParticipant`, `CheckOutboundCallStatus`, `DistributeByPercentage`, `EvaluateDataTableValues`, `GetCustomerProfileObject`, `LoadContactContent`, `CreatePersistentContactAssociation`, `UpdateContactRoutingCriteria`.
- **Clarify parameter shapes & value domains** — `TransferContactToQueue` takes no `QueueId` (set via `UpdateContactTargetQueue`); `Compare` operators `Text*` / `Number*OrEqualTo`; `CheckMetricData.MetricType` five-value enum; `InvokeLambda` `ResponseType` accepts `STRING_MAP` or `JSON`; `GetParticipantInput` needs `InputTimeLimitSeconds` and a string `DisableCancelKey`; `Loop`/`Wait` need `NextAction`; recording `AnalyticsModes` tuned for import.
- **Re-verify every corrected worked-example flow** imports via `CreateContactFlow`.

### Also on this branch
Repo hardening and docs polish (security fix for attachment path validation, docs set streamlining, workshop guide link, dropping the Playwright e2e harness), plus the broader v2.x feature/UX work that had built up here.

## Testing
- `pytest tests/test_contact_flow_linter.py tests/test_shape_parity.py` — 46 passed.
- Corrected knowledge-base examples and the generator's headline flow example re-imported successfully against the real `CreateContactFlow` API.

_Note: generated Contact Flows are starting points — review and scope before production use (see README Security section)._