### PR TITLE
feat: Claude Opus 5 in the model selector + self-service password reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Then trigger with `/aicc-builder`. Full install + usage details:
 Runtime highlights:
 
 - Runtime: ECS Fargate (ARM64 Graviton) running FastAPI + Uvicorn
-- Model: **Claude Opus** on Amazon Bedrock — selectable per session: **Opus 4.8** (default, `global.anthropic.claude-opus-4-8`), **4.7** (`global.anthropic.claude-opus-4-7`), or **4.6** (`global.anthropic.claude-opus-4-6-v1`) — applied to the orchestrator and every sub-agent, with cross-region inference + prompt caching
+- Model: **Claude Opus** on Amazon Bedrock — selectable per session: **Opus 5** (`global.anthropic.claude-opus-5`), **4.8** (default, `global.anthropic.claude-opus-4-8`), **4.7** (`global.anthropic.claude-opus-4-7`), or **4.6** (`global.anthropic.claude-opus-4-6-v1`) — applied to the orchestrator and every sub-agent, with cross-region inference + prompt caching
 - WebSocket: ALB with Cognito JWT (sticky sessions, 4h idle timeout), proxied same-origin through CloudFront
 - Session storage: 3-tier — in-memory → S3 Files NFS (`/mnt/s3/`) → DynamoDB
 - Contact Flow RAG: Bedrock Knowledge Base backed by **Amazon S3 Vectors** (replaced OpenSearch Serverless in v2.1 — far lower idle cost for a small, infrequently-queried corpus). The ECS task gets `CONTACT_FLOW_KB_ID` two ways: `deploy.sh` injects it from the KB stack output, and (v2.2) the KB stack also publishes it to SSM for the task to resolve at startup — so RAG stays on even when the deploy-time output isn't resolvable (e.g. KB stack deployed separately)
@@ -384,14 +384,23 @@ cd backend/ecs && uvicorn app:app --port 8080
 
 ```bash
 # UserPoolId is printed by deploy.sh
+#
+# NOTE: the pool uses email as an ALIAS, so `--username` must NOT be an email
+# address (Cognito rejects it with InvalidParameterException). Use a plain
+# username and attach the email as an attribute — `email_verified=true` is what
+# makes sign-in by email (and the "Forgot password?" flow) work.
 aws cognito-idp admin-create-user \
   --user-pool-id <UserPoolId> \
-  --username <email> \
-  --user-attributes Name=email,Value=<email> \
+  --username <username> \
+  --user-attributes Name=email,Value=<email> Name=email_verified,Value=true \
   --temporary-password "TempPass123!" \
   --message-action SUPPRESS \
   --region ap-northeast-2
 ```
+
+The user signs in with `<email>` and is prompted to set a new password on first
+login. Password policy: 8+ characters with an uppercase letter, a lowercase
+letter, and a number (no symbol required).
 
 ---
 
@@ -412,7 +421,7 @@ aws cognito-idp admin-create-user \
 
 | Layer | Technologies |
 |---|---|
-| **AI** | Strands Agents SDK · **Claude Opus 4.8 (default), 4.7, 4.6** on Amazon Bedrock (`global.anthropic.claude-opus-4-8`, cross-region inference) · Context Engineering (CLUES format) |
+| **AI** | Strands Agents SDK · **Claude Opus 5, 4.8 (default), 4.7, 4.6** on Amazon Bedrock (`global.anthropic.claude-opus-4-8`, cross-region inference) · Context Engineering (CLUES format) |
 | **Frontend** | React 18 · TypeScript · Vite · Tailwind CSS · Zustand · React Flow |
 | **Backend** | Python 3.11 · FastAPI · Uvicorn · S3 Files NFS · DynamoDB |
 | **Infra** | AWS CDK · CloudFront · Cognito · ECS Fargate · ALB · X-Ray |
