### PR TITLE
fix(deps): Bump aws-cdk-lib to 2.263.0 to clear the brace-expansion advisory

### DIFF
--- a/infrastructure/package-lock.json
+++ b/infrastructure/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "dependencies": {
         "@cdklabs/generative-ai-cdk-constructs": "^0.1.314",
-        "aws-cdk-lib": "^2.262.0",
+        "aws-cdk-lib": "^2.263.0",
         "constructs": "^10.4.0"
       },
       "devDependencies": {
@@ -132,9 +132,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.262.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.262.0.tgz",
-      "integrity": "sha512-6zRVoWRd8kQs9ZZ9xhERSm36W8uWS2vW3/g9Zx0xlhvRRiUwTc80bzfJkohKGdT/5AOW+wy6fSDvohavG94pcA==",
+      "version": "2.263.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.263.0.tgz",
+      "integrity": "sha512-cXC9wnOr+LknMee9x0kYwofgVs8aN8eBKsbzcE90sDUtpLTgWG2Bd+9koqxBKPeIU8kig/GGBFwJ69Wr+hLKDg==",
       "bundleDependencies": [
         "@aws/cloudformation-validate",
         "@balena/dockerignore",
@@ -155,7 +155,7 @@
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
         "@aws-cdk/cloud-assembly-api": "^2.2.6",
         "@aws-cdk/cloud-assembly-schema": "^54.11.0",
-        "@aws/cloudformation-validate": "1.5.0-beta",
+        "@aws/cloudformation-validate": "1.6.0-beta",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^11.3.6",
@@ -190,12 +190,11 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@aws/cloudformation-validate": {
-      "version": "1.5.0-beta",
+      "version": "1.6.0-beta",
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^22.15.0",
-        "npm": ">=10.5.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
@@ -212,14 +211,14 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
-      "version": "5.0.7",
+      "version": "5.0.8",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/case": {

--- a/infrastructure/package.json
+++ b/infrastructure/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@cdklabs/generative-ai-cdk-constructs": "^0.1.314",
-    "aws-cdk-lib": "^2.262.0",
+    "aws-cdk-lib": "^2.263.0",
     "constructs": "^10.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Closes the open Dependabot alert for **brace-expansion** (DoS via unbounded expansion length, high) on `infrastructure/package-lock.json`.

Dependabot flagged it but opened no PR, because the vulnerable copy is not directly resolvable: it lives at `node_modules/aws-cdk-lib/node_modules/brace-expansion` (reached via `minimatch`), and `aws-cdk-lib` ships with `bundleDependencies`. `npm update brace-expansion` cannot move it — only a newer `aws-cdk-lib` can.

`aws-cdk-lib` 2.262.0 → 2.263.0 bundles `brace-expansion` 5.0.8, exactly the patched version the advisory requires.

The frontend copy of `brace-expansion` is 1.1.16 (via `eslint` → `minimatch@3`), outside the affected `>=4.0.0 <5.0.8` range, so no change is needed there.

## Verification

- `npm install` clean; the nested dependency now resolves to `brace-expansion@5.0.8`.
- `tsc --noEmit` clean.
- `cdk synth` succeeds — all three stacks synthesize.
- `npm audit` on `infrastructure/` now reports **0 vulnerabilities** at every severity.