@@ -684,6 +693,27 @@ export S3FILES_MOUNT_PATH=/tmp/s3files SESSION_STORE_BACKEND=s3files
 cd backend/ecs && uvicorn app:app --port 8080
 # wscat -c "ws://localhost:8080/ws?sessionId=test-1"
 ```
+
+### 관리자 사용자 생성
+
+```bash
+# UserPoolId는 deploy.sh 출력에 표시됩니다
+#
+# 주의: 이 유저풀은 이메일을 ALIAS로 사용하므로 `--username`에 이메일 주소를
+# 넣을 수 없습니다(InvalidParameterException으로 거부됩니다). username은 일반
+# 문자열로 두고 이메일은 속성으로 넣으세요. 이메일 로그인과 "비밀번호를
+# 잊으셨나요?" 플로우는 `email_verified=true`가 있어야 동작합니다.
+aws cognito-idp admin-create-user \
+  --user-pool-id <UserPoolId> \
+  --username <username> \
+  --user-attributes Name=email,Value=<email> Name=email_verified,Value=true \
+  --temporary-password "TempPass123!" \
+  --message-action SUPPRESS \
+  --region ap-northeast-2
+```
+
+사용자는 `<email>`로 로그인하며 첫 로그인 시 새 비밀번호를 설정하게 됩니다.
+비밀번호 정책: 8자 이상, 대문자·소문자·숫자 각 1자 이상(특수문자 불필요).
 
 ---
 
@@ -1027,14 +1057,24 @@ cd backend/ecs && uvicorn app:app --port 8080
 
 ```bash
 # UserPoolId は deploy.sh の出力に表示されます
+#
+# 注意: このユーザープールはメールを ALIAS として使うため、`--username` に
+# メールアドレスは指定できません（InvalidParameterException になります）。
+# username は通常の文字列にし、メールは属性として付与してください。
+# `email_verified=true` があって初めてメールでのサインイン（および
+# 「パスワードをお忘れですか?」）が機能します。
 aws cognito-idp admin-create-user \
   --user-pool-id <UserPoolId> \
-  --username <email> \
-  --user-attributes Name=email,Value=<email> \
+  --username <username> \
+  --user-attributes Name=email,Value=<email> Name=email_verified,Value=true \
   --temporary-password "TempPass123!" \
   --message-action SUPPRESS \
   --region ap-northeast-2
 ```
+
+ユーザーは `<email>` でサインインし、初回ログイン時に新しいパスワードの設定を
+求められます。パスワードポリシー: 8 文字以上、大文字・小文字・数字を各 1 つ以上
+（記号は不要）。
 
 ---
 

--- a/backend/ecs/src/tools/model_selection.py
+++ b/backend/ecs/src/tools/model_selection.py
@@ -8,7 +8,7 @@ same id.
 
 API quirk this module exists to handle:
   * Opus 4.6 **accepts** ``temperature``.
-  * Opus 4.7 and 4.8 **removed** ``temperature`` — sending it returns HTTP 400.
+  * Opus 4.7, 4.8 and 5 **removed** ``temperature`` — sending it returns HTTP 400.
 
 So model construction must conditionally include ``temperature``. ``build_model_kwargs``
 centralizes that branch: every construction site routes through it, passing whatever
@@ -32,6 +32,7 @@ logger = logging.getLogger(__name__)
 # region) — note 4.6 carries a `-v1` suffix while 4.7/4.8 do not. Using the wrong
 # form 404s at invoke time.
 ALLOWED_MODEL_IDS = {
+    "global.anthropic.claude-opus-5",
     "global.anthropic.claude-opus-4-8",
     "global.anthropic.claude-opus-4-7",
     "global.anthropic.claude-opus-4-6-v1",
@@ -41,8 +42,11 @@ ALLOWED_MODEL_IDS = {
 DEFAULT_MODEL_ID = "global.anthropic.claude-opus-4-8"
 
 # Models that REMOVED the `temperature` parameter (sending it → HTTP 400).
-# Opus 4.6 still ACCEPTS temperature; 4.7 and 4.8 removed it.
+# Opus 4.6 still ACCEPTS temperature; 4.7, 4.8 and 5 removed it (verified live
+# against Converse in ap-northeast-2: Opus 5 returns ValidationException
+# "`temperature` is deprecated for this model").
 MODELS_WITHOUT_TEMPERATURE = {
+    "global.anthropic.claude-opus-5",
     "global.anthropic.claude-opus-4-8",
     "global.anthropic.claude-opus-4-7",
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -13,7 +13,8 @@ import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuthStore } from "../stores/authStore";
 import { useBuilderStore } from "../stores/builderStore";
-import { Loader2, Lock, Mail, Eye, EyeOff, AlertCircle, Globe, Check, X } from "lucide-react";
+import { requestPasswordReset, confirmPasswordReset } from "../services/auth";
+import { Loader2, Lock, Mail, Eye, EyeOff, AlertCircle, Globe, Check, X, KeyRound } from "lucide-react";
 import type { Language } from "../types";
 import { LANGUAGES } from "../types";
 import { cn } from "../lib/utils";
@@ -45,6 +46,21 @@ const STRINGS: Record<Language, Record<string, string>> = {
     policyUpper: 'An uppercase letter',
     policyLower: 'A lowercase letter',
     policyNum: 'A number',
+    forgotLink: 'Forgot your password?',
+    resetTitle: 'Reset Password',
+    resetSubtitle: "Enter your email and we'll send you a verification code",
+    sendCode: 'Send Verification Code',
+    sendingCode: 'Sending code…',
+    enterEmail: 'Please enter your email',
+    resetConfirmTitle: 'Enter Verification Code',
+    resetConfirmSubtitle: 'Check your email for the code, then set a new password',
+    code: 'Verification Code',
+    codePlaceholder: 'Enter the 6-digit code',
+    enterCode: 'Please enter the verification code',
+    resetPassword: 'Reset Password',
+    resettingPassword: 'Resetting password…',
+    resetDone: 'Password reset. Please sign in with your new password.',
+    backToSignIn: 'Back to sign in',
   },
   'ko-KR': {
     title: 'AICC Builder',
@@ -72,6 +88,21 @@ const STRINGS: Record<Language, Record<string, string>> = {
     policyUpper: '대문자 포함',
     policyLower: '소문자 포함',
     policyNum: '숫자 포함',
+    forgotLink: '비밀번호를 잊으셨나요?',
+    resetTitle: '비밀번호 재설정',
+    resetSubtitle: '이메일을 입력하시면 인증 코드를 보내드립니다',
+    sendCode: '인증 코드 받기',
+    sendingCode: '인증 코드 전송 중…',
+    enterEmail: '이메일을 입력하세요',
+    resetConfirmTitle: '인증 코드 입력',
+    resetConfirmSubtitle: '이메일로 받은 코드를 입력하고 새 비밀번호를 설정하세요',
+    code: '인증 코드',
+    codePlaceholder: '6자리 코드를 입력하세요',
+    enterCode: '인증 코드를 입력하세요',
+    resetPassword: '비밀번호 재설정',
+    resettingPassword: '비밀번호 재설정 중…',
+    resetDone: '비밀번호가 재설정되었습니다. 새 비밀번호로 로그인하세요.',
+    backToSignIn: '로그인으로 돌아가기',
   },
   'ja-JP': {
     title: 'AICC Builder',
@@ -99,6 +130,21 @@ const STRINGS: Record<Language, Record<string, string>> = {
     policyUpper: '大文字を含む',
     policyLower: '小文字を含む',
     policyNum: '数字を含む',
+    forgotLink: 'パスワードをお忘れですか?',
+    resetTitle: 'パスワードの再設定',
+    resetSubtitle: 'メールアドレスを入力すると確認コードを送信します',
+    sendCode: '確認コードを送信',
+    sendingCode: '確認コード送信中…',
+    enterEmail: 'メールアドレスを入力してください',
+    resetConfirmTitle: '確認コードの入力',
+    resetConfirmSubtitle: 'メールに届いたコードを入力し、新しいパスワードを設定してください',
+    code: '確認コード',
+    codePlaceholder: '6桁のコードを入力',
+    enterCode: '確認コードを入力してください',
+    resetPassword: 'パスワードを再設定',
+    resettingPassword: 'パスワード再設定中…',
+    resetDone: 'パスワードを再設定しました。新しいパスワードでサインインしてください。',
+    backToSignIn: 'サインインに戻る',
   },
 };
 
@@ -138,6 +184,13 @@ export function LoginPage() {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
+
+  // Self-service password reset (Cognito forgotPassword / confirmPassword).
+  // 'request' = ask for the code, 'confirm' = code + new password.
+  const [resetStage, setResetStage] = useState<null | 'request' | 'confirm'>(null);
+  const [resetCode, setResetCode] = useState("");
+  const [resetBusy, setResetBusy] = useState(false);
+  const [notice, setNotice] = useState<string | null>(null);
 
   // Redirect if already authenticated
   useEffect(() => {
@@ -183,8 +236,76 @@ export function LoginPage() {
     if (success) navigate("/");
   };
 
-  const displayError = localError || error;
+  const openReset = () => {
+    setLocalError(null);
+    setNotice(null);
+    clearError();
+    setNewPasswordValue("");
+    setConfirmPassword("");
+    setResetCode("");
+    setResetStage('request');
+  };
 
+  const closeReset = () => {
+    setLocalError(null);
+    setNotice(null);
+    clearError();
+    setResetStage(null);
+    setResetCode("");
+    setNewPasswordValue("");
+    setConfirmPassword("");
+  };
+
+  const handleResetRequest = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLocalError(null);
+    setNotice(null);
+    clearError();
+    if (!email) {
+      setLocalError(t.enterEmail);
+      return;
+    }
+    setResetBusy(true);
+    const res = await requestPasswordReset(email);
+    setResetBusy(false);
+    if (res.success) {
+      setResetStage('confirm');
+    } else {
+      setLocalError(res.error || t.enterEmail);
+    }
+  };
+
+  const handleResetConfirm = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLocalError(null);
+    setNotice(null);
+    clearError();
+    if (!resetCode) {
+      setLocalError(t.enterCode);
+      return;
+    }
+    if (!newPasswordValue || !confirmPassword) {
+      setLocalError(t.enterConfirm);
+      return;
+    }
+    if (newPasswordValue !== confirmPassword) {
+      setLocalError(t.noMatch);
+      return;
+    }
+    if (!policyOk) return;
+    setResetBusy(true);
+    const res = await confirmPasswordReset(email, resetCode, newPasswordValue);
+    setResetBusy(false);
+    if (res.success) {
+      closeReset();
+      setPassword("");
+      setNotice(t.resetDone);
+    } else {
+      setLocalError(res.error || t.resetPassword);
+    }
+  };
+
+  const displayError = localError || error;
   const inputClasses =
     'w-full pl-10 pr-12 py-3 bg-surface-50 dark:bg-surface-900 border border-surface-300 dark:border-surface-600 rounded-lg ' +
     'text-surface-900 dark:text-surface-100 placeholder-surface-400 dark:placeholder-surface-500 ' +
@@ -209,6 +330,191 @@ export function LoginPage() {
       </div>
     </div>
   );
+
+  const ErrorBanner = displayError ? (
+    <div role="alert" aria-live="assertive" className="mb-6 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg flex items-start gap-3">
+      <AlertCircle className="w-5 h-5 text-red-500 dark:text-red-400 flex-shrink-0 mt-0.5" />
+      <p className="text-red-600 dark:text-red-300 text-sm">{displayError}</p>
+    </div>
+  ) : null;
+
+  const PasswordPolicyList = (
+    <ul className="space-y-1.5 text-xs">
+      <PolicyItem ok={policy.len} label={t.policyLen} />
+      <PolicyItem ok={policy.upper} label={t.policyUpper} />
+      <PolicyItem ok={policy.lower} label={t.policyLower} />
+      <PolicyItem ok={policy.num} label={t.policyNum} />
+    </ul>
+  );
+
+  const BackToSignIn = (
+    <div className="mt-6 text-center">
+      <button
+        type="button"
+        onClick={closeReset}
+        className="text-sm text-primary-600 dark:text-primary-400 hover:underline"
+      >
+        {t.backToSignIn}
+      </button>
+    </div>
+  );
+
+  // Password reset — step 1: request a verification code by email.
+  if (resetStage === 'request') {
+    return (
+      <div className="relative min-h-screen bg-surface-50 dark:bg-gradient-dark flex items-center justify-center p-4">
+        {LanguagePicker}
+        <div className="w-full max-w-md">
+          <div className="bg-white dark:bg-surface-850 backdrop-blur-sm rounded-2xl border border-surface-200 dark:border-surface-700 p-8 shadow-xl dark:shadow-glow">
+            <div className="text-center mb-8">
+              <h1 className="text-2xl font-bold text-surface-900 dark:text-surface-100 mb-2">{t.resetTitle}</h1>
+              <p className="text-surface-500 dark:text-surface-400 text-sm">{t.resetSubtitle}</p>
+            </div>
+
+            {ErrorBanner}
+
+            <form onSubmit={handleResetRequest} className="space-y-6">
+              <div>
+                <label htmlFor="resetEmail" className="block text-sm font-medium text-surface-700 dark:text-surface-300 mb-2">
+                  {t.email}
+                </label>
+                <div className="relative">
+                  <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-surface-400" />
+                  <input
+                    id="resetEmail"
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    className={inputClasses}
+                    placeholder={t.emailPlaceholder}
+                    disabled={resetBusy}
+                    autoComplete="email"
+                  />
+                </div>
+              </div>
+
+              <button
+                type="submit"
+                disabled={resetBusy}
+                className="w-full py-3 bg-primary-600 dark:bg-primary-500 hover:bg-primary-700 dark:hover:bg-primary-600 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors flex items-center justify-center gap-2"
+              >
+                {resetBusy ? (
+                  <><Loader2 className="w-5 h-5 animate-spin" />{t.sendingCode}</>
+                ) : (
+                  t.sendCode
+                )}
+              </button>
+            </form>
+
+            {BackToSignIn}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Password reset — step 2: emailed code + new password.
+  if (resetStage === 'confirm') {
+    return (
+      <div className="relative min-h-screen bg-surface-50 dark:bg-gradient-dark flex items-center justify-center p-4">
+        {LanguagePicker}
+        <div className="w-full max-w-md">
+          <div className="bg-white dark:bg-surface-850 backdrop-blur-sm rounded-2xl border border-surface-200 dark:border-surface-700 p-8 shadow-xl dark:shadow-glow">
+            <div className="text-center mb-8">
+              <h1 className="text-2xl font-bold text-surface-900 dark:text-surface-100 mb-2">{t.resetConfirmTitle}</h1>
+              <p className="text-surface-500 dark:text-surface-400 text-sm">{t.resetConfirmSubtitle}</p>
+            </div>
+
+            {ErrorBanner}
+
+            <form onSubmit={handleResetConfirm} className="space-y-6">
+              <div>
+                <label htmlFor="resetCode" className="block text-sm font-medium text-surface-700 dark:text-surface-300 mb-2">
+                  {t.code}
+                </label>
+                <div className="relative">
+                  <KeyRound className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-surface-400" />
+                  <input
+                    id="resetCode"
+                    type="text"
+                    inputMode="numeric"
+                    value={resetCode}
+                    onChange={(e) => setResetCode(e.target.value.trim())}
+                    className={inputClasses}
+                    placeholder={t.codePlaceholder}
+                    disabled={resetBusy}
+                    autoComplete="one-time-code"
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label htmlFor="resetNewPassword" className="block text-sm font-medium text-surface-700 dark:text-surface-300 mb-2">
+                  {t.newPassword}
+                </label>
+                <div className="relative">
+                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-surface-400" />
+                  <input
+                    id="resetNewPassword"
+                    type={showPassword ? "text" : "password"}
+                    value={newPasswordValue}
+                    onChange={(e) => setNewPasswordValue(e.target.value)}
+                    className={inputClasses}
+                    placeholder={t.newPasswordPlaceholder}
+                    disabled={resetBusy}
+                    autoComplete="new-password"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    aria-label={showPassword ? 'Hide password' : 'Show password'}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-surface-400 hover:text-surface-600 dark:hover:text-surface-300"
+                  >
+                    {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
+                  </button>
+                </div>
+              </div>
+
+              <div>
+                <label htmlFor="resetConfirmPassword" className="block text-sm font-medium text-surface-700 dark:text-surface-300 mb-2">
+                  {t.confirmPassword}
+                </label>
+                <div className="relative">
+                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-surface-400" />
+                  <input
+                    id="resetConfirmPassword"
+                    type={showPassword ? "text" : "password"}
+                    value={confirmPassword}
+                    onChange={(e) => setConfirmPassword(e.target.value)}
+                    className={inputClasses}
+                    placeholder={t.confirmPlaceholder}
+                    disabled={resetBusy}
+                    autoComplete="new-password"
+                  />
+                </div>
+              </div>
+
+              {PasswordPolicyList}
+
+              <button
+                type="submit"
+                disabled={resetBusy || !policyOk}
+                className="w-full py-3 bg-primary-600 dark:bg-primary-500 hover:bg-primary-700 dark:hover:bg-primary-600 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors flex items-center justify-center gap-2"
+              >
+                {resetBusy ? (
+                  <><Loader2 className="w-5 h-5 animate-spin" />{t.resettingPassword}</>
+                ) : (
+                  t.resetPassword
+                )}
+              </button>
+            </form>
+
+            {BackToSignIn}
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   // New password form (for first-time login)
   if (needsNewPassword) {
@@ -321,6 +627,13 @@ export function LoginPage() {
             </div>
           )}
 
+          {notice && !displayError && (
+            <div role="status" aria-live="polite" className="mb-6 p-4 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg flex items-start gap-3">
+              <Check className="w-5 h-5 text-green-500 dark:text-green-400 flex-shrink-0 mt-0.5" />
+              <p className="text-green-700 dark:text-green-300 text-sm">{notice}</p>
+            </div>
+          )}
+
           <form onSubmit={handleSubmit} className="space-y-6">
             <div>
               <label htmlFor="email" className="block text-sm font-medium text-surface-700 dark:text-surface-300 mb-2">
@@ -364,6 +677,15 @@ export function LoginPage() {
                   className="absolute right-3 top-1/2 -translate-y-1/2 text-surface-400 hover:text-surface-600 dark:hover:text-surface-300"
                 >
                   {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
+                </button>
+              </div>
+              <div className="mt-2 text-right">
+                <button
+                  type="button"
+                  onClick={openReset}
+                  className="text-xs text-primary-600 dark:text-primary-400 hover:underline"
+                >
+                  {t.forgotLink}
                 </button>
               </div>
             </div>

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -15,7 +15,11 @@ import {
 // Configuration from environment variables
 const userPoolId = (import.meta as any).env?.VITE_USER_POOL_ID || "";
 const clientId = (import.meta as any).env?.VITE_USER_POOL_CLIENT_ID || "";
-const region = (import.meta as any).env?.VITE_COGNITO_REGION || "ap-northeast-1";
+// NOTE: `region` is informational only (exposed via `authConfig` for debugging).
+// amazon-cognito-identity-js derives the Cognito endpoint from the pool id's
+// region prefix, so this value never affects auth. Default matches deploy.sh's
+// default region so the debug output can't imply the wrong one.
+const region = (import.meta as any).env?.VITE_COGNITO_REGION || "ap-northeast-2";
 
 // ── Dev-only auth bypass (local E2E) ──────────────────────────────────────
 // When VITE_DEV_AUTH=1 AND running a dev build, skip Cognito entirely so the
@@ -205,6 +209,59 @@ export async function completeNewPasswordChallenge(
       resolve({
         success: false,
         error: error instanceof Error ? error.message : "Password change failed",
+      });
+    }
+  });
+}
+
+/**
+ * Start a self-service password reset.
+ *
+ * Cognito emails a verification code to the user's *verified* email
+ * (the pool's AccountRecoverySetting is `verified_email`). Users created by an
+ * admin without `email_verified=true` therefore cannot use this — Cognito
+ * replies with an InvalidParameterException about no registered/verified email.
+ */
+export async function requestPasswordReset(username: string): Promise<AuthResult> {
+  return new Promise((resolve) => {
+    try {
+      const pool = getUserPool();
+      const cognitoUser = new CognitoUser({ Username: username, Pool: pool });
+      cognitoUser.forgotPassword({
+        onSuccess: () => resolve({ success: true }),
+        onFailure: (err: Error) =>
+          resolve({ success: false, error: err.message || "Failed to start password reset" }),
+      });
+    } catch (error) {
+      resolve({
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to start password reset",
+      });
+    }
+  });
+}
+
+/**
+ * Complete a password reset with the emailed verification code.
+ */
+export async function confirmPasswordReset(
+  username: string,
+  code: string,
+  newPassword: string
+): Promise<AuthResult> {
+  return new Promise((resolve) => {
+    try {
+      const pool = getUserPool();
+      const cognitoUser = new CognitoUser({ Username: username, Pool: pool });
+      cognitoUser.confirmPassword(code, newPassword, {
+        onSuccess: () => resolve({ success: true }),
+        onFailure: (err: Error) =>
+          resolve({ success: false, error: err.message || "Failed to reset password" }),
+      });
+    } catch (error) {
+      resolve({
+        success: false,
+        error: error instanceof Error ? error.message : "Failed to reset password",
       });
     }
   });

--- a/frontend/src/stores/builderStore.ts
+++ b/frontend/src/stores/builderStore.ts
@@ -29,10 +29,11 @@ export interface ModelOption {
 }
 
 export const MODELS: ModelOption[] = [
+  { id: 'global.anthropic.claude-opus-5', label: 'Opus 5' },
   { id: 'global.anthropic.claude-opus-4-8', label: 'Opus 4.8' },
   { id: 'global.anthropic.claude-opus-4-7', label: 'Opus 4.7' },
   // NOTE: 4.6 carries the `-v1` suffix in Bedrock (verified ACTIVE inference
-  // profile in ap-northeast-2); 4.7/4.8 do not. Must match the backend allowlist.
+  // profile in ap-northeast-2); 4.7/4.8/5 do not. Must match the backend allowlist.
   { id: 'global.anthropic.claude-opus-4-6-v1', label: 'Opus 4.6' },
 ];
 


### PR DESCRIPTION
## Summary

Two user-facing additions, plus a correction to the user-creation docs that could not work against the deployed pool.

**Claude Opus 5** — `global.anthropic.claude-opus-5` added to the frontend dropdown and the backend allowlist. Default stays Opus 4.8. Opus 5 also removed `temperature`, so it joins `MODELS_WITHOUT_TEMPERATURE`; without that, any sub-agent passing a temperature would get a 400.

**Self-service password reset** — the pool already had `AccountRecoverySetting=verified_email`, but the login screen exposed no way to use it. Adds a "Forgot your password?" link and a two-step flow (email → emailed code + new password), reusing the existing live password-policy checklist so it matches the pool policy. Localized en/ko/ja.

**Docs** — the README's `admin-create-user` example cannot work against this pool: `--username <email>` is rejected with `InvalidParameterException` because email is an ALIAS attribute, and the example omitted `email_verified=true`, which is what makes both email sign-in and the reset flow work. Corrected in all language sections (the Korean section had no user-creation block at all).

Also drops the misleading `ap-northeast-1` default for `VITE_COGNITO_REGION` — the value is informational only, since `amazon-cognito-identity-js` derives the endpoint from the pool id's region prefix.

## Verification

- `npx tsc --noEmit` and `npm run build` clean.
- Opus 5 model id confirmed ACTIVE via `bedrock list-inference-profiles` in ap-northeast-2.
- Temperature behavior confirmed against the live Converse API: with `temperature` → `ValidationException: temperature is deprecated for this model`; without it, and with `output_config.effort`, the call completes (`stopReason: end_turn`).
- Backend resolver asserted: Opus 5 allowlisted, temperature dropped for it, still sent for 4.6.
- Both reset legs exercised against the live pool: `forgot-password` returns `CodeDeliveryDetails` for the verified email; `confirm-forgot-password` rejects a wrong code with `CodeMismatchException`.
- Deployed to the dev stack; the bundle served through CloudFront contains the new model option and reset strings.

## Note

Depends on nothing, but overlaps thematically with #29 (deploy-time config correctness). Reviewed independently.