### PR TITLE
fix: business outcomes as 200, plus interview, stream and flow-import fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,10 @@ content/
 .env.local
 .env.*.local
 # deploy.sh renames a developer's .env.local out of the way before a build so it
-# can't override deploy-generated config; the backup is a local artifact.
+# can't override deploy-generated config; the backup is a local artifact, and it
+# still holds real Cognito/API identifiers.
 .env.local.bak
+.env*.bak
 
 # === Work in Progress ===
 
@@ -110,6 +112,15 @@ questionnaire/*.docx
 frontend/playwright-report/
 frontend/test-results/
 frontend/e2e/.auth/
+
+# The Playwright e2e harness stays LOCAL — it is not part of the published
+# sample. It drives our deployed dev environment and carries environment
+# specifics (URLs, saved Cognito state, transcripts of real runs) that must not
+# land in the public repo. Keep it out of git entirely rather than trying to
+# scrub it per-file.
+frontend/e2e/
+frontend/playwright.config.ts
+frontend/.env.e2e
 
 .e2e-tmp/
 

--- a/backend/ecs/app.py
+++ b/backend/ecs/app.py
@@ -1195,24 +1195,36 @@ def _sanitize_messages_for_agent(messages: list) -> list:
 _SAFE_SESSION_ID = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
 
 
-def _session_base_dir(session_id: str) -> Optional[Path]:
-    """Resolve the on-NFS directory for a session, or None if the id is unsafe.
+def _is_safe_session_id(session_id: str) -> bool:
+    """True only for ids that look like a real session id."""
+    return bool(session_id) and bool(_SAFE_SESSION_ID.match(session_id))
 
-    Two independent checks, because either alone can be argued with:
-      1. the id must match the allowlist (no separators, no dots, bounded), and
-      2. the resolved path must still sit inside <mount>/sessions.
-    (2) is the backstop that makes traversal impossible even if (1) is ever
-    loosened — and it's what makes the safety local and checkable here.
+
+def _session_base_dir(session_id: str) -> Optional[Path]:
+    """The on-NFS directory for a session, or None if it isn't there (yet).
+
+    The path is never built by concatenating the caller's string. The id is
+    matched against the allowlist and then looked up among the directory entries
+    that ACTUALLY exist under <mount>/sessions, and the returned Path comes from
+    that listing. So the only reachable values are real children of the sessions
+    root — traversal is impossible by construction rather than by
+    after-the-fact validation, which also means no user-controlled string ever
+    flows into a filesystem path (CodeQL py/path-injection).
+
+    Returns None both for an unsafe id and for a session whose directory doesn't
+    exist yet (the first interview turn) — callers treat both as "nothing saved".
     """
-    if not session_id or not _SAFE_SESSION_ID.match(session_id):
-        logger.warning(f"[interview_state] rejected unsafe session id: {session_id!r}")
+    if not _is_safe_session_id(session_id):
+        logger.warning("[interview_state] rejected unsafe session id: %r", session_id)
         return None
-    sessions_root = (Path(S3FILES_MOUNT) / "sessions").resolve()
-    candidate = (sessions_root / session_id).resolve()
-    if candidate != sessions_root and sessions_root not in candidate.parents:
-        logger.warning(f"[interview_state] path escaped sessions root: {session_id!r}")
-        return None
-    return candidate
+    sessions_root = Path(S3FILES_MOUNT) / "sessions"
+    try:
+        for entry in sessions_root.iterdir():
+            if entry.name == session_id and entry.is_dir():
+                return entry
+    except OSError as e:
+        logger.warning("[interview_state] cannot list sessions root: %s", e)
+    return None
 
 
 def _read_interview_state(session_id: str) -> Optional[str]:
@@ -1230,18 +1242,22 @@ def _read_interview_state(session_id: str) -> Optional[str]:
     result each turn. Mirrors the `<generation_state>` block that already does
     this for the generation phase.
     """
-    base = _session_base_dir(session_id)
-    if base is None:
+    # An unsafe id gets nothing at all. A safe id whose directory doesn't exist
+    # yet (first turn) still gets the block: the ⏳ lines and the accompanying
+    # rules are exactly what's needed while the first specs are being saved.
+    if not _is_safe_session_id(session_id):
+        logger.warning("[interview_state] rejected unsafe session id: %r", session_id)
         return None
+    base = _session_base_dir(session_id)
     lines: list[str] = []
 
     # Operation specs → assets/specs/{op_id}.json
     try:
-        specs_dir = base / "assets" / "specs"
+        specs_dir = (base / "assets" / "specs") if base is not None else None
         spec_ids = sorted(
             p.stem for p in specs_dir.iterdir()
             if p.is_file() and p.suffix == ".json" and p.stem != "infrastructure_spec"
-        ) if specs_dir.is_dir() else []
+        ) if specs_dir is not None and specs_dir.is_dir() else []
     except Exception:
         spec_ids = []
     if spec_ids:
@@ -1250,21 +1266,23 @@ def _read_interview_state(session_id: str) -> Optional[str]:
         lines.append("⏳ Operation specs: none saved yet")
 
     # Session-level artifacts → state/*.json
-    state_dir = base / "state"
+    state_dir = (base / "state") if base is not None else None
     for filename, label in (
         ("infrastructure_spec.json", "Infrastructure spec"),
         ("flow_config.json", "Session flow config"),
     ):
         try:
-            exists = (state_dir / filename).is_file()
+            exists = state_dir is not None and (state_dir / filename).is_file()
         except Exception:
             exists = False
         lines.append(f"{'✅' if exists else '⏳'} {label}: {'SAVED' if exists else 'not saved yet'}")
 
     # Requirement documents → state/requirements/{doc_type}.txt
     try:
-        req_dir = state_dir / "requirements"
-        docs = sorted(p.stem for p in req_dir.iterdir() if p.is_file()) if req_dir.is_dir() else []
+        req_dir = (state_dir / "requirements") if state_dir is not None else None
+        docs = sorted(
+            p.stem for p in req_dir.iterdir() if p.is_file()
+        ) if req_dir is not None and req_dir.is_dir() else []
     except Exception:
         docs = []
     if docs:

--- a/backend/ecs/app.py
+++ b/backend/ecs/app.py
@@ -2454,9 +2454,27 @@ async def handle_send_message_ws(websocket: WebSocket, session_id: str, message:
                     tool_name = tool_use.get("name", "")
                     tool_use_id = tool_use.get("toolUseId", "")
 
+                    # Strands streams the tool arguments as a PARTIAL JSON STRING and
+                    # only json.loads() it at content_block_stop (see
+                    # strands/event_loop/streaming.py: current_tool_use["input"] starts
+                    # as "" and is +='d per delta). So during streaming this is a str,
+                    # not a dict — an isinstance(..., dict) guard here silently drops
+                    # every input, leaving tool_inputs empty and the UI with no
+                    # operation name on its tool cards. Accept both shapes: keep the
+                    # dict when it finally arrives, and parse the string opportunistically
+                    # (a fragment simply fails to parse and is skipped, so the last
+                    # successful parse wins — which is the complete object).
                     tool_input = tool_use.get("input", {})
-                    if tool_use_id and isinstance(tool_input, dict) and tool_input:
-                        tool_inputs[tool_use_id] = tool_input
+                    if tool_use_id and tool_input:
+                        if isinstance(tool_input, dict):
+                            tool_inputs[tool_use_id] = tool_input
+                        elif isinstance(tool_input, str):
+                            try:
+                                parsed = json.loads(tool_input)
+                                if isinstance(parsed, dict) and parsed:
+                                    tool_inputs[tool_use_id] = parsed
+                            except (ValueError, TypeError):
+                                pass  # still a partial fragment — wait for more deltas
 
                     if tool_use_id and tool_use_id not in tool_invocations_started:
                         tool_invocations_started.add(tool_use_id)
@@ -2474,7 +2492,13 @@ async def handle_send_message_ws(websocket: WebSocket, session_id: str, message:
                             "type": "tool_start",
                             "tool": tool_name,
                             "toolUseId": tool_use_id,
-                            "input": tool_input,
+                            # Always a dict (possibly empty), never the raw partial
+                            # JSON string: the client does Object.keys(input), which on
+                            # a string yields char indices — that renders a tool card
+                            # with a garbled char-by-char "input". tool_start fires on
+                            # the first delta, so this is usually {} and gets filled in
+                            # by the throttled tool_status/tool_end updates.
+                            "input": tool_inputs.get(tool_use_id, {}),
                         })
 
                 # ToolResultMessageEvent

--- a/backend/ecs/app.py
+++ b/backend/ecs/app.py
@@ -29,6 +29,7 @@ import time
 import traceback
 from typing import Optional, Dict, Any
 from datetime import datetime
+from pathlib import Path
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Query, HTTPException, Depends, Header
 from fastapi.responses import JSONResponse
@@ -1184,6 +1185,76 @@ def _sanitize_messages_for_agent(messages: list) -> list:
 
 
 # ========================================
+# Interview State — authoritative "what is already saved"
+# ========================================
+def _read_interview_state(session_id: str) -> Optional[str]:
+    """Summarize what the interview has ALREADY persisted, straight off NFS.
+
+    Why this exists: conversation history is pruned (MAX_HISTORY_MESSAGES) and
+    tool payloads are truncated (MAX_TOOL_INPUT_LENGTH / MAX_TOOL_RESULT_LENGTH),
+    so in a long interview the evidence that a spec was saved falls out of
+    context. A max_tokens truncation makes it worse: Strands rewrites the
+    toolUse blocks as "incomplete" text, so the record of the save disappears
+    entirely. The agent then re-asks "shall I save the specs?" and re-saves the
+    same specs in a loop.
+
+    The files on NFS are the ground truth, so read them directly and inject the
+    result each turn. Mirrors the `<generation_state>` block that already does
+    this for the generation phase.
+    """
+    safe_id = session_id.replace("..", "_").replace("/", "_").replace("\\", "_")
+    base = Path(S3FILES_MOUNT) / "sessions" / safe_id
+    lines: list[str] = []
+
+    # Operation specs → assets/specs/{op_id}.json
+    try:
+        specs_dir = base / "assets" / "specs"
+        spec_ids = sorted(
+            p.stem for p in specs_dir.iterdir()
+            if p.is_file() and p.suffix == ".json" and p.stem != "infrastructure_spec"
+        ) if specs_dir.is_dir() else []
+    except Exception:
+        spec_ids = []
+    if spec_ids:
+        lines.append(f"✅ Operation specs SAVED ({len(spec_ids)}): {', '.join(spec_ids)}")
+    else:
+        lines.append("⏳ Operation specs: none saved yet")
+
+    # Session-level artifacts → state/*.json
+    state_dir = base / "state"
+    for filename, label in (
+        ("infrastructure_spec.json", "Infrastructure spec"),
+        ("flow_config.json", "Session flow config"),
+    ):
+        try:
+            exists = (state_dir / filename).is_file()
+        except Exception:
+            exists = False
+        lines.append(f"{'✅' if exists else '⏳'} {label}: {'SAVED' if exists else 'not saved yet'}")
+
+    # Requirement documents → state/requirements/{doc_type}.txt
+    try:
+        req_dir = state_dir / "requirements"
+        docs = sorted(p.stem for p in req_dir.iterdir() if p.is_file()) if req_dir.is_dir() else []
+    except Exception:
+        docs = []
+    if docs:
+        lines.append(f"✅ Requirement documents SAVED: {', '.join(docs)}")
+    else:
+        lines.append("⏳ Requirement documents: none saved yet")
+
+    # Interview handoff marker (complete_interview already called?)
+    try:
+        handoff = check_interview_handoff(session_id) is not None
+    except Exception:
+        handoff = False
+    if handoff:
+        lines.append("✅ complete_interview: ALREADY CALLED (interview is finished)")
+
+    return "\n".join(lines) if lines else None
+
+
+# ========================================
 # Health Check
 # ========================================
 @app.get("/ping")
@@ -2159,6 +2230,37 @@ async def handle_send_message_ws(websocket: WebSocket, session_id: str, message:
     ui_language = message.get("language", "ko-KR")
     context_prefix = f'[Session: session_id="{effective_session_id}" language="{ui_language}"]'
 
+    # Interview phase: inject the authoritative list of already-saved specs.
+    # Read from NFS, not from conversation memory — history gets pruned and tool
+    # payloads truncated, and a max_tokens truncation erases toolUse records
+    # entirely, which is what made the agent re-ask "shall I save the specs?"
+    # and save the same specs over and over.
+    interview_state_block = ""
+    if current_phase == "interview":
+        try:
+            interview_state = _read_interview_state(effective_session_id)
+            if interview_state:
+                interview_state_block = (
+                    "\n<interview_state>\n"
+                    "Authoritative record of what is ALREADY PERSISTED on disk for this\n"
+                    "session. Trust this over conversation memory — the chat log is pruned,\n"
+                    "so an earlier save may no longer appear above.\n"
+                    "⛔ Items marked ✅ are SAVED. Do NOT re-save them and do NOT ask the\n"
+                    "   user whether to save them again.\n"
+                    "⛔ Only call save_operation_spec for operations NOT in the saved list,\n"
+                    "   or when the user explicitly asks to change an existing one\n"
+                    "   (then prefer update_operation_spec).\n"
+                    "⛔ If everything needed is ✅ and the user says they are done, move on to\n"
+                    "   the analysis document / complete_interview — do not loop back to saving.\n"
+                    "⚠️ Emit ONE save_operation_spec call per turn. Batching several large spec\n"
+                    "   payloads into a single turn can hit the output token limit, which\n"
+                    "   silently discards ALL of them.\n\n"
+                    f"{interview_state}\n"
+                    "</interview_state>\n\n"
+                )
+        except Exception as iv_err:
+            logger.warning(f"[interview_state] read failed (non-critical): {iv_err}")
+
     # Structured Note-Taking: inject generation progress into context
     # This survives conversation history pruning and gives the orchestrator
     # full awareness of what has been generated/reviewed/fixed.
@@ -2220,7 +2322,10 @@ async def handle_send_message_ws(websocket: WebSocket, session_id: str, message:
     except Exception as scope_err:
         logger.warning(f"[generation_scope] inject failed (non-critical): {scope_err}")
 
-    combined_state = f"{generation_state_block}{modification_state_block}{generation_scope_block}"
+    combined_state = (
+        f"{interview_state_block}{generation_state_block}"
+        f"{modification_state_block}{generation_scope_block}"
+    )
 
     if content_blocks:
         # Multimodal: prepend session context to the text block in content_blocks

--- a/backend/ecs/app.py
+++ b/backend/ecs/app.py
@@ -1187,6 +1187,34 @@ def _sanitize_messages_for_agent(messages: list) -> list:
 # ========================================
 # Interview State — authoritative "what is already saved"
 # ========================================
+# Session ids are minted by the frontend as `session-<uuid4>` and are the only
+# user-controlled value that reaches the filesystem here. Validate against an
+# ALLOWLIST rather than stripping bad characters: a blocklist has to anticipate
+# every encoding (".." , "%2e%2e", "....//", backslashes, NUL) whereas this
+# rejects anything that isn't a plain id outright.
+_SAFE_SESSION_ID = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
+
+
+def _session_base_dir(session_id: str) -> Optional[Path]:
+    """Resolve the on-NFS directory for a session, or None if the id is unsafe.
+
+    Two independent checks, because either alone can be argued with:
+      1. the id must match the allowlist (no separators, no dots, bounded), and
+      2. the resolved path must still sit inside <mount>/sessions.
+    (2) is the backstop that makes traversal impossible even if (1) is ever
+    loosened — and it's what makes the safety local and checkable here.
+    """
+    if not session_id or not _SAFE_SESSION_ID.match(session_id):
+        logger.warning(f"[interview_state] rejected unsafe session id: {session_id!r}")
+        return None
+    sessions_root = (Path(S3FILES_MOUNT) / "sessions").resolve()
+    candidate = (sessions_root / session_id).resolve()
+    if candidate != sessions_root and sessions_root not in candidate.parents:
+        logger.warning(f"[interview_state] path escaped sessions root: {session_id!r}")
+        return None
+    return candidate
+
+
 def _read_interview_state(session_id: str) -> Optional[str]:
     """Summarize what the interview has ALREADY persisted, straight off NFS.
 
@@ -1202,8 +1230,9 @@ def _read_interview_state(session_id: str) -> Optional[str]:
     result each turn. Mirrors the `<generation_state>` block that already does
     this for the generation phase.
     """
-    safe_id = session_id.replace("..", "_").replace("/", "_").replace("\\", "_")
-    base = Path(S3FILES_MOUNT) / "sessions" / safe_id
+    base = _session_base_dir(session_id)
+    if base is None:
+        return None
     lines: list[str] = []
 
     # Operation specs → assets/specs/{op_id}.json

--- a/backend/ecs/app.py
+++ b/backend/ecs/app.py
@@ -39,6 +39,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(
 
 from strands import Agent
 from strands.models import BedrockModel
+from strands.types.exceptions import MaxTokensReachedException
 from botocore.config import Config as BotocoreConfig
 
 # Import shared modules from src/
@@ -485,6 +486,31 @@ async def validate_cognito_token(token: str) -> Optional[Dict]:
 # ========================================
 # Model Configuration (same as AgentCore)
 # ========================================
+# Output token budget for the ORCHESTRATOR.
+#
+# ⚠️ This MUST be set explicitly. Strands omits `maxTokens` from
+# `inferenceConfig` when `max_tokens` is None, and Bedrock's default in that
+# case is only **4096** output tokens (verified live against
+# global.anthropic.claude-opus-4-8 in ap-northeast-2: omitting maxTokens with a
+# long-output prompt returns stopReason=max_tokens at outputTokens=4096).
+#
+# 4096 is far too small for the orchestrator: a single `save_operation_spec`
+# toolUse payload can exceed it, and an interview turn that saves several specs
+# is truncated mid-toolUse. Strands then replaces EVERY toolUse in that turn
+# with "tool use was incomplete due to maximum token limits being reached",
+# so the saves never register in history and the agent asks to save again —
+# the repeated-spec-saving loop.
+#
+# 128000 is the hard model ceiling (Bedrock rejects 128001 with "exceeds the
+# model limit of 128000") for Opus 4.6/4.7/4.8/5. Sub-agents in
+# `agents/agent_pool.py` already use 128000; the orchestrator emits chat text
+# plus tool inputs rather than whole files, so 64000 gives ~16x headroom over
+# the old effective budget while keeping a sane cutoff.
+ORCHESTRATOR_MAX_TOKENS = min(
+    int(os.environ.get("ORCHESTRATOR_MAX_TOKENS", "64000")), 128000
+)
+
+
 def get_model_config(model_id: Optional[str] = None):
     # Orchestrator model follows the per-request/persisted selection.
     # No temperature is passed (orchestrator never set one), so the
@@ -494,6 +520,7 @@ def get_model_config(model_id: Optional[str] = None):
     kwargs = build_model_kwargs(
         model_id,
         region_name=AWS_REGION,
+        max_tokens=ORCHESTRATOR_MAX_TOKENS,
         boto_client_config=BotocoreConfig(
             read_timeout=300,
             retries={"max_attempts": 3, "mode": "adaptive"},
@@ -2445,6 +2472,57 @@ async def handle_send_message_ws(websocket: WebSocket, session_id: str, message:
                 "message": "생성이 취소됐어요.",
             })
             raise
+        except MaxTokensReachedException as e:
+            # The turn was cut off mid-toolUse because the model hit its output
+            # cap. Strands has already replaced every toolUse block in that
+            # assistant message with "tool use was incomplete…" text, so those
+            # tool calls did NOT execute — nothing was saved.
+            #
+            # Surface this as an actionable notice instead of a raw stack-trace
+            # error, and tell the agent (via the persisted history) exactly what
+            # happened so the next turn splits the work instead of retrying the
+            # same oversized batch. Without this the agent re-asks "should I save
+            # the specs?" and re-saves in a loop.
+            logger.warning(
+                f"[BG] max_tokens reached for {session_id} "
+                f"(cap={ORCHESTRATOR_MAX_TOKENS}): {e}"
+            )
+            await safe_send_or_log({
+                "type": "max_tokens_truncated",
+                "content": (
+                    "응답이 출력 토큰 한도에 도달해서 중간에 끊겼어요. "
+                    "직전 도구 호출은 실행되지 않았습니다 — 저장된 내용은 없어요. "
+                    "이어서 진행하려면 '계속'이라고 말씀해 주세요 (한 번에 하나씩 나눠서 처리합니다)."
+                ),
+            })
+            try:
+                partial = _extract_new_messages(streaming_agent.messages, pre_stream_message_count)
+                if partial:
+                    try:
+                        _update_generation_progress(effective_session_id, partial)
+                    except Exception:
+                        pass
+                    # Leave an explicit breadcrumb so the next turn's context
+                    # states that the truncated tool calls never ran.
+                    partial.append({
+                        "role": "user",
+                        "content": [{"text": (
+                            "[System] The previous assistant turn was truncated at the output "
+                            "token limit. Any tool calls in that turn did NOT execute — nothing "
+                            "was saved by them. Do NOT assume they succeeded, and do NOT ask the "
+                            "user to re-confirm work that was already saved in EARLIER turns. "
+                            "Verify current state with list_operations() / get_all_tool_ids() "
+                            "first, then emit ONE tool call per turn to finish the remaining work."
+                        )}],
+                    })
+                    session["conversation_history"].extend(partial)
+                    session["conversation_history"] = _prune_conversation_history(
+                        session["conversation_history"], max_messages=MAX_HISTORY_MESSAGES
+                    )
+                    _context_store.save_conversation_history(session_id, session["conversation_history"])
+            except Exception as save_err:
+                logger.error(f"[BG] Failed to save history after max_tokens for {session_id}: {save_err}")
+            await safe_send_or_log({"type": "stream_end"})
         except Exception as e:
             logger.error(f"[BG] Streaming error for {session_id}: {e}\n{traceback.format_exc()}")
             await safe_send_or_log({"type": "error", "content": str(e)})

--- a/backend/ecs/app.py
+++ b/backend/ecs/app.py
@@ -3105,8 +3105,40 @@ async def handle_create_new_session_ws(websocket: WebSocket, session_id: str, da
     partial run) and ``model`` (one of the allowlisted Bedrock ids) chosen on the
     start screen. Both are persisted to NFS so detect_phase / the phase prompt /
     every BedrockModel construction reason about the right values from turn one.
+
+    NEVER purge state while an agent task is running for this session. The
+    frontend fires createNewSession on reconnect-with-no-history (useWebSocket.ts),
+    and on a WS flap right after the kickoff message that arrives mid-turn: the
+    agent is already streaming, and clear_all_specs()/cleanup_session() would drop
+    its ProjectWorkspace out from under it. Every later workspace-mediated write in
+    that turn then fails — save_requirement_document returns
+    "Workspace not initialised (no session)" and the S3 backup of specs/state is
+    silently skipped (observed on prod 2026-08-05: the NFS fast-path still wrote,
+    so nothing looked broken until the analysis document failed to save).
     """
     data = data or {}
+
+    # A running agent owns this session's state — reset would yank it mid-turn.
+    async with _background_tasks_lock:
+        _bg = _background_tasks.get(session_id)
+        _bg_running = bool(_bg and not _bg["task"].done())
+    if _bg_running:
+        logger.warning(
+            f"[createNewSession] ignored for {session_id}: an agent task is still "
+            "running; keeping the live workspace/specs instead of resetting."
+        )
+        _eff_live = session_store.get(session_id, {}).get("session_data", {}).get("original_session_id", session_id) \
+            if isinstance(session_store.get(session_id), dict) else session_id
+        _live_scope = _get_generation_scope(_eff_live)
+        await safe_send_json(websocket, {
+            "type": "session_created",
+            "sessionId": session_id,
+            "phase": _detect_phase(session_id),
+            "scope": [] if set(_live_scope) >= set(_FULL_ASSET_SET) else _live_scope,
+            "selectedModel": _get_selected_model(_eff_live) or resolve_model_id(),
+        })
+        return
+
     if session_id in session_store:
         # Flush before clearing
         try:

--- a/backend/ecs/src/agents/_consistency_rules.py
+++ b/backend/ecs/src/agents/_consistency_rules.py
@@ -138,7 +138,8 @@ turns the tool into something the model can't call.
 If a spec field has `enum_values` populated, those EXACT values — same
 casing, same spelling, same order, same punctuation (underscores vs
 hyphens matter) — must appear verbatim in OpenAPI `enum:` and in any
-Lambda validation code (e.g., `if value not in {...}: return 400`).
+Lambda validation code (e.g., `if value not in {...}: ...` returning a
+200 rejection body per BUSINESS_OUTCOME_200_RULE).
 Do NOT paraphrase, translate, abbreviate, or alphabetize. If the customer
 supplied 18 Electrolux program modes, emit all 18 verbatim.
 
@@ -156,6 +157,49 @@ camelCase spelled by the spec. Do NOT rename, flatten, or drop keys.
 `event`-parsing and response-building must use the spec's nested field
 names verbatim. For scalar output fields with `enum_values`, validate
 against those exact values before returning.
+
+### 17. BUSINESS_OUTCOME_200_RULE  (CRITICAL — fixes "there is an issue with the tool")
+An Amazon Connect AI agent treats **any non-2xx HTTP response as a tool
+execution failure**. It never reads the response body, so it cannot tell the
+customer what happened — it just reports that the tool is broken and the turn
+is lost.
+
+Therefore: **a business outcome is NOT an HTTP error.** Every outcome the AI
+agent is supposed to talk about MUST return `200`, with the outcome expressed
+as a field IN THE BODY.
+
+"Business outcome" means any answer the operation is designed to produce,
+including the negative ones:
+
+  - authentication did not match (wrong SSN digits / accountId / PIN)
+  - record not found, no reservation for that phone number
+  - too many attempts / account locked out
+  - date unavailable, seat taken, insufficient balance
+  - a validation problem the customer can fix ("I need your account number")
+
+All of the above → `200` + a discriminator field. Do NOT use 400, 401, 403,
+404, 409 or 429 for any of them.
+
+```python
+# ❌ WRONG — the AI agent says "there is an issue with the tool" and gives up
+if last_four_digits != stored_last_four:
+    return create_response(403, {"verified": False, "lockout": True})
+
+# ✅ RIGHT — the AI agent reads verified/lockout and responds to the customer
+if last_four_digits != stored_last_four:
+    return create_response(200, {"verified": False, "remainingAttempts": remaining,
+                                 "lockout": False})
+```
+
+Reserve non-2xx for faults the AI agent genuinely cannot act on:
+  - `5xx` — the operation itself broke (unhandled exception, database down).
+    Connect retries 5xx, which is the correct behaviour for a transient fault.
+
+The body must let the model distinguish outcomes without the status code, so
+always include an explicit discriminator (`verified`, `found`, `success`,
+`status`, `outcome`, …) plus enough detail to speak to the customer. State the
+same in the OpenAPI `200` schema and in the tool description, so the model
+knows the negative outcome is a normal, expected response.
 
 ## 🔒 END OF GOLDEN RULES — APPLY ALL OF THE ABOVE TO THE OUTPUT BELOW 🔒
 """

--- a/backend/ecs/src/agents/infrastructure_generator/agent.py
+++ b/backend/ecs/src/agents/infrastructure_generator/agent.py
@@ -65,8 +65,8 @@ def get_infrastructure_schema(project_name: str = "") -> str:
         return result
     # S3 fallback (A4)
     try:
-        from tools.project_workspace import get_workspace
-        ws = get_workspace()
+        from tools.project_workspace import ensure_workspace
+        ws = ensure_workspace()
         if ws:
             schema_dict = ws.load_schema()
             if schema_dict:
@@ -690,8 +690,8 @@ Only change what the modification request asks for.
                     result["summary"] += " with schema"
                     # Persist schema to S3 workspace (A4)
                     try:
-                        from tools.project_workspace import get_workspace
-                        ws = get_workspace()
+                        from tools.project_workspace import ensure_workspace
+                        ws = ensure_workspace()
                         if ws:
                             ws.save_schema(json.loads(schema_json))
                     except Exception as _e:

--- a/backend/ecs/src/agents/lambda_generator/agent.py
+++ b/backend/ecs/src/agents/lambda_generator/agent.py
@@ -487,6 +487,29 @@ Database: {db_type}{schema_section}{infra_spec_section}{modification_section}
             if not code:
                 code, parse_method = _parse_code_block(full_response)
 
+        # Deterministic status-code repair, BEFORE the asset is streamed or
+        # written. An Amazon Connect AI agent treats any non-2xx tool response as
+        # an execution failure — it never reads the body, so a Lambda that answers
+        # "SSN digits didn't match" with 403 makes the agent tell the customer the
+        # tool is broken. Business outcomes must be 200 with a discriminator in the
+        # body (BUSINESS_OUTCOME_200_RULE). 5xx is left alone: a real fault, where
+        # Connect's retry is the behaviour we want. Fault-tolerant.
+        status_fix = {"fixes_applied": [], "warnings": []}
+        if code and isinstance(code, str) and parse_method != "workspace_tools":
+            try:
+                from tools.asset_linters import lint_lambda_status_codes
+                status_fix = lint_lambda_status_codes(code)
+                if status_fix["fixes_applied"]:
+                    code = status_fix["fixed_code"]
+                    logger.info(
+                        f"[LAMBDA] {operation_id}: rewrote {len(status_fix['fixes_applied'])} "
+                        f"business-outcome 4xx → 200: {status_fix['fixes_applied'][:3]}"
+                    )
+                if status_fix["warnings"]:
+                    logger.warning(f"[LAMBDA] {operation_id}: {status_fix['warnings'][:3]}")
+            except Exception as e:
+                logger.warning(f"[LAMBDA] status-code lint skipped: {e}")
+
         if code:
             if parse_method != "workspace_tools":
                 logger.info(f"Code parsed successfully for {operation_id} using method: {parse_method}")
@@ -507,6 +530,22 @@ Database: {db_type}{schema_section}{infra_spec_section}{modification_section}
                 # Normal generation: stream asset as before
                 elif not streamer.found_code_block:
                     _stream_asset("lambda", "index.py", code, operation_id)
+                elif status_fix["fixes_applied"]:
+                    # The incremental streamer already pushed the UNFIXED source
+                    # into the frontend's preview cache. Force a full, non-delta
+                    # re-stream so the repaired code is what the user sees and
+                    # downloads — matching what we persist. Same reason the
+                    # contact-flow linter re-streams after an autofix.
+                    try:
+                        from tools.streaming_callback import stream_asset as _stream_full
+                        _stream_full("lambda", "index.py", code, operation_id=operation_id,
+                                     is_complete=True, force_full=True)
+                    except Exception as e:
+                        logger.warning(f"[LAMBDA] re-stream after status-code autofix failed: {e}")
+                        try:
+                            _stream_asset("lambda", "index.py", code, operation_id)
+                        except Exception:
+                            pass
 
             yield {
                 "type": "progress",
@@ -539,9 +578,16 @@ Database: {db_type}{schema_section}{infra_spec_section}{modification_section}
                 "parse_method": parse_method,
                 "syntax_ok": py_lint["ok"],
                 "syntax_errors": py_lint["errors"][:5],
+                "status_code_fixes": status_fix["fixes_applied"][:10],
+                "status_code_warnings": status_fix["warnings"][:5],
                 "summary": (
                     f"Generated index.py for {operation_id}"
                     + ("" if py_lint["ok"] else f" — ⚠️ SYNTAX ERROR (patch before deploy): {py_lint['errors'][0]['message']}")
+                    + (
+                        f" — rewrote {len(status_fix['fixes_applied'])} business-outcome 4xx → 200 "
+                        "(Connect AI agents read non-2xx as a tool failure)"
+                        if status_fix["fixes_applied"] else ""
+                    )
                 ),
                 "_completion_marker": "SUBAGENT_COMPLETE"  # Explicit completion signal
             }

--- a/backend/ecs/src/agents/lambda_generator/system_prompt.py
+++ b/backend/ecs/src/agents/lambda_generator/system_prompt.py
@@ -44,7 +44,9 @@ return {
 
 If a spec field has `enum_values`, any validation you add MUST compare against the
 EXACT set (case/underscores preserved). Do NOT paraphrase or normalize.
-Example: `if payload["state"] not in {"RUNNING", "FINISH", "IDLE"}: return 400`.
+Example: `if payload["state"] not in {"RUNNING", "FINISH", "IDLE"}: ...` — and
+return that rejection as **200** with `success=False`, per
+BUSINESS_OUTCOME_200_RULE, never as a 400.
 
 NEVER emit flattened output like `{"machineType": ..., "state": ..., "remainingSeconds": ...}`
 at the top level when the spec says `machineStatus` is an array of those objects.
@@ -289,6 +291,70 @@ When Lambda is called via API Gateway:
 
 ---
 
+## 🚨 STATUS CODES: BUSINESS OUTCOMES ARE ALWAYS 200 (BUSINESS_OUTCOME_200_RULE)
+
+An Amazon Connect AI agent treats **any non-2xx response as a tool failure**. It
+does not read the body — it tells the customer the tool is broken. So every
+outcome the AI agent must SPEAK ABOUT has to be `200`, with the outcome carried
+in the body.
+
+This includes the negative outcomes, which is the part that is easy to get wrong:
+
+| Scenario | ❌ Never | ✅ Always | Body discriminator |
+|---|---|---|---|
+| Auth digits/PIN/SSN don't match | 401 / 403 | **200** | `"verified": false` |
+| Record / reservation not found | 404 | **200** | `"found": false` |
+| Too many attempts, locked out | 403 / 429 | **200** | `"lockout": true` |
+| Date unavailable, seat taken | 409 | **200** | `"available": false` |
+| Missing/invalid input the customer can supply | 400 | **200** | `"success": false` + which field |
+| Unhandled exception, DB down | — | **500** | `"error"` (Connect retries 5xx — correct for faults) |
+
+`5xx` is the ONLY correct non-2xx: a real fault the agent cannot act on.
+
+```python
+# ❌ WRONG — agent reports "there is an issue with the tool", customer is stuck
+if last_four_digits != stored_last_four:
+    return create_response(403, {"verified": False, "lockout": True})
+if not item:
+    return create_response(404, {"found": False})
+if not account_number:
+    return create_response(400, {"error": "accountNumber is required"})
+
+# ✅ RIGHT — agent reads the body and says the right thing to the customer
+if last_four_digits != stored_last_four:
+    return create_response(200, {
+        "verified": False,
+        "remainingAttempts": remaining,
+        "lockout": False,
+        "message": "The digits provided do not match our records.",
+    })
+if not item:
+    return create_response(200, {
+        "verified": False, "found": False, "lockout": False,
+        "message": "No account was found with that number.",
+    })
+if not account_number:
+    return create_response(200, {
+        "verified": False, "found": False, "lockout": False,
+        "message": "accountNumber is required to verify the caller.",
+    })
+
+# ✅ 5xx stays 5xx — a genuine fault, and Connect's retry is what we want
+except Exception as e:
+    logger.error(f"Error: {e}", exc_info=True)
+    return create_response(500, {"error": "Internal server error"})
+```
+
+**Always include an explicit boolean/enum discriminator** (`verified`, `found`,
+`available`, `success`, `status`) so the model can tell outcomes apart without
+the status code, plus a human-readable `message` it can paraphrase. A bare
+`200 {}` is as useless to the agent as a 403.
+
+Never emit a validation helper that raises straight into a `400`. Convert the
+validation failure into a `200` body that names the missing field.
+
+---
+
 ## RESPONSE FORMATS
 
 ### 1. STRING_MAP Format (Contact Flow Direct - RECOMMENDED)
@@ -364,6 +430,7 @@ def handler(event, context):
             return create_response(200, {"success": True, "data": result})
 
     except Exception as e:
+        # 500 only for genuine faults — never for a business outcome.
         logger.error(f"Error: {e}")
         if is_connect_direct:
             return {"status": "ERROR", "errorMessage": str(e)}
@@ -676,11 +743,18 @@ def handler(event, context):
             return create_response(200, {"success": True, "data": result})
 
     except KeyError as e:
+        # A missing field is a BUSINESS OUTCOME the AI agent must talk about
+        # (it needs to ask the customer for the value), so it returns 200 with
+        # success=False — NOT 400, which the agent would read as a tool failure.
         logger.warning(f"Missing required field: {e}")
         error_result = {"status": "VALIDATION_ERROR", "errorMessage": f"Missing required field: {e}"}
         if is_connect_direct:
             return error_result
-        return create_response(400, {"success": False, "error": str(e)})
+        return create_response(200, {
+            "success": False,
+            "status": "VALIDATION_ERROR",
+            "message": f"Missing required field: {e}",
+        })
 
     except Exception as e:
         logger.error(f"Error processing request: {e}", exc_info=True)

--- a/backend/ecs/src/agents/openapi_generator/system_prompt.py
+++ b/backend/ecs/src/agents/openapi_generator/system_prompt.py
@@ -424,17 +424,56 @@ components:
             searchedId: "R-123456"
 ```
 
-### Common Error Codes and AI Guidance
+### 🚨 Common Outcome Codes and AI Guidance (BUSINESS_OUTCOME_200_RULE)
 
-| Code | HTTP Status | AI Response Guidance |
+An Amazon Connect AI agent treats **any non-2xx response as a tool failure** — it
+never reads the body, and tells the customer the tool is broken. So every outcome
+the agent must speak about is declared under **`200`**, with the outcome carried in
+the response body. These are business outcomes, not HTTP errors:
+
+| Outcome code (in body) | HTTP Status | AI Response Guidance |
 |------|-------------|---------------------|
-| `NOT_FOUND` | 404 | Ask customer to verify identifier |
-| `VALIDATION_ERROR` | 400 | Explain which field is invalid |
-| `CONFLICT` | 409 | Resource already exists or state conflict |
-| `DATE_UNAVAILABLE` | 409 | Suggest alternative dates |
-| `UNAUTHORIZED` | 401 | Verify customer identity |
-| `RATE_LIMITED` | 429 | Ask customer to wait and try again |
-| `INTERNAL_ERROR` | 500 | Apologize and offer to transfer to agent |
+| `NOT_FOUND` | **200** | Ask customer to verify identifier |
+| `VALIDATION_ERROR` | **200** | Explain which field is invalid |
+| `CONFLICT` | **200** | Resource already exists or state conflict |
+| `DATE_UNAVAILABLE` | **200** | Suggest alternative dates |
+| `UNAUTHORIZED` / auth mismatch | **200** | Verify customer identity, offer retry |
+| `RATE_LIMITED` / lockout | **200** | Explain lockout, offer transfer |
+| `INTERNAL_ERROR` | 500 | Genuine fault — Connect retries; apologize and transfer |
+
+`500` is the only status that stays non-2xx.
+
+Therefore the `200` response schema MUST be able to express both outcomes: include
+the discriminator field (`verified`, `found`, `available`, `success`, `status`) and
+mark the outcome-specific fields as optional rather than splitting them across
+status codes. Say so in the `description` and in
+`x-amazon-connect-tool-description`, so the model knows a negative outcome is a
+normal, expected `200` it should read and act on.
+
+```yaml
+responses:
+  '200':
+    description: |
+      Verification result. ALWAYS 200, including when verification fails —
+      read `verified` to determine the outcome:
+        - verified=true  → caller authenticated
+        - verified=false + lockout=false → digits did not match, retries remain
+        - verified=false + lockout=true  → too many attempts, transfer to an agent
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/VerifyCallerResponse'
+  '500':
+    description: "Internal error — retryable fault"
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ErrorResponse'
+```
+
+Do NOT emit `'400'`, `'401'`, `'403'`, `'404'`, `'409'` or `'429'` response
+entries for business outcomes — a declared 4xx teaches the model to expect a
+failure it cannot handle, and the Lambda must not return one either.
 
 ---
 
@@ -504,13 +543,16 @@ paths:
           description: "Unique {item} identifier"
       responses:
         '200':
-          description: "{Item} found"
+          description: |
+            Lookup result — ALWAYS 200, including "not found".
+            Read `found`: true → item returned; false → no such {item},
+            ask the customer to verify the identifier.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ItemResponse'
-        '404':
-          description: "{Item} not found"
+        '500':
+          description: "Internal error — retryable fault"
           content:
             application/json:
               schema:
@@ -599,20 +641,20 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateRequest'
       responses:
-        '201':
-          description: "{Item} created"
+        '200':
+          description: |
+            Creation result — ALWAYS 200. Read `success`:
+              - success=true  → created, return the new id
+              - success=false + status=VALIDATION_ERROR → tell the customer which field
+              - success=false + status=DATE_UNAVAILABLE  → suggest alternatives
+            Do NOT declare 400/409 here: the AI agent reads a non-2xx as a
+            broken tool and cannot relay the outcome.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/CreateResponse'
-        '400':
-          description: "Invalid input"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '409':
-          description: "Conflict (dates unavailable, etc.)"
+        '500':
+          description: "Internal error — retryable fault"
           content:
             application/json:
               schema:
@@ -662,19 +704,17 @@ paths:
               $ref: '#/components/schemas/UpdateRequest'
       responses:
         '200':
-          description: "{Item} updated"
+          description: |
+            Update result — ALWAYS 200. Read `success`:
+              - success=true  → updated
+              - success=false + status=NOT_FOUND → ask to verify the identifier
+              - success=false + status=CONFLICT  → explain the policy restriction
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ItemResponse'
-        '404':
-          description: "{Item} not found"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '409':
-          description: "Cannot modify (policy restriction)"
+        '500':
+          description: "Internal error — retryable fault"
           content:
             application/json:
               schema:
@@ -723,19 +763,17 @@ paths:
               $ref: '#/components/schemas/CancelRequest'
       responses:
         '200':
-          description: "{Item} cancelled"
+          description: |
+            Cancellation result — ALWAYS 200. Read `success`:
+              - success=true  → cancelled
+              - success=false + status=NOT_FOUND → ask to verify the identifier
+              - success=false + status=CONFLICT  → explain why it cannot be cancelled
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/CancelResponse'
-        '404':
-          description: "{Item} not found"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '409':
-          description: "Cannot cancel"
+        '500':
+          description: "Internal error — retryable fault"
           content:
             application/json:
               schema:
@@ -1403,13 +1441,15 @@ No explanation before or after.
               $ref: '#/components/schemas/OperationNameRequest'
       responses:
         '200':
-          description: "..."
+          description: |
+            ... — ALWAYS 200, including negative outcomes; state which body
+            field the agent should read to tell them apart.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/OperationNameResponse'
-        '400':
-          description: "..."
+        '500':
+          description: "Internal error — retryable fault"
           content:
             application/json:
               schema:

--- a/backend/ecs/src/prompts/interview_agent_prompt.py
+++ b/backend/ecs/src/prompts/interview_agent_prompt.py
@@ -331,6 +331,30 @@ Data API를 사용하면 VPC 설정 없이도 Lambda에서 RDS에 접근 가능�
 
 ## SPEC SAVING RULES
 
+### ⛔ 절대 규칙: 한 턴에 save_operation_spec은 1개만
+
+operation spec 하나의 JSON payload는 매우 큽니다. 한 턴에 여러 개를 몰아서
+호출하면 출력 토큰 한도에 걸려 **턴 전체가 중간에 잘리고, 그 턴의 모든 도구
+호출이 실행되지 않습니다** (아무것도 저장되지 않음). 그러면 "저장했나?" →
+"다시 저장" 루프에 빠집니다.
+
+- operation이 여러 개면 → **한 턴에 하나씩** 저장하세요.
+- 저장 후 짧게 "N/M 저장 완료, 다음은 X" 정도만 말하고 다음 턴으로 넘기세요.
+- 절대 여러 spec을 한 응답에 병렬로 호출하지 마세요.
+
+### ⛔ 절대 규칙: 이미 저장된 것은 다시 묻지 않기
+
+매 턴 컨텍스트에 `<interview_state>` 블록이 주입됩니다. 그것이 디스크에 실제로
+저장된 내용의 **유일한 진실**입니다 (대화 기록은 길어지면 잘려나가므로 신뢰할 수
+없습니다).
+
+- `<interview_state>`에서 ✅ 표시된 항목 → 이미 저장됨. **다시 저장하지도, 저장할지
+  묻지도 마세요.**
+- 사용자가 "끝났다 / 다 됐다"고 하면 → ✅ 목록을 확인하고, 빠진 것만 처리한 뒤
+  분석 문서 작성 → `complete_interview`로 진행하세요. 저장 단계로 되돌아가지 마세요.
+- 확실하지 않으면 `list_operations()`로 확인하세요 — 사용자에게 되묻지 마세요.
+- 기존 spec을 수정할 때는 `save_operation_spec`이 아니라 `update_operation_spec`.
+
 ### save_operation_spec 호출 시 포함할 항목:
 - `operation_id` (snake_case, 예: check_reservation)
 - `http_method` (POST, GET 등)

--- a/backend/ecs/src/prompts/system_prompt.py
+++ b/backend/ecs/src/prompts/system_prompt.py
@@ -1809,6 +1809,60 @@ CloudFormation, Lambda, and OpenAPI, each operation MUST include these fields:
      Same for length/pattern/format: the field's constraints travel with the
      field wherever it appears.
 
+7. **🚨 `error_responses[].status_code` is ALWAYS 200 for business outcomes**
+   (BUSINESS_OUTCOME_200_RULE — this spec field is what every generator reads).
+
+   An Amazon Connect AI agent treats **any non-2xx tool response as an execution
+   failure**: it never reads the body, so it cannot tell the customer what
+   happened — it just says there is a problem with the tool and the turn is lost.
+
+   So a *business outcome* is never an HTTP error. When you record an
+   `error_responses` entry for any outcome the AI agent must SPEAK ABOUT, set
+   `status_code: 200` and put the outcome in the body via `error_code`:
+
+   | Outcome the customer hears about | `status_code` | `error_code` |
+   |---|---|---|
+   | auth digits / SSN / PIN mismatch | **200** | `UNAUTHORIZED` |
+   | record / reservation not found | **200** | `NOT_FOUND` |
+   | too many attempts, locked out | **200** | `RATE_LIMITED` |
+   | date unavailable, seat taken | **200** | `CONFLICT` / `DATE_UNAVAILABLE` |
+   | missing or invalid input the customer can supply | **200** | `VALIDATION_ERROR` |
+   | unhandled exception, database down | 500 | `INTERNAL_ERROR` |
+
+   `500` is the ONLY status that stays non-2xx (Connect retries 5xx, which is
+   correct for a transient fault).
+
+   Also make sure `output_fields` includes an explicit **discriminator** the model
+   can branch on — `verified`, `found`, `available`, `success` or `status` — plus a
+   customer-readable `message`. Without it a 200 cannot express "failed", and the
+   agent cannot tell a negative outcome from a positive one.
+
+   ```python
+   # ✅ authentication operation: the failure modes are 200 + a discriminator
+   save_operation_spec(
+       operation_id="verifyCaller",
+       output_fields=[
+           {"name": "verified", "type": "boolean"},        # ← discriminator
+           {"name": "remainingAttempts", "type": "number"},
+           {"name": "lockout", "type": "boolean"},
+           {"name": "message", "type": "string"},
+       ],
+       error_responses=[
+           {"status_code": 200, "error_code": "UNAUTHORIZED",
+            "message": "The digits provided do not match our records.",
+            "condition": "lastFourDigits mismatch"},
+           {"status_code": 200, "error_code": "RATE_LIMITED",
+            "message": "Too many attempts — transferring you to an agent.",
+            "condition": "attempts >= 3"},
+           {"status_code": 500, "error_code": "INTERNAL_ERROR",
+            "message": "Internal error", "condition": "unhandled exception"},
+       ],
+   )
+   ```
+
+   ❌ Never write `{"status_code": 403, "error_code": "UNAUTHORIZED"}` — that is
+   the exact drift that makes a working Lambda look like a broken tool.
+
 ### Example: Calling Infrastructure Generator (Recommended)
 ```python
 # After interview is complete, generate complete CloudFormation template

--- a/backend/ecs/src/templates/deploy_workshop.sh
+++ b/backend/ecs/src/templates/deploy_workshop.sh
@@ -1965,11 +1965,49 @@ import sys, json, re
 problems = '''$RESULT'''
 path = sys.argv[1]
 d = json.load(open(path))
-# Invalid Action property name. Path: Actions[i].Parameters.X -> drop that parameter
-for m in re.finditer(r'Actions\[(\d+)\]\.Parameters\.([A-Za-z]+)', problems):
-    idx, prop = int(m.group(1)), m.group(2)
-    if idx < len(d['Actions']):
-        d['Actions'][idx]['Parameters'].pop(prop, None)
+
+# Redaction/language conflict. Contact Lens real-time redaction is only offered
+# for some languages; requesting it with any other AnalyticsLanguage is rejected
+# with a message that blames AnalyticsLanguage, not the redaction block. Deleting
+# the language then yields "missing required property" (it IS required), so the
+# generic rules below can never converge — handle it explicitly, first.
+# Verified against CreateContactFlow (2026-08-06): en-US + redaction passes,
+# ko-KR + redaction fails, ko-KR without redaction passes.
+REDACTION_OK = {'en-US','en-GB','en-AU','en-IN','es-US','fr-CA','fr-FR','de-DE','it-IT','pt-BR'}
+if 'AnalyticsLanguage' in problems:
+    for a in d.get('Actions', []):
+        vab = ((a.get('Parameters') or {}).get('VoiceBehavior') or {}).get('VoiceAnalyticsBehavior')
+        if not isinstance(vab, dict):
+            continue
+        red = vab.get('ConversationalAnalyticsRedactionConfiguration')
+        if isinstance(red, dict) and str(red.get('Enabled','')).lower() == 'true' \
+           and str(vab.get('AnalyticsLanguage','')) not in REDACTION_OK:
+            vab['ConversationalAnalyticsRedactionConfiguration'] = {'Enabled': 'False'}
+
+# Generic: drop the property the API called invalid. Two things matter here.
+#  1. Delete the LEAF named in the path, not the top-level branch. The old code
+#     matched only the first path segment, so a complaint about
+#     Parameters.VoiceBehavior.VoiceAnalyticsBehavior.AnalyticsLanguage deleted
+#     the whole VoiceBehavior and left Parameters {} — itself invalid, turning a
+#     fixable flow into an unfixable one.
+#  2. Only act on "Invalid ..." problems. For "missing required property",
+#     deleting things is exactly backwards.
+for pm in re.finditer(r'(Invalid Action property (?:value|name)|Action is missing required property)\.\s*Path:\s*Actions\[(\d+)\]\.Parameters((?:\.[A-Za-z0-9_]+)*)', problems):
+    kind, idx, rest = pm.group(1), int(pm.group(2)), pm.group(3)
+    if kind.startswith('Action is missing') or idx >= len(d.get('Actions', [])):
+        continue
+    segs = [s for s in rest.split('.') if s]
+    if not segs:
+        continue  # "Parameters" itself — nothing safe to delete generically
+    node = d['Actions'][idx].get('Parameters')
+    for s in segs[:-1]:
+        if not isinstance(node, dict):
+            node = None
+            break
+        node = node.get(s)
+    if isinstance(node, dict):
+        node.pop(segs[-1], None)
+
 json.dump(d, open(path, 'w'), ensure_ascii=False, indent=1)
 PYEOF
         attempt=$((attempt+1))

--- a/backend/ecs/src/tools/asset_linters.py
+++ b/backend/ecs/src/tools/asset_linters.py
@@ -900,6 +900,40 @@ _VALID_JSONPATH_ROOTS = (
 )
 
 
+# Languages for which Contact Lens real-time redaction can be requested inside
+# UpdateContactRecordingAndAnalyticsBehavior. Asking for redaction with any other
+# AnalyticsLanguage makes CreateContactFlow reject the flow, and the error names
+# AnalyticsLanguage rather than the redaction block — see the fix-up below.
+# Verified against CreateContactFlow (ap-northeast-2, 2026-08-06): en-US passes
+# with redaction enabled, ko-KR does not.
+REDACTION_SUPPORTED_LANGUAGES = {
+    "en-US", "en-GB", "en-AU", "en-IN", "es-US", "fr-CA", "fr-FR",
+    "de-DE", "it-IT", "pt-BR",
+}
+
+# Fallback when analytics is enabled but AnalyticsLanguage is missing (the API
+# requires it). Matches the default the rest of the pipeline assumes.
+_DEFAULT_ANALYTICS_LANGUAGE = "ko-KR"
+
+
+def _flow_analytics_language(actions: list) -> str:
+    """Best-guess AnalyticsLanguage for a flow, from its own voice settings."""
+    for a in actions:
+        if not isinstance(a, dict):
+            continue
+        p = a.get("Parameters") or a.get("parameters") or {}
+        if not isinstance(p, dict):
+            continue
+        for key in ("LanguageCode", "AnalyticsLanguage"):
+            val = p.get(key)
+            if isinstance(val, str) and "-" in val:
+                return val
+        tts = p.get("TextToSpeechVoice")
+        if isinstance(tts, dict) and isinstance(tts.get("languageCode"), str):
+            return tts["languageCode"]
+    return _DEFAULT_ANALYTICS_LANGUAGE
+
+
 def _normalize_contact_flow_params(actions: list, ids_to_first: dict, fixes: list) -> None:
     """Rewrite block Parameters/Transitions to the shapes Amazon Connect's
     CreateContactFlow API actually accepts. Mutates `actions` in place and
@@ -953,6 +987,40 @@ def _normalize_contact_flow_params(actions: list, ids_to_first: dict, fixes: lis
                 if et not in have and nxt:
                     errs.append({"ErrorType": et, "NextAction": nxt})
                     fixes.append(f"[{aid}] UpdateContactRecordingAndAnalyticsBehavior: added required {et} error branch")
+
+            # Contact Lens real-time redaction is only supported for a subset of
+            # languages. Asking for it with an unsupported AnalyticsLanguage is
+            # rejected as "Invalid Action property value ... AnalyticsLanguage",
+            # which is misleading — the language is fine, the REDACTION is not.
+            # CreateContactFlow-verified (2026-08-06, ap-northeast-2):
+            #   ko-KR + redaction Enabled=True  -> Invalid ... AnalyticsLanguage
+            #   en-US + redaction Enabled=True  -> OK
+            #   ko-KR + redaction absent/False  -> OK
+            #   AnalyticsLanguage omitted       -> "missing required property"
+            # So: keep AnalyticsLanguage (it is REQUIRED) and drop the redaction
+            # request instead. Recording/analytics still work; only redaction is
+            # unavailable for that language.
+            vb = p.get("VoiceBehavior") if isinstance(p, dict) else None
+            vab = vb.get("VoiceAnalyticsBehavior") if isinstance(vb, dict) else None
+            if isinstance(vab, dict):
+                lang = str(vab.get("AnalyticsLanguage") or "")
+                red = vab.get("ConversationalAnalyticsRedactionConfiguration")
+                red_on = isinstance(red, dict) and str(red.get("Enabled", "")).lower() == "true"
+                if red_on and lang not in REDACTION_SUPPORTED_LANGUAGES:
+                    vab["ConversationalAnalyticsRedactionConfiguration"] = {"Enabled": "False"}
+                    fixes.append(
+                        f"[{aid}] UpdateContactRecordingAndAnalyticsBehavior: disabled "
+                        f"ConversationalAnalyticsRedactionConfiguration — redaction is not "
+                        f"supported for AnalyticsLanguage={lang or '(unset)'} and the API "
+                        f"rejects the flow with a misleading AnalyticsLanguage error"
+                    )
+                # AnalyticsLanguage is REQUIRED whenever analytics is enabled.
+                elif not lang and str(vab.get("Enabled", "")).lower() == "true":
+                    vab["AnalyticsLanguage"] = _flow_analytics_language(actions)
+                    fixes.append(
+                        f"[{aid}] UpdateContactRecordingAndAnalyticsBehavior: added required "
+                        f"AnalyticsLanguage={vab['AnalyticsLanguage']}"
+                    )
 
         # --- UpdateContactRecordingBehavior: {Agent, Customer} → RecordingBehavior
         if t == "UpdateContactRecordingBehavior":

--- a/backend/ecs/src/tools/asset_linters.py
+++ b/backend/ecs/src/tools/asset_linters.py
@@ -513,6 +513,158 @@ def lint_python_source(code: str) -> dict:
         return {"ok": False, "errors": [{"line": None, "message": str(e)[:120]}]}
 
 
+# An Amazon Connect AI agent treats any non-2xx tool response as an execution
+# failure: it never reads the body, so it cannot relay the outcome and just says
+# the tool is broken. Business outcomes ("digits didn't match", "not found",
+# "locked out", "date unavailable") MUST therefore be 200 with a discriminator in
+# the body. 5xx is left alone — a genuine fault, and Connect's retry is correct.
+# See BUSINESS_OUTCOME_200_RULE in agents/_consistency_rules.py.
+_BUSINESS_OUTCOME_4XX = range(400, 500)
+
+# A 200 body has to let the model tell outcomes apart without the status code.
+_DISCRIMINATOR_KEYS = frozenset({
+    "verified", "found", "success", "available", "status", "outcome", "lockout",
+    "eligible", "valid", "matched", "exists", "authenticated", "allowed",
+    "isvalid", "iseligible", "errorcode", "resultcode",
+})
+
+
+def _status_code_nodes(tree) -> list:
+    """Collect AST Constant nodes that are an HTTP status code in a response.
+
+    Two shapes, which are the only two the generators emit:
+      * ``create_response(4xx, {...})`` / ``..., status_code=4xx)`` — any callee
+        whose name ends in ``response`` (create_response, _response, make_response)
+      * a dict literal carrying ``"statusCode": 4xx`` (returned to API Gateway)
+
+    Returns a list of (const_node, body_node_or_None) so the caller can also
+    inspect the body that ships with the code.
+    """
+    import ast
+
+    found: list = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            fname = ""
+            if isinstance(node.func, ast.Name):
+                fname = node.func.id
+            elif isinstance(node.func, ast.Attribute):
+                fname = node.func.attr
+            if not fname.lower().endswith("response"):
+                continue
+            body = node.args[1] if len(node.args) > 1 else None
+            if node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, int):
+                found.append((node.args[0], body))
+            for kw in node.keywords:
+                if kw.arg in ("status_code", "statusCode", "code") and \
+                        isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, int):
+                    found.append((kw.value, body))
+        elif isinstance(node, ast.Dict):
+            for key, value in zip(node.keys, node.values):
+                if not (isinstance(key, ast.Constant) and key.value == "statusCode"):
+                    continue
+                if isinstance(value, ast.Constant) and isinstance(value.value, int):
+                    found.append((value, node))
+    return found
+
+
+def _body_has_discriminator(body_node) -> bool:
+    """True if the response body carries a field the model can branch on.
+
+    Only inspects literal dict keys — a body built by a helper call is given the
+    benefit of the doubt (we cannot see into it, and a false warning is worse
+    than a missing one).
+    """
+    import ast
+
+    if body_node is None:
+        return True
+    if not isinstance(body_node, ast.Dict):
+        return True
+    keys = {
+        k.value.lower()
+        for k in body_node.keys
+        if isinstance(k, ast.Constant) and isinstance(k.value, str)
+    }
+    if not keys:
+        return True
+    return bool(keys & _DISCRIMINATOR_KEYS)
+
+
+def lint_lambda_status_codes(code: str) -> dict:
+    """Rewrite 4xx business-outcome responses to 200 (BUSINESS_OUTCOME_200_RULE).
+
+    This is the deterministic safety net for the failure the prompts also warn
+    about: a Lambda that answers "authentication failed" with 403 makes the
+    Connect AI agent report a broken tool instead of telling the customer what
+    happened. Observed on a real build where an SSN/accountId verification tool
+    returned 400/403/409 and every negative path had to be corrected by hand.
+
+    Rewrites are position-exact (AST offsets), so only the integer literal
+    changes — comments, strings and formatting are untouched. 5xx is preserved.
+    Never raises; returns the input unchanged if anything goes wrong.
+
+    Returns {ok, fixed_code, fixes_applied, warnings}.
+    """
+    out = {"ok": True, "fixed_code": code, "fixes_applied": [], "warnings": []}
+    try:
+        import ast
+
+        tree = ast.parse(code)
+    except SyntaxError:
+        # Syntax is reported by lint_python_source; nothing safe to do here.
+        return out
+    except Exception as e:
+        logger.warning(f"[LINT_LAMBDA] status-code scan skipped: {e}")
+        return out
+
+    try:
+        edits = []
+        for const, body in _status_code_nodes(tree):
+            if const.value not in _BUSINESS_OUTCOME_4XX:
+                continue
+            if const.end_lineno is None or const.end_col_offset is None:
+                continue
+            edits.append((const.lineno, const.col_offset, const.end_col_offset, const.value, body))
+
+        if not edits:
+            return out
+
+        lines = code.splitlines(keepends=True)
+        # Apply bottom-up / right-to-left so earlier offsets stay valid.
+        for lineno, col, end_col, old_value, body in sorted(edits, reverse=True):
+            idx = lineno - 1
+            if idx >= len(lines):
+                continue
+            line = lines[idx]
+            if line[col:end_col] != str(old_value):
+                # Offsets didn't line up (unexpected encoding/continuation) —
+                # skip rather than corrupt the file.
+                continue
+            lines[idx] = line[:col] + "200" + line[end_col:]
+            out["fixes_applied"].append(
+                f"line {lineno}: HTTP {old_value} → 200 "
+                "(business outcome must be 200 or the Connect AI agent reads it as a tool failure)"
+            )
+            if not _body_has_discriminator(body):
+                out["warnings"].append(
+                    f"line {lineno}: response body has no outcome discriminator "
+                    f"(one of {', '.join(sorted(list(_DISCRIMINATOR_KEYS)[:6]))}...) — "
+                    "the AI agent cannot tell this apart from success; add e.g. "
+                    '"success": false with a customer-readable "message"'
+                )
+
+        candidate = "".join(lines)
+        # Re-parse: a rewrite that breaks the file must never be shipped.
+        ast.parse(candidate)
+        out["fixed_code"] = candidate
+        out["fixes_applied"].reverse()
+        return out
+    except Exception as e:
+        logger.warning(f"[LINT_LAMBDA] status-code autofix aborted, passing through: {e}")
+        return {"ok": True, "fixed_code": code, "fixes_applied": [], "warnings": []}
+
+
 @tool
 def lint_lambda(session_id: str = "", operation_id: str = "", file_name: str = "index.py") -> dict:
     """Syntax-check a generated Lambda handler (Python) for a session.

--- a/backend/ecs/src/tools/openapi_generator.py
+++ b/backend/ecs/src/tools/openapi_generator.py
@@ -393,22 +393,13 @@ def _build_responses(op_spec: OperationSpec, success_schema_name: str) -> dict:
             }
         }
 
-    # Add standard error responses if not already present
-    if "400" not in responses:
-        responses["400"] = {
-            "description": "Bad request - validation error",
-            "content": {
-                "application/json": {
-                    "schema": error_schema
-                }
-            }
-        }
-
-    if "401" not in responses and op_spec.requires_authentication:
-        responses["401"] = {
-            "description": "Unauthorized - API key required"
-        }
-
+    # Deliberately NO 4xx entries here (BUSINESS_OUTCOME_200_RULE). An Amazon
+    # Connect AI agent reads any non-2xx as a tool execution failure — it never
+    # looks at the body — so declaring a 400/401 teaches the model to expect a
+    # failure it cannot relay to the customer. Business outcomes (validation,
+    # not-found, auth mismatch, conflict) are 200 with a discriminator in the
+    # body; ErrorResponse.status_code coerces them. Only 5xx stays non-2xx,
+    # because a genuine fault is exactly what Connect should retry.
     if "500" not in responses:
         responses["500"] = {
             "description": "Internal server error",

--- a/backend/ecs/src/tools/project_workspace.py
+++ b/backend/ecs/src/tools/project_workspace.py
@@ -61,6 +61,31 @@ def get_workspace() -> Optional["ProjectWorkspace"]:
     return get_workspace_for(current_session_id.get())
 
 
+def ensure_workspace() -> Optional["ProjectWorkspace"]:
+    """Like :func:`get_workspace`, but rebuild the workspace if it went missing.
+
+    A ProjectWorkspace holds no unrecoverable state — just the session_id plus
+    read-through caches — so recreating one for a session that still has a bound
+    ``current_session_id`` is always safe and strictly better than failing the
+    caller's write.
+
+    This exists because the workspace CAN disappear mid-turn: a reconnect that
+    fires ``createNewSession`` runs cleanup_session() and drops the dict entry
+    while the agent is still streaming. app.py now refuses to reset a session with
+    a live agent task, but that guard only covers the paths it knows about — a
+    write that lands here must not be lost to a bookkeeping race.
+    """
+    sid = current_session_id.get()
+    if not sid:
+        return None
+    ws = get_workspace_for(sid)
+    if ws is None:
+        ws = ProjectWorkspace(sid)
+        set_workspace_for(sid, ws)
+        logger.warning(f"[Workspace] Re-initialised mid-turn for session {sid}")
+    return ws
+
+
 # ---------------------------------------------------------------------------
 # ProjectWorkspace
 # ---------------------------------------------------------------------------
@@ -436,7 +461,7 @@ def save_requirement_document(
     Returns:
         Confirmation with S3 key and a character count
     """
-    ws = get_workspace()
+    ws = ensure_workspace()
     if not ws:
         return {"success": False, "error": "Workspace not initialised (no session)"}
     ok = ws.save_requirement(doc_type, content, operation_id)
@@ -487,7 +512,7 @@ def load_requirement_document(
     Returns:
         The document content or an error if not found
     """
-    ws = get_workspace()
+    ws = ensure_workspace()
     if not ws:
         return {"success": False, "error": "Workspace not initialised (no session)"}
     text = ws.load_requirement(doc_type, operation_id)

--- a/backend/ecs/src/tools/spec_manager.py
+++ b/backend/ecs/src/tools/spec_manager.py
@@ -1272,8 +1272,8 @@ def save_operation_spec(
         if sid:
             _nfs_persist_spec(sid, operation_id, spec.model_dump())
         try:
-            from tools.project_workspace import get_workspace
-            ws = get_workspace()
+            from tools.project_workspace import ensure_workspace
+            ws = ensure_workspace()
             if ws:
                 ws.save_spec(operation_id, spec.model_dump())
         except Exception as e:
@@ -1361,8 +1361,8 @@ def get_operation_spec(operation_id: str) -> dict:
 
         # S3 fallback (A2)
         try:
-            from tools.project_workspace import get_workspace
-            ws = get_workspace()
+            from tools.project_workspace import ensure_workspace
+            ws = ensure_workspace()
             if ws:
                 spec_dict = ws.load_spec(operation_id)
                 if spec_dict:
@@ -1432,8 +1432,8 @@ def get_all_specs() -> dict[str, OperationSpec]:
         # S3 fallback if still empty
         if not _specs_bucket():
             try:
-                from tools.project_workspace import get_workspace
-                ws = get_workspace()
+                from tools.project_workspace import ensure_workspace
+                ws = ensure_workspace()
                 if ws:
                     all_dicts = ws.load_all_specs()
                     for op_id, spec_dict in all_dicts.items():
@@ -1586,8 +1586,8 @@ def restore_specs_from_workspace():
 
     # S3 fallback for any missing specs
     try:
-        from tools.project_workspace import get_workspace
-        ws = get_workspace()
+        from tools.project_workspace import ensure_workspace
+        ws = ensure_workspace()
         if ws:
             all_dicts = ws.load_all_specs()
             s3_restored = 0
@@ -1630,8 +1630,8 @@ def update_operation_spec(
     # Load existing spec (memory first, then S3 fallback)
     if operation_id not in _specs_bucket():
         try:
-            from tools.project_workspace import get_workspace
-            ws = get_workspace()
+            from tools.project_workspace import ensure_workspace
+            ws = ensure_workspace()
             if ws:
                 spec_dict = ws.load_spec(operation_id)
                 if spec_dict:
@@ -1690,8 +1690,8 @@ def update_operation_spec(
         if sid:
             _nfs_persist_spec(sid, operation_id, updated_spec.model_dump())
         try:
-            from tools.project_workspace import get_workspace
-            ws = get_workspace()
+            from tools.project_workspace import ensure_workspace
+            ws = ensure_workspace()
             if ws:
                 ws.save_spec(operation_id, updated_spec.model_dump())
         except Exception as e:
@@ -1734,8 +1734,8 @@ def format_operation_summary() -> dict:
     # Ensure specs are loaded from S3 if memory is empty
     if not _specs_bucket():
         try:
-            from tools.project_workspace import get_workspace
-            ws = get_workspace()
+            from tools.project_workspace import ensure_workspace
+            ws = ensure_workspace()
             if ws:
                 all_dicts = ws.load_all_specs()
                 for op_id, spec_dict in all_dicts.items():
@@ -1906,8 +1906,8 @@ def get_session_flow_config() -> Optional[SessionFlowConfig]:
         # S3 fallback
         if cfg is None:
             try:
-                from tools.project_workspace import get_workspace
-                ws = get_workspace()
+                from tools.project_workspace import ensure_workspace
+                ws = ensure_workspace()
                 if ws:
                     data = ws.load_flow_config()
                     if data:
@@ -1991,8 +1991,8 @@ def save_session_flow_config(
                 except Exception as e:
                     logger.warning(f"[SpecManager] NFS persist failed for flow config: {e}")
         try:
-            from tools.project_workspace import get_workspace
-            ws = get_workspace()
+            from tools.project_workspace import ensure_workspace
+            ws = ensure_workspace()
             if ws:
                 ws.save_flow_config(config.model_dump())
         except Exception as e:
@@ -2057,8 +2057,8 @@ def get_contact_flow_spec() -> Optional[ContactFlowSpec]:
         logger.warning(f"[SpecManager] NFS contact_flow_spec restore failed: {e}")
     # S3 fallback
     try:
-        from tools.project_workspace import get_workspace
-        ws = get_workspace()
+        from tools.project_workspace import ensure_workspace
+        ws = ensure_workspace()
         if ws and hasattr(ws, "_load_json"):
             data = ws._load_json(["contact_flow_spec.json"])
             if data:
@@ -2134,8 +2134,8 @@ def save_contact_flow_spec(
                 except Exception as e:
                     logger.warning(f"[SpecManager] NFS persist failed for contact_flow_spec: {e}")
             try:
-                from tools.project_workspace import get_workspace
-                ws = get_workspace()
+                from tools.project_workspace import ensure_workspace
+                ws = ensure_workspace()
                 if ws and hasattr(ws, "_save_json"):
                     ws._save_json(["contact_flow_spec.json"], spec.model_dump())
             except Exception as e:
@@ -2271,8 +2271,8 @@ def save_infrastructure_spec(
 
         # Persist to S3
         try:
-            from tools.project_workspace import get_workspace
-            ws = get_workspace()
+            from tools.project_workspace import ensure_workspace
+            ws = ensure_workspace()
             if ws:
                 ws.save_infrastructure_spec(spec_dict)
         except Exception as e:
@@ -2325,8 +2325,8 @@ def get_infrastructure_spec() -> Optional[InfrastructureSpec]:
         # S3 fallback
         if spec is None:
             try:
-                from tools.project_workspace import get_workspace
-                ws = get_workspace()
+                from tools.project_workspace import ensure_workspace
+                ws = ensure_workspace()
                 if ws:
                     data = ws.load_infrastructure_spec()
                     if data:
@@ -2429,8 +2429,8 @@ def restore_flow_config_from_workspace():
 
     # S3 fallback
     try:
-        from tools.project_workspace import get_workspace
-        ws = get_workspace()
+        from tools.project_workspace import ensure_workspace
+        ws = ensure_workspace()
         if ws:
             data = ws.load_flow_config()
             if data:

--- a/backend/ecs/src/tools/spec_manager.py
+++ b/backend/ecs/src/tools/spec_manager.py
@@ -29,6 +29,36 @@ from tools.session_context import (
 logger = logging.getLogger(__name__)
 
 
+def _gsi_name_list(gsi) -> list[str]:
+    """GSI index names, whatever shape gsi_indexes happens to be in.
+
+    DataSourceSpec normalizes this on the way in, but specs already persisted to
+    NFS can hold the raw shape, so every reader goes through here.
+
+    The trap: ``for g in gsi_indexes`` over a bare string iterates CHARACTERS, so
+    "phone-index" renders as "p, h, o, n, e, -, i, n, d, e, x" (seen on prod
+    2026-08-05). A string is therefore treated as one name — or as a
+    comma-separated list of names — never as a sequence of characters.
+    """
+    if not gsi:
+        return []
+    if isinstance(gsi, str):
+        return [p.strip() for p in gsi.split(",") if p.strip()]
+    if isinstance(gsi, dict):
+        gsi = [gsi]
+    names: list[str] = []
+    for g in gsi:
+        if isinstance(g, dict):
+            names.append(str(g.get("name") or g.get("index_name") or "?"))
+        elif isinstance(g, str):
+            names.append(g)
+        elif hasattr(g, "name"):
+            names.append(str(getattr(g, "name", "?")))
+        else:
+            names.append(str(g))
+    return names
+
+
 class FlexibleBaseModel(BaseModel):
     """
     Base model with flexible configuration for LLM compatibility.
@@ -268,6 +298,35 @@ class DataSourceSpec(FlexibleBaseModel):
     )
     connection_secret_arn: Optional[str] = Field(default=None)
     region: Optional[str] = Field(default=None)
+
+    @field_validator("gsi_indexes", mode="before")
+    @classmethod
+    def _coerce_gsi_indexes(cls, v):
+        """Accept a bare string / dict for gsi_indexes and wrap it in a list.
+
+        Found on prod 2026-08-05: the model sometimes passes a single index as a
+        plain string ("phone-index") rather than a list. `Optional[list]` allows a
+        str through (a str IS iterable), and every reader does
+        ``for g in gsi_indexes`` — which iterates a string CHARACTER BY CHARACTER
+        and renders "p, h, o, n, e, -, i, n, d, e, x". The agent noticed this in
+        its own summary and "corrected" a spec that was never actually wrong.
+
+        Normalizing here fixes all readers at once instead of hardening each
+        loop, and keeps what's stored on disk in one predictable shape.
+        """
+        if v is None or isinstance(v, list):
+            return v
+        if isinstance(v, str):
+            s = v.strip()
+            if not s:
+                return None
+            # "phone-index, reservation-index" → two entries.
+            return [{"name": part.strip()} for part in s.split(",") if part.strip()]
+        if isinstance(v, dict):
+            return [v]
+        if isinstance(v, tuple):
+            return list(v)
+        return v
 
 
 class ToolSpec(FlexibleBaseModel):
@@ -882,10 +941,9 @@ def _format_spec_as_markdown(op_id: str, spec: OperationSpec) -> str:
         table = getattr(ds, 'table_name', None) or '?'
         pk = getattr(ds, 'partition_key', None) or '?'
         lines += ["", "### Data Source", f"- Table: `{table}` (PK: `{pk}`)"]
-        gsi = getattr(ds, 'gsi_indexes', None) or []
+        gsi = _gsi_name_list(getattr(ds, 'gsi_indexes', None))
         if gsi:
-            gsi_names = [g.get('name', '?') if isinstance(g, dict) else str(g) for g in gsi]
-            lines.append(f"- GSI: {', '.join(gsi_names)}")
+            lines.append(f"- GSI: {', '.join(gsi)}")
 
     # Business rules
     if spec.business_rules:
@@ -1710,15 +1768,7 @@ def format_operation_summary() -> dict:
         if ds:
             table = getattr(ds, "table_name", None) or "?"
             pk = getattr(ds, "partition_key", None) or "?"
-            gsi_list = getattr(ds, "gsi_indexes", None) or []
-            gsi_names = []
-            for g in gsi_list:
-                if isinstance(g, dict):
-                    gsi_names.append(g.get("name", "?"))
-                elif hasattr(g, "name"):
-                    gsi_names.append(getattr(g, "name", "?"))
-                else:
-                    gsi_names.append(str(g))
+            gsi_names = _gsi_name_list(getattr(ds, "gsi_indexes", None))
             gsi_str = ", ".join(gsi_names) if gsi_names else "none"
             ds_info = f"{table} (PK: {pk}, GSI: {gsi_str})"
 

--- a/backend/ecs/src/tools/spec_manager.py
+++ b/backend/ecs/src/tools/spec_manager.py
@@ -201,13 +201,43 @@ class BusinessRule(FlexibleBaseModel):
 
 
 class ErrorResponse(FlexibleBaseModel):
-    """Specification for an error response."""
+    """Specification for an error response.
+
+    NOTE on ``status_code``: an Amazon Connect AI agent treats any non-2xx tool
+    response as an execution failure — it never reads the body, so it cannot relay
+    the outcome and simply reports that the tool is broken. Business outcomes are
+    therefore coerced to 200 here (BUSINESS_OUTCOME_200_RULE); only 5xx, a genuine
+    fault Connect should retry, is preserved.
+    """
 
     status_code: Optional[int] = Field(
         default=None,
-        description="HTTP status code",
+        description="HTTP status code (business outcomes are always 200; only 5xx faults differ)",
         validation_alias=AliasChoices("status_code", "statusCode", "status", "code")
     )
+
+    @field_validator("status_code", mode="before")
+    @classmethod
+    def _coerce_business_outcome_to_200(cls, v):
+        """Rewrite a 4xx business outcome to 200.
+
+        The orchestrator prompt already says to record 200, but the spec is what
+        every downstream generator reads, so the invariant is enforced here rather
+        than trusted. Non-int values are passed through untouched for Pydantic's
+        own error reporting.
+        """
+        try:
+            code = int(v)
+        except (TypeError, ValueError):
+            return v
+        if 400 <= code < 500:
+            logger.warning(
+                f"[SPEC] error_responses.status_code {code} → 200: a business outcome "
+                "must be 2xx or the Connect AI agent reads it as a tool failure "
+                "(BUSINESS_OUTCOME_200_RULE)"
+            )
+            return 200
+        return code
     error_code: Optional[str] = Field(
         default=None,
         validation_alias=AliasChoices("error_code", "errorCode")

--- a/backend/ecs/tests/test_contact_flow_linter.py
+++ b/backend/ecs/tests/test_contact_flow_linter.py
@@ -307,3 +307,61 @@ def test_getparticipantinput_store_mode_strips_invalid_dtmf_and_errors():
     # only NoMatchingError remains
     types = {e["ErrorType"] for e in a["Transitions"]["Errors"]}
     assert types == {"NoMatchingError"}
+
+
+def _analytics_flow(language="ko-KR", redaction_enabled=True):
+    """A flow whose recording block asks for Contact Lens redaction."""
+    flow = _valid_flow()
+    vab = {
+        "Enabled": "True",
+        "AnalyticsModes": ["RealTime", "AutomatedInteraction"],
+        "SentimentConfiguration": {"Enabled": "True"},
+    }
+    if language is not None:
+        vab["AnalyticsLanguage"] = language
+    if redaction_enabled is not None:
+        vab["ConversationalAnalyticsRedactionConfiguration"] = {
+            "Enabled": "True" if redaction_enabled else "False",
+            "RedactionResults": "RedactedAndOriginal",
+            "RedactionEntities": ["ALL"],
+        }
+    flow["Actions"].insert(1, {
+        "Identifier": "rec", "Type": "UpdateContactRecordingAndAnalyticsBehavior",
+        "Parameters": {"VoiceBehavior": {
+            "VoiceRecordingBehavior": {"RecordedParticipants": ["Agent", "Customer"]},
+            "VoiceAnalyticsBehavior": vab}},
+        "Transitions": {"NextAction": "end"}})
+    flow["Actions"][0]["Transitions"]["NextAction"] = "rec"
+    return flow
+
+
+def _voice_analytics(flow, identifier="rec"):
+    a, _ = _fixed_action(flow, identifier)
+    return a["Parameters"]["VoiceBehavior"]["VoiceAnalyticsBehavior"]
+
+
+def test_redaction_disabled_for_unsupported_analytics_language():
+    # ko-KR + redaction is rejected by CreateContactFlow, and the error names
+    # AnalyticsLanguage. The language is required, so redaction is what must go.
+    vab = _voice_analytics(_analytics_flow(language="ko-KR"))
+    assert vab["AnalyticsLanguage"] == "ko-KR"
+    assert vab["ConversationalAnalyticsRedactionConfiguration"] == {"Enabled": "False"}
+
+
+def test_redaction_kept_for_supported_analytics_language():
+    vab = _voice_analytics(_analytics_flow(language="en-US"))
+    assert vab["AnalyticsLanguage"] == "en-US"
+    assert vab["ConversationalAnalyticsRedactionConfiguration"]["Enabled"] == "True"
+
+
+def test_missing_analytics_language_is_added():
+    # AnalyticsLanguage is required whenever analytics is enabled; without it the
+    # API fails with "Action is missing required property".
+    vab = _voice_analytics(_analytics_flow(language=None, redaction_enabled=False))
+    assert vab["AnalyticsLanguage"]
+
+
+def test_redaction_already_disabled_is_left_alone():
+    flow = _analytics_flow(language="ko-KR", redaction_enabled=False)
+    vab = _voice_analytics(flow)
+    assert vab["ConversationalAnalyticsRedactionConfiguration"]["Enabled"] == "False"

--- a/backend/ecs/tests/test_gsi_index_rendering.py
+++ b/backend/ecs/tests/test_gsi_index_rendering.py
@@ -1,0 +1,117 @@
+"""Regression test: a GSI name must never render character by character.
+
+Found on prod 2026-08-05 (long-input e2e). The agent's own summary showed
+
+    GSI: p, h, o, n, e, -, i, n, d, e, x
+
+instead of ``phone-index``, and the agent then "corrected" a spec that was
+actually stored correctly — burning a turn and re-saving over good data.
+
+Cause: ``DataSourceSpec.gsi_indexes`` is ``Optional[list]``, but the model
+sometimes passes a single index as a bare string. Pydantic lets a ``str`` through
+(nothing coerces it), and every reader did ``for g in gsi_indexes`` — iterating a
+string yields its CHARACTERS. Two independent readers had the bug
+(``_spec_to_markdown`` and the review summary).
+
+Fixed on both sides: a ``mode="before"`` validator wraps non-list input, and all
+readers go through ``_gsi_name_list`` (specs already on NFS still hold the raw
+shape, so the readers can't assume the validator ran).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.abspath(os.path.join(_HERE, "..", "src"))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+from tools.spec_manager import DataSourceSpec, _gsi_name_list  # noqa: E402
+
+# The exact value from the prod transcript.
+PROD_GSI = "phone-index"
+# What the bug produced.
+CHAR_SPLIT = "p, h, o, n, e, -, i, n, d, e, x"
+
+
+def test_the_original_bug_is_reproducible_without_the_helper():
+    """Pin WHY this exists: the naive loop really does split a string.
+
+    If this ever stops being true the helper is redundant — but as long as it
+    holds, every raw ``for g in gsi`` loop is a latent instance of this bug.
+    """
+    naive = [g.get("name", "?") if isinstance(g, dict) else str(g) for g in PROD_GSI]
+    assert ", ".join(naive) == CHAR_SPLIT
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (PROD_GSI, ["phone-index"]),                                # the prod shape
+        ("phone-index, reservation-index", ["phone-index", "reservation-index"]),
+        ([{"name": "phone-index"}], ["phone-index"]),               # documented shape
+        ([{"index_name": "phone-index"}], ["phone-index"]),         # alt key
+        (["phone-index", "res-index"], ["phone-index", "res-index"]),  # list of str
+        ({"name": "phone-index"}, ["phone-index"]),                 # bare dict
+        (None, []),
+        ([], []),
+        ("", []),
+        ("   ", []),
+    ],
+)
+def test_gsi_name_list_handles_every_shape(raw, expected):
+    assert _gsi_name_list(raw) == expected
+
+
+def test_gsi_name_list_never_splits_a_string_into_characters():
+    """The assertion that would have caught the prod bug."""
+    out = _gsi_name_list(PROD_GSI)
+    assert ", ".join(out) != CHAR_SPLIT
+    assert out == ["phone-index"]
+    assert all(len(n) > 1 for n in out), f"a name was split into single chars: {out}"
+
+
+@pytest.mark.parametrize("alias", ["gsi", "gsi_indexes", "gsiIndexes", "indexes", "secondaryIndexes"])
+def test_a_bare_string_is_normalized_on_input_through_every_alias(alias):
+    """The validator must fire regardless of which alias the model used."""
+    spec = DataSourceSpec(**{"table_name": "LoyaltyMembers", alias: PROD_GSI})
+
+    assert isinstance(spec.gsi_indexes, list), f"{alias} left a non-list on the model"
+    assert spec.gsi_indexes == [{"name": "phone-index"}]
+    assert _gsi_name_list(spec.gsi_indexes) == ["phone-index"]
+
+
+def test_documented_list_shape_is_untouched():
+    """The normalizer must not disturb input that was already correct."""
+    proper = [{"name": "phone-index", "partition_key": "phoneNumber"}]
+    spec = DataSourceSpec(table_name="LoyaltyMembers", gsi_indexes=proper)
+    assert spec.gsi_indexes == proper
+
+
+def test_empty_string_becomes_none_not_a_bogus_index():
+    """"" must not turn into [{'name': ''}] — that renders as an empty GSI name."""
+    spec = DataSourceSpec(table_name="T", gsi="")
+    assert not spec.gsi_indexes
+
+
+def test_readers_do_not_iterate_gsi_indexes_directly():
+    """Guard the source. Any ``for g in ...gsi...`` loop reintroduces the bug;
+    readers must go through _gsi_name_list.
+    """
+    import re
+
+    path = os.path.join(_SRC, "tools", "spec_manager.py")
+    with open(path, encoding="utf-8") as f:
+        src = f.read()
+
+    # Allow the loop inside the helper itself; flag it anywhere else.
+    helper_start = src.index("def _gsi_name_list")
+    helper_end = src.index("class FlexibleBaseModel")
+    outside = src[:helper_start] + src[helper_end:]
+
+    bad = re.findall(r"for \w+ in [^\n]*gsi[^\n]*:", outside, flags=re.IGNORECASE)
+    assert not bad, f"a reader iterates gsi directly — use _gsi_name_list: {bad}"

--- a/backend/ecs/tests/test_interview_state.py
+++ b/backend/ecs/tests/test_interview_state.py
@@ -182,6 +182,7 @@ def test_unsafe_session_ids_are_rejected(app_mod, tmp_path, hostile_id):
     victim = _session_dir(tmp_path, "victim")
     (victim / "assets" / "specs" / "secret_op.json").write_text("{}", encoding="utf-8")
 
+    assert app_mod._is_safe_session_id(hostile_id) is False
     assert app_mod._session_base_dir(hostile_id) is None
     assert app_mod._read_interview_state(hostile_id) is None
 
@@ -198,20 +199,34 @@ def test_unsafe_session_ids_are_rejected(app_mod, tmp_path, hostile_id):
 def test_legitimate_session_ids_are_accepted(app_mod, tmp_path, good_id):
     """The allowlist must not be so tight that real sessions break — that would
     silently disable the whole <interview_state> fix."""
+    assert app_mod._is_safe_session_id(good_id) is True
+    _session_dir(tmp_path, good_id)  # the directory must exist to be resolved
     base = app_mod._session_base_dir(good_id)
     assert base is not None
     assert base.name == good_id
     assert base.parent.name == "sessions"
 
 
-def test_resolved_path_stays_inside_the_sessions_root(app_mod, tmp_path):
-    """Second, independent guarantee: whatever the allowlist admits must still
-    resolve inside <mount>/sessions. This is the backstop that keeps traversal
-    impossible even if the pattern is later loosened."""
+def test_resolved_dir_comes_from_the_sessions_listing(app_mod, tmp_path):
+    """The returned Path must be a real child of <mount>/sessions, taken from
+    the directory listing rather than built from the caller's string — that is
+    what makes traversal impossible by construction."""
     sessions_root = (tmp_path / "sessions").resolve()
+    _session_dir(tmp_path, "session-abc")
     base = app_mod._session_base_dir("session-abc")
     assert base is not None
-    assert sessions_root in base.parents
+    assert sessions_root in base.resolve().parents
+
+
+def test_valid_id_with_no_directory_yet_still_gets_the_pending_block(app_mod, tmp_path):
+    """On the FIRST interview turn the session dir may not exist yet. The block
+    must still be emitted — its ⏳ lines and the "one save per turn" rules are
+    exactly what's needed while the first specs are being written. Returning
+    None here would silently drop the fix at the moment it matters most."""
+    out = app_mod._read_interview_state("session-not-created-yet")
+    assert out is not None
+    assert "⏳ Operation specs: none saved yet" in out
+    assert "✅" not in out
 
 
 def test_interview_state_is_injected_only_during_the_interview(app_mod):

--- a/backend/ecs/tests/test_interview_state.py
+++ b/backend/ecs/tests/test_interview_state.py
@@ -154,24 +154,64 @@ def test_reader_never_raises_on_broken_state(app_mod, tmp_path, monkeypatch):
 @pytest.mark.parametrize(
     "hostile_id",
     [
-        # Each of these resolves to <mount>/sessions/victim if left unsanitized,
-        # i.e. it would read another user's specs.
+        # Traversal in several encodings — each resolves INTO another session's
+        # directory (or outside the mount entirely) if used verbatim.
         "../sessions/victim",
         "..%s..%ssessions%svictim" % (os.sep, os.sep, os.sep),
         "sub/../victim",
+        "....//sessions//victim",
+        "/etc/passwd",
+        "..\\..\\sessions\\victim",
+        # Absolute-ish and NUL-byte attempts.
+        "sessions/victim",
+        "victim\x00",
+        # Shapes that are simply not session ids.
+        "",
+        ".",
+        "..",
+        "a" * 200,
     ],
 )
-def test_path_traversal_in_session_id_is_neutralized(app_mod, tmp_path, hostile_id):
-    """The session id reaches the filesystem, so it must be sanitized. These
-    ids all resolve INTO another session's directory when used verbatim, so if
-    the sanitization is dropped the victim's operation ids leak into the block."""
+def test_unsafe_session_ids_are_rejected(app_mod, tmp_path, hostile_id):
+    """The session id is the only user-controlled value that reaches the
+    filesystem here (CodeQL "uncontrolled data in path expression"). Real ids
+    are `session-<uuid4>`, so anything outside the allowlist must be REFUSED —
+    not scrubbed into some neighbouring path. Refusing returns None, which the
+    caller treats as "no block to inject".
+    """
     victim = _session_dir(tmp_path, "victim")
     (victim / "assets" / "specs" / "secret_op.json").write_text("{}", encoding="utf-8")
 
-    out = app_mod._read_interview_state(hostile_id)
+    assert app_mod._session_base_dir(hostile_id) is None
+    assert app_mod._read_interview_state(hostile_id) is None
 
-    assert "secret_op" not in out
-    assert "⏳ Operation specs: none saved yet" in out
+
+@pytest.mark.parametrize(
+    "good_id",
+    [
+        "session-3f2b1c9a-7d4e-4a1b-9c8f-0e5d6a7b8c9d",  # the real shape
+        "test-1",
+        "abc_123",
+        "A" * 128,  # exactly at the length bound
+    ],
+)
+def test_legitimate_session_ids_are_accepted(app_mod, tmp_path, good_id):
+    """The allowlist must not be so tight that real sessions break — that would
+    silently disable the whole <interview_state> fix."""
+    base = app_mod._session_base_dir(good_id)
+    assert base is not None
+    assert base.name == good_id
+    assert base.parent.name == "sessions"
+
+
+def test_resolved_path_stays_inside_the_sessions_root(app_mod, tmp_path):
+    """Second, independent guarantee: whatever the allowlist admits must still
+    resolve inside <mount>/sessions. This is the backstop that keeps traversal
+    impossible even if the pattern is later loosened."""
+    sessions_root = (tmp_path / "sessions").resolve()
+    base = app_mod._session_base_dir("session-abc")
+    assert base is not None
+    assert sessions_root in base.parents
 
 
 def test_interview_state_is_injected_only_during_the_interview(app_mod):

--- a/backend/ecs/tests/test_interview_state.py
+++ b/backend/ecs/tests/test_interview_state.py
@@ -1,0 +1,182 @@
+"""Regression tests for the interview spec-saving loop (2026-08-04 real run).
+
+The reported symptom: in a long interview the agent had already saved every
+operation spec, yet it kept asking "shall I save the specs?" and re-saving the
+same ones. Root cause was twofold:
+
+  1. The orchestrator ran with no ``max_tokens``, so Bedrock applied its 4096
+     default. A turn containing a big ``save_operation_spec`` payload hit the
+     output cap and Strands rewrote EVERY toolUse block in that assistant
+     message as "tool use was incomplete due to maximum token limits being
+     reached" — the tool never ran and the save vanished from history.
+  2. History is pruned (MAX_HISTORY_MESSAGES) and tool payloads truncated, so
+     even successful saves fall out of context in a long interview.
+
+The fix injects ``<interview_state>``, derived from the files on NFS rather
+than from conversation history, so the agent can always see what is already
+persisted. These tests pin that reader's contract: what exists must be
+reported ✅, what doesn't must be ⏳, and it must never raise on a partial or
+missing session directory (it runs on every interview turn).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import pytest
+
+# Make ``src`` importable the same way the Docker entrypoint does.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.abspath(os.path.join(_HERE, "..", "src"))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+
+@pytest.fixture()
+def app_mod(tmp_path, monkeypatch):
+    """Import app.py with the NFS mount pointed at a temp dir.
+
+    S3FILES_MOUNT is read at import time, so patch the module attribute after
+    import to keep this fixture independent of import order.
+    """
+    monkeypatch.setenv("S3FILES_MOUNT_PATH", str(tmp_path))
+    monkeypatch.setenv("SESSION_STORE_BACKEND", "s3files")
+    sys.path.insert(0, os.path.abspath(os.path.join(_HERE, "..")))
+    import app  # noqa: E402
+
+    monkeypatch.setattr(app, "S3FILES_MOUNT", str(tmp_path))
+    return app
+
+
+def _session_dir(tmp_path, sid: str):
+    d = tmp_path / "sessions" / sid
+    (d / "assets" / "specs").mkdir(parents=True, exist_ok=True)
+    (d / "state" / "requirements").mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def test_empty_session_reports_everything_pending(app_mod, tmp_path):
+    """A fresh interview must show every item as ⏳ — and must not crash on a
+    session directory that doesn't exist yet (the very first turn)."""
+    out = app_mod._read_interview_state("brand-new-session")
+    assert out is not None
+    assert "⏳ Operation specs: none saved yet" in out
+    assert "⏳ Infrastructure spec: not saved yet" in out
+    assert "⏳ Requirement documents: none saved yet" in out
+    # Nothing is done, so no ✅ anywhere.
+    assert "✅" not in out
+
+
+def test_saved_specs_are_listed_by_operation_id(app_mod, tmp_path):
+    """The whole point: already-saved specs must be visible as ✅ WITH their
+    ids, so the agent can tell what's done without relying on history."""
+    sid = "sess-specs"
+    d = _session_dir(tmp_path, sid)
+    for op in ("cancel_reservation", "check_availability", "check_reservation"):
+        (d / "assets" / "specs" / f"{op}.json").write_text(
+            json.dumps({"operation_id": op}), encoding="utf-8"
+        )
+
+    out = app_mod._read_interview_state(sid)
+
+    assert "✅ Operation specs SAVED (3):" in out
+    # Sorted and complete — a missing id would let the agent re-ask for it.
+    assert "cancel_reservation, check_availability, check_reservation" in out
+    assert "⏳ Operation specs" not in out
+
+
+def test_infrastructure_spec_is_not_counted_as_an_operation(app_mod, tmp_path):
+    """infrastructure_spec.json lives alongside the op specs in some layouts;
+    counting it would inflate the count and invent an operation that the
+    interviewer never defined."""
+    sid = "sess-infra-mixed"
+    d = _session_dir(tmp_path, sid)
+    (d / "assets" / "specs" / "check_reservation.json").write_text("{}", encoding="utf-8")
+    (d / "assets" / "specs" / "infrastructure_spec.json").write_text("{}", encoding="utf-8")
+
+    out = app_mod._read_interview_state(sid)
+
+    assert "✅ Operation specs SAVED (1): check_reservation" in out
+    assert "infrastructure_spec" not in out.split("\n")[0]
+
+
+def test_state_artifacts_and_requirements_are_reported(app_mod, tmp_path):
+    sid = "sess-state"
+    d = _session_dir(tmp_path, sid)
+    (d / "state" / "infrastructure_spec.json").write_text("{}", encoding="utf-8")
+    (d / "state" / "requirements" / "business_analysis.txt").write_text("x", encoding="utf-8")
+
+    out = app_mod._read_interview_state(sid)
+
+    assert "✅ Infrastructure spec: SAVED" in out
+    # flow_config wasn't written, so it must still read as pending.
+    assert "⏳ Session flow config: not saved yet" in out
+    assert "✅ Requirement documents SAVED: business_analysis" in out
+
+
+def test_handoff_marker_is_surfaced(app_mod, tmp_path, monkeypatch):
+    """Once complete_interview has run, the block must say so — this is what
+    stops the "you said done, shall I save the specs again?" turn."""
+    sid = "sess-handoff"
+    _session_dir(tmp_path, sid)
+    monkeypatch.setattr(app_mod, "check_interview_handoff", lambda _sid: {"status": "ready"})
+
+    out = app_mod._read_interview_state(sid)
+    assert "✅ complete_interview: ALREADY CALLED" in out
+
+
+def test_handoff_marker_absent_when_not_called(app_mod, tmp_path, monkeypatch):
+    sid = "sess-no-handoff"
+    _session_dir(tmp_path, sid)
+    monkeypatch.setattr(app_mod, "check_interview_handoff", lambda _sid: None)
+
+    out = app_mod._read_interview_state(sid)
+    assert "complete_interview" not in out
+
+
+def test_reader_never_raises_on_broken_state(app_mod, tmp_path, monkeypatch):
+    """It runs on EVERY interview turn, so a filesystem hiccup (stale NFS
+    handle, permissions) must degrade to a pending line, not break the turn."""
+    sid = "sess-broken"
+    _session_dir(tmp_path, sid)
+
+    def boom(_sid):
+        raise RuntimeError("NFS stale file handle")
+
+    monkeypatch.setattr(app_mod, "check_interview_handoff", boom)
+
+    out = app_mod._read_interview_state(sid)  # must not raise
+    assert "⏳ Operation specs: none saved yet" in out
+
+
+@pytest.mark.parametrize(
+    "hostile_id",
+    [
+        # Each of these resolves to <mount>/sessions/victim if left unsanitized,
+        # i.e. it would read another user's specs.
+        "../sessions/victim",
+        "..%s..%ssessions%svictim" % (os.sep, os.sep, os.sep),
+        "sub/../victim",
+    ],
+)
+def test_path_traversal_in_session_id_is_neutralized(app_mod, tmp_path, hostile_id):
+    """The session id reaches the filesystem, so it must be sanitized. These
+    ids all resolve INTO another session's directory when used verbatim, so if
+    the sanitization is dropped the victim's operation ids leak into the block."""
+    victim = _session_dir(tmp_path, "victim")
+    (victim / "assets" / "specs" / "secret_op.json").write_text("{}", encoding="utf-8")
+
+    out = app_mod._read_interview_state(hostile_id)
+
+    assert "secret_op" not in out
+    assert "⏳ Operation specs: none saved yet" in out
+
+
+def test_interview_state_is_injected_only_during_the_interview(app_mod):
+    """Sanity on the wiring: the block is prepended to combined_state, so the
+    reader must exist and be callable by the WS handler (a rename would silently
+    drop the fix — the injection is wrapped in a try/except).
+    """
+    assert callable(app_mod._read_interview_state)

--- a/backend/ecs/tests/test_lambda_status_codes.py
+++ b/backend/ecs/tests/test_lambda_status_codes.py
@@ -1,0 +1,426 @@
+"""Regression test: business outcomes must be HTTP 200, not 4xx.
+
+Reported from a real build (2026-08-05). The AI agent authenticated callers with
+accountId + the last 4 SSN digits. On a successful match the generated Lambda
+returned 200 — correct. On a MISMATCH it returned 400/403/409, and the Amazon
+Connect AI agent then told the customer "there is an issue with the tool" instead
+of "those digits don't match, try again".
+
+Cause: Connect treats any non-2xx tool response as an execution failure. It never
+reads the body, so it cannot relay the outcome. Every negative path had to be
+corrected to 200 by hand before the agent worked.
+
+Fixed in two layers:
+  1. BUSINESS_OUTCOME_200_RULE in agents/_consistency_rules.py (shared by the
+     Lambda, OpenAPI and prompt generators) + the per-generator prompts, whose
+     own examples previously taught `create_response(400, ...)`.
+  2. ``lint_lambda_status_codes`` — a deterministic AST autofix that rewrites
+     4xx → 200 before the asset is streamed or persisted. The prompt is the
+     instruction; the linter is the guarantee.
+
+5xx is deliberately preserved: that is a genuine fault, and Connect's retry on
+5xx is the behaviour we want.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.abspath(os.path.join(_HERE, "..", "src"))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+from tools.asset_linters import (  # noqa: E402
+    lint_lambda_status_codes,
+    lint_python_source,
+)
+
+
+def _codes(code: str) -> list[int]:
+    """Every status code passed to a create_response(...) call."""
+    return [int(m) for m in re.findall(r"create_response\((\d+)", code)]
+
+
+# ---------------------------------------------------------------------------
+# The reported case, end to end
+# ---------------------------------------------------------------------------
+
+# Condensed from the handler that was reported: caller verification by
+# accountNumber + last 4 SSN digits, with attempt tracking and lockout.
+REPORTED_HANDLER = '''
+import json
+
+
+def create_response(status_code: int, body: dict) -> dict:
+    return {"statusCode": status_code, "body": json.dumps(body)}
+
+
+def handler(event, context):
+    try:
+        body = json.loads(event.get("body", "{}"))
+        account_number = body.get("accountNumber")
+        last_four_digits = body.get("lastFourDigits")
+
+        if not account_number or not last_four_digits:
+            return create_response(400, {
+                "verified": False,
+                "error": "accountNumber and lastFourDigits are required"
+            })
+
+        current_attempts = _attempt_tracker.get(account_number, 0)
+        if current_attempts >= MAX_ATTEMPTS:
+            return create_response(403, {
+                "verified": False, "remainingAttempts": 0, "lockout": True
+            })
+
+        item = lookup(account_number)
+        if not item:
+            return create_response(404, {"verified": False, "found": False})
+
+        if last_four_digits == item.get("lastFourDigits", ""):
+            return create_response(200, {"verified": True, "lockout": False})
+        else:
+            return create_response(409, {
+                "verified": False, "remainingAttempts": 1, "lockout": False
+            })
+
+    except Exception as e:
+        return create_response(500, {"verified": False, "error": "Internal server error"})
+'''
+
+
+def test_the_reported_bug_every_business_outcome_becomes_200():
+    """400 (missing input), 403 (lockout), 404 (no account), 409 (mismatch) → 200."""
+    result = lint_lambda_status_codes(REPORTED_HANDLER)
+
+    codes = _codes(result["fixed_code"])
+    assert 400 not in codes
+    assert 403 not in codes
+    assert 404 not in codes
+    assert 409 not in codes
+    assert len(result["fixes_applied"]) == 4
+
+
+def test_the_genuine_fault_path_stays_500():
+    """Connect retries 5xx, which is right for a transient fault. Never rewrite it."""
+    result = lint_lambda_status_codes(REPORTED_HANDLER)
+
+    assert 500 in _codes(result["fixed_code"]), "the 500 fault path must be preserved"
+
+
+def test_the_success_path_is_untouched():
+    result = lint_lambda_status_codes(REPORTED_HANDLER)
+
+    assert _codes(result["fixed_code"]).count(200) == 5  # 1 original + 4 rewritten
+
+
+def test_the_rewrite_still_compiles():
+    """A repair that breaks the handler would be far worse than the bug."""
+    result = lint_lambda_status_codes(REPORTED_HANDLER)
+
+    assert lint_python_source(result["fixed_code"])["ok"]
+
+
+def test_the_rewrite_changes_only_the_status_literals():
+    """Position-exact edits: no reflowing, no lost comments, no lost strings."""
+    result = lint_lambda_status_codes(REPORTED_HANDLER)
+    before = REPORTED_HANDLER.splitlines()
+    after = result["fixed_code"].splitlines()
+
+    assert len(before) == len(after)
+    differing = [i for i, (a, b) in enumerate(zip(before, after)) if a != b]
+    assert len(differing) == 4
+    for i in differing:
+        # Only the number changed on each differing line.
+        assert re.sub(r"\d+", "N", before[i]) == re.sub(r"\d+", "N", after[i])
+
+
+def test_bodies_and_comments_survive_verbatim():
+    """The business payload must be preserved exactly — only the code changes."""
+    result = lint_lambda_status_codes(REPORTED_HANDLER)
+
+    for fragment in (
+        '"accountNumber and lastFourDigits are required"',
+        '"remainingAttempts": 1',
+        '"lockout": True',
+        'json.loads(event.get("body", "{}"))',
+    ):
+        assert fragment in result["fixed_code"]
+
+
+# ---------------------------------------------------------------------------
+# Shapes the generators actually emit
+# ---------------------------------------------------------------------------
+
+def test_a_bare_statuscode_dict_is_rewritten():
+    """Not every handler routes through a create_response helper."""
+    code = 'def handler(e, c):\n    return {"statusCode": 404, "body": "{}"}\n'
+
+    result = lint_lambda_status_codes(code)
+
+    assert '"statusCode": 200' in result["fixed_code"]
+    assert result["fixes_applied"]
+
+
+def test_a_status_code_keyword_argument_is_rewritten():
+    code = (
+        "def handler(e, c):\n"
+        '    return create_response(status_code=403, body={"verified": False})\n'
+    )
+
+    result = lint_lambda_status_codes(code)
+
+    assert "status_code=200" in result["fixed_code"]
+
+
+def test_a_helper_named_something_else_is_still_covered():
+    """Generators emit _response / make_response / build_response too."""
+    code = 'def handler(e, c):\n    return make_response(409, {"available": False})\n'
+
+    result = lint_lambda_status_codes(code)
+
+    assert "make_response(200" in result["fixed_code"]
+
+
+def test_a_clean_handler_is_returned_untouched():
+    """No 4xx means no edit and no re-stream — idempotence matters, because a
+    reported fix triggers a full re-stream to the frontend."""
+    code = (
+        "def handler(e, c):\n"
+        '    return create_response(200, {"verified": True})\n'
+    )
+
+    result = lint_lambda_status_codes(code)
+
+    assert result["fixed_code"] == code
+    assert result["fixes_applied"] == []
+
+
+def test_running_it_twice_changes_nothing_further():
+    once = lint_lambda_status_codes(REPORTED_HANDLER)["fixed_code"]
+    twice = lint_lambda_status_codes(once)
+
+    assert twice["fixed_code"] == once
+    assert twice["fixes_applied"] == []
+
+
+def test_201_and_other_2xx_are_left_alone():
+    """A create is legitimately 201; only 4xx is the bug."""
+    code = 'def handler(e, c):\n    return create_response(201, {"success": True})\n'
+
+    result = lint_lambda_status_codes(code)
+
+    assert "create_response(201" in result["fixed_code"]
+    assert result["fixes_applied"] == []
+
+
+# ---------------------------------------------------------------------------
+# Discriminator warning — a 200 the model can't interpret is no better
+# ---------------------------------------------------------------------------
+
+def test_a_200_body_with_no_discriminator_warns():
+    """Rewriting 404 → 200 on a body of only {"error": ...} would make failure
+    indistinguishable from success. Fix the code, but flag the body."""
+    code = (
+        "def handler(e, c):\n"
+        '    return create_response(404, {"message": "not found"})\n'
+    )
+
+    result = lint_lambda_status_codes(code)
+
+    assert result["fixes_applied"]
+    assert result["warnings"], "a 200 with no outcome field must be flagged"
+
+
+def test_a_body_with_a_discriminator_does_not_warn():
+    code = (
+        "def handler(e, c):\n"
+        '    return create_response(404, {"found": False, "message": "not found"})\n'
+    )
+
+    result = lint_lambda_status_codes(code)
+
+    assert result["fixes_applied"]
+    assert result["warnings"] == []
+
+
+def test_a_body_built_by_a_helper_is_given_the_benefit_of_the_doubt():
+    """We cannot see into a helper call; a false warning is worse than none."""
+    code = "def handler(e, c):\n    return create_response(404, build_body(x))\n"
+
+    result = lint_lambda_status_codes(code)
+
+    assert result["warnings"] == []
+
+
+# ---------------------------------------------------------------------------
+# Fault tolerance — linting must never break the pipeline
+# ---------------------------------------------------------------------------
+
+def test_syntactically_invalid_source_passes_through_unchanged():
+    """Syntax is lint_python_source's job. This must not raise or mangle."""
+    broken = 'def handler(e, c):\n    return create_response(404, {"a": \n'
+
+    result = lint_lambda_status_codes(broken)
+
+    assert result["fixed_code"] == broken
+    assert result["fixes_applied"] == []
+
+
+@pytest.mark.parametrize("src", ["", "\n", "# just a comment\n", "x = 1"])
+def test_degenerate_input_is_safe(src):
+    result = lint_lambda_status_codes(src)
+
+    assert result["fixed_code"] == src
+
+
+def test_non_ascii_content_does_not_shift_offsets():
+    """Column offsets are byte-vs-char sensitive; Korean strings are the norm in
+    these generated handlers, so pin that the right literal is replaced."""
+    code = (
+        "def handler(e, c):\n"
+        '    return create_response(403, {"verified": False, "message": "인증에 실패했습니다"})\n'
+    )
+
+    result = lint_lambda_status_codes(code)
+
+    assert "create_response(200" in result["fixed_code"]
+    assert "인증에 실패했습니다" in result["fixed_code"]
+    assert lint_python_source(result["fixed_code"])["ok"]
+
+
+# ---------------------------------------------------------------------------
+# The prompts must agree with the linter
+# ---------------------------------------------------------------------------
+
+def _read(*parts: str) -> str:
+    with open(os.path.join(_SRC, *parts), encoding="utf-8") as f:
+        return f.read()
+
+
+def test_the_shared_golden_rule_exists():
+    """All three affected generators import CONSISTENCY_RULES, so the rule lives
+    there rather than being duplicated per prompt."""
+    rules = _read("agents", "_consistency_rules.py")
+
+    assert "BUSINESS_OUTCOME_200_RULE" in rules
+
+
+def test_no_generator_example_still_teaches_a_4xx_business_outcome():
+    """FEW_SHOT_TRUST_RULE says examples must not contradict the rules — but a
+    model copies the example it can see. The Lambda prompt used to return 400 on
+    a missing field, which is exactly the reported bug.
+    """
+    prompt = _read("agents", "lambda_generator", "system_prompt.py")
+
+    # A 4xx is allowed only inside a block explicitly marked as the wrong way.
+    # The ❌ marker sits on the comment line that opens the block, so track it
+    # until the matching ✅ block starts.
+    offenders = []
+    in_wrong_block = False
+    for line in prompt.splitlines():
+        if "❌" in line:
+            in_wrong_block = True
+        elif "✅" in line:
+            in_wrong_block = False
+        if re.search(r"create_response\(4\d\d", line) and not in_wrong_block:
+            offenders.append(line.strip())
+
+    assert not offenders, (
+        "these examples teach a 4xx business outcome without marking it wrong:\n"
+        + "\n".join(offenders)
+    )
+
+
+def test_the_openapi_prompt_no_longer_maps_outcomes_to_4xx():
+    """A declared 404/409 response teaches the model to expect a failure it
+    cannot handle, so the OpenAPI templates must not declare them either."""
+    prompt = _read("agents", "openapi_generator", "system_prompt.py")
+
+    declared = re.findall(r"^\s+'(4\d\d)':", prompt, re.MULTILINE)
+
+    assert not declared, f"OpenAPI templates still declare 4xx responses: {declared}"
+
+
+def test_the_orchestrator_prompt_states_the_rule_for_the_spec():
+    """The OperationSpec is the contract every generator reads (docs/agentic-ai.md),
+    so the orchestrator must record 200 in error_responses[].status_code — a 403
+    there would propagate to every asset."""
+    prompt = _read("prompts", "system_prompt.py")
+
+    assert "BUSINESS_OUTCOME_200_RULE" in prompt
+    assert "error_responses" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Spec layer — the upstream source of truth
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("bad", [400, 401, 403, 404, 409, 429, "403"])
+def test_the_spec_coerces_a_4xx_business_outcome_to_200(bad):
+    """Enforced in the model, not just asked for in the prompt: the spec is what
+    the Lambda, OpenAPI and prompt generators all read."""
+    from tools.spec_manager import ErrorResponse
+
+    assert ErrorResponse(status_code=bad).status_code == 200
+
+
+@pytest.mark.parametrize("keep", [200, 201, 500, 503])
+def test_the_spec_preserves_2xx_and_5xx(keep):
+    """5xx must survive — Connect retries it, which is right for a real fault."""
+    from tools.spec_manager import ErrorResponse
+
+    assert ErrorResponse(status_code=keep).status_code == keep
+
+
+def test_the_spec_accepts_the_llms_alias_spellings():
+    """The orchestrator is an LLM; statusCode/status/code all reach this field."""
+    from tools.spec_manager import ErrorResponse
+
+    for alias in ("status_code", "statusCode", "status", "code"):
+        assert ErrorResponse(**{alias: 404}).status_code == 200
+
+
+def test_a_missing_status_code_stays_none():
+    """Absent is not the same as wrong — don't invent a code."""
+    from tools.spec_manager import ErrorResponse
+
+    assert ErrorResponse(error_code="NOT_FOUND").status_code is None
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI generator — must not inject 4xx of its own
+# ---------------------------------------------------------------------------
+
+def test_the_openapi_generator_declares_no_4xx_responses():
+    """It used to add 400 (and 401 when auth was on) unconditionally, so even a
+    spec with only 200s produced a document that taught the model to expect a
+    failure it cannot handle."""
+    from tools.openapi_generator import _build_responses
+    from tools.spec_manager import OperationSpec
+
+    spec = OperationSpec(
+        operation_id="verifyCaller", operation_type="custom", http_method="POST",
+        path="/tools/verify_caller", summary="s", description="d",
+        input_fields=[], output_fields=[], requires_authentication=True,
+        error_responses=[
+            {"status_code": 403, "error_code": "UNAUTHORIZED", "message": "no match"},
+            {"status_code": 404, "error_code": "NOT_FOUND", "message": "no account"},
+            {"status_code": 500, "error_code": "INTERNAL_ERROR", "message": "boom"},
+        ],
+    )
+
+    responses = _build_responses(spec, "VerifyCallerResponse")
+
+    assert not [c for c in responses if c.startswith("4")], (
+        f"4xx responses declared: {sorted(responses)}"
+    )
+    assert "200" in responses and "500" in responses
+    # The outcomes still reach the model — folded into the 200 description.
+    assert "UNAUTHORIZED" in responses["200"]["description"]
+    assert "NOT_FOUND" in responses["200"]["description"]

--- a/backend/ecs/tests/test_orchestrator_max_tokens.py
+++ b/backend/ecs/tests/test_orchestrator_max_tokens.py
@@ -1,0 +1,101 @@
+"""Regression test for the orchestrator's output-token budget.
+
+Background (2026-08-04 real run): the interview intermittently died with
+max_tokens errors. The context window (1M) was never close — the problem was
+OUTPUT. Strands omits ``maxTokens`` from ``inferenceConfig`` when its
+``max_tokens`` is ``None``, and Bedrock's default in that case is only **4096**
+output tokens. Verified live against ``global.anthropic.claude-opus-4-8`` in
+ap-northeast-2:
+
+    maxTokens omitted  → stopReason=max_tokens at outputTokens=4096
+    maxTokens=64000    → stopReason=end_turn   at outputTokens=26078
+    maxTokens=128001   → ValidationException: exceeds the model limit of 128000
+
+``get_model_config()`` passed no ``max_tokens``, so the orchestrator ran the
+whole interview on 4096 output tokens while every sub-agent got 128000. A
+single ``save_operation_spec`` payload can exceed 4096 on its own.
+
+This test pins the invariant that broke: the cap must be EXPLICIT (never None),
+comfortably above Bedrock's 4096 default, and clamped to the model ceiling so
+an env override can't turn every request into a ValidationException.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+# Make ``src`` importable the same way the Docker entrypoint does.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.abspath(os.path.join(_HERE, "..", "src"))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+# Bedrock's default when inferenceConfig.maxTokens is absent.
+BEDROCK_DEFAULT_MAX_TOKENS = 4096
+# Hard ceiling for Opus 4.6/4.7/4.8/5 — Bedrock rejects anything above this.
+MODEL_OUTPUT_CEILING = 128000
+
+
+@pytest.fixture()
+def app_mod(tmp_path, monkeypatch):
+    monkeypatch.setenv("S3FILES_MOUNT_PATH", str(tmp_path))
+    monkeypatch.setenv("SESSION_STORE_BACKEND", "s3files")
+    sys.path.insert(0, os.path.abspath(os.path.join(_HERE, "..")))
+    import app  # noqa: E402
+
+    return app
+
+
+def test_orchestrator_max_tokens_is_explicit_and_above_the_bedrock_default(app_mod):
+    cap = app_mod.ORCHESTRATOR_MAX_TOKENS
+    assert cap is not None, "must be explicit — None makes Bedrock fall back to 4096"
+    assert isinstance(cap, int)
+    assert cap > BEDROCK_DEFAULT_MAX_TOKENS, (
+        f"cap={cap} is at or below Bedrock's implicit default "
+        f"({BEDROCK_DEFAULT_MAX_TOKENS}); the interview will truncate again"
+    )
+
+
+def test_orchestrator_max_tokens_is_within_the_model_ceiling(app_mod):
+    assert app_mod.ORCHESTRATOR_MAX_TOKENS <= MODEL_OUTPUT_CEILING
+
+
+@pytest.mark.parametrize(
+    "env_value,expected",
+    [
+        ("999999", MODEL_OUTPUT_CEILING),  # over the ceiling → clamped
+        ("128000", MODEL_OUTPUT_CEILING),  # exactly at the ceiling → kept
+        ("32000", 32000),                  # under → honoured
+    ],
+)
+def test_env_override_is_clamped_to_the_model_ceiling(monkeypatch, env_value, expected):
+    """An operator raising the cap must not be able to push it past the model
+    limit — that would turn every orchestrator call into a ValidationException.
+    Re-evaluates the same expression app.py uses at import time.
+    """
+    monkeypatch.setenv("ORCHESTRATOR_MAX_TOKENS", env_value)
+    value = min(int(os.environ.get("ORCHESTRATOR_MAX_TOKENS", "64000")), MODEL_OUTPUT_CEILING)
+    assert value == expected
+
+
+def test_get_model_config_passes_the_cap_to_bedrock(app_mod, monkeypatch):
+    """The cap is worthless if it never reaches BedrockModel. Capture the kwargs
+    build_model_kwargs receives and assert max_tokens is among them.
+    """
+    captured: dict = {}
+
+    def fake_build_model_kwargs(model_id, **kwargs):
+        captured.update(kwargs)
+        captured["model_id"] = model_id
+        return {"model_id": model_id or "stub", "max_tokens": kwargs.get("max_tokens")}
+
+    monkeypatch.setattr(app_mod, "build_model_kwargs", fake_build_model_kwargs)
+    monkeypatch.setattr(app_mod, "BedrockModel", lambda **kw: kw)
+
+    app_mod.get_model_config()
+
+    assert "max_tokens" in captured, "get_model_config() did not pass max_tokens"
+    assert captured["max_tokens"] == app_mod.ORCHESTRATOR_MAX_TOKENS

--- a/backend/ecs/tests/test_tool_input_streaming.py
+++ b/backend/ecs/tests/test_tool_input_streaming.py
@@ -1,0 +1,164 @@
+"""Regression test: tool inputs must survive Strands' streaming shape.
+
+Found by the 2026-08-05 prod e2e run. Every ``save_operation_spec`` tool frame
+reached the client with an EMPTY input, so the UI's tool cards showed no
+operation name ("작업 사양 저장" with no "checkReservation") and the expanded
+input panel was hidden entirely (``hasInput`` is false for ``{}``).
+
+Root cause is in how Strands streams tool arguments. In
+``strands/event_loop/streaming.py`` the accumulator starts as a STRING::
+
+    current_tool_use["input"] = ""                      # handle_content_block_start
+    state["current_tool_use"]["input"] += delta[...]    # handle_content_block_delta
+    current_tool_use["input"] = json.loads(...)         # handle_content_block_stop
+
+So for the whole streaming window ``current_tool_use["input"]`` is a partial JSON
+*string*; it only becomes a dict at the very end. app.py guarded the capture with
+``isinstance(tool_input, dict)``, which is never true while streaming, so
+``tool_inputs`` was never populated — and the ``tool_end`` frame reads from that
+same map.
+
+Two invariants are pinned here:
+
+  1. A partial-then-complete string sequence must end up captured as a dict
+     (parse opportunistically; fragments just fail and are skipped).
+  2. What goes out on the wire must ALWAYS be a dict, never the raw string. The
+     client calls ``Object.keys(input)``, which on a string returns char indices
+     ("0","1","2",…) — that is the garbled char-by-char input the agent itself
+     flagged in the transcript.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def capture(tool_inputs: dict, tool_use_id: str, tool_input) -> None:
+    """The capture logic from app.py's current_tool_use branch.
+
+    Kept as a standalone mirror because the real one is inline in a ~200-line
+    async streaming loop that can't be driven without a live Bedrock stream.
+    Any change to the original must be mirrored here or these tests go stale —
+    that's the tradeoff for testing it at all.
+    """
+    if tool_use_id and tool_input:
+        if isinstance(tool_input, dict):
+            tool_inputs[tool_use_id] = tool_input
+        elif isinstance(tool_input, str):
+            try:
+                parsed = json.loads(tool_input)
+                if isinstance(parsed, dict) and parsed:
+                    tool_inputs[tool_use_id] = parsed
+            except (ValueError, TypeError):
+                pass
+
+
+# The exact shape Strands produces: "" then growing fragments, then the whole
+# object. Only the last one is parseable.
+COMPLETE = {"operation_id": "checkReservation", "summary": "예약 조회"}
+FRAGMENTS = [
+    "",
+    '{"operation_id"',
+    '{"operation_id": "checkRese',
+    '{"operation_id": "checkReservation", "summary"',
+    json.dumps(COMPLETE, ensure_ascii=False),
+]
+
+
+def test_streamed_string_input_is_captured_as_a_dict():
+    """The bug: with an isinstance(dict) guard this map stays EMPTY."""
+    tool_inputs: dict = {}
+    for frag in FRAGMENTS:
+        capture(tool_inputs, "tu-1", frag)
+
+    assert tool_inputs.get("tu-1") == COMPLETE, (
+        "tool input was never captured — the UI gets {} and shows no operation name"
+    )
+    assert tool_inputs["tu-1"]["operation_id"] == "checkReservation"
+
+
+def test_partial_fragments_alone_capture_nothing():
+    """A turn cut off mid-stream must not publish half-parsed arguments."""
+    tool_inputs: dict = {}
+    for frag in FRAGMENTS[:-1]:  # everything except the complete object
+        capture(tool_inputs, "tu-2", frag)
+
+    assert "tu-2" not in tool_inputs
+
+
+def test_dict_input_is_still_captured():
+    """content_block_stop delivers a real dict — that path must keep working."""
+    tool_inputs: dict = {}
+    capture(tool_inputs, "tu-3", COMPLETE)
+    assert tool_inputs["tu-3"] == COMPLETE
+
+
+def test_a_later_complete_parse_wins():
+    """Two tool uses in one turn must not bleed into each other, and the last
+    successful parse for an id is the authoritative one."""
+    tool_inputs: dict = {}
+    capture(tool_inputs, "tu-4", json.dumps({"operation_id": "a"}))
+    capture(tool_inputs, "tu-4", json.dumps({"operation_id": "a", "summary": "full"}))
+    capture(tool_inputs, "tu-5", json.dumps({"operation_id": "b"}))
+
+    assert tool_inputs["tu-4"] == {"operation_id": "a", "summary": "full"}
+    assert tool_inputs["tu-5"] == {"operation_id": "b"}
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        '"just a string"',   # valid JSON, not an object
+        "[1, 2, 3]",         # valid JSON array
+        "42",
+        "null",
+        "true",
+        "{}",                # empty object — nothing to show
+        "{not json at all",
+    ],
+)
+def test_non_object_json_is_ignored(hostile):
+    """json.loads succeeds on scalars and arrays too. Storing those would put a
+    non-dict on the wire and reintroduce the Object.keys() char-index rendering."""
+    tool_inputs: dict = {}
+    capture(tool_inputs, "tu-6", hostile)
+    assert "tu-6" not in tool_inputs
+
+
+def test_what_goes_on_the_wire_is_always_a_dict():
+    """tool_start fires on the FIRST delta, when nothing is parseable yet. It must
+    send {} rather than the partial string.
+
+    If a string leaked through, the client's Object.keys(input) would yield
+    ("0","1","2",…) and render the input character by character — the display bug
+    seen in the prod transcript.
+    """
+    tool_inputs: dict = {}
+    capture(tool_inputs, "tu-7", '{"operation_id"')  # unparseable fragment
+
+    on_the_wire = tool_inputs.get("tu-7", {})
+
+    assert isinstance(on_the_wire, dict)
+    assert on_the_wire == {}
+    # The failure mode, made explicit: char indices instead of field names.
+    assert list(on_the_wire.keys()) != ["0", "1", "2"]
+
+
+def test_app_py_does_not_reintroduce_the_isinstance_dict_guard():
+    """Guard the actual source: the one-line regression that caused this bug was
+    ``if tool_use_id and isinstance(tool_input, dict) and tool_input:``. If that
+    exact shape comes back, the streamed string is dropped again.
+    """
+    import os
+
+    app_py = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "app.py")
+    with open(app_py, encoding="utf-8") as f:
+        src = f.read()
+
+    assert "isinstance(tool_input, dict) and tool_input" not in src, (
+        "the dict-only guard is back — streamed tool inputs will be dropped again"
+    )
+    # And the string branch must still be there.
+    assert "isinstance(tool_input, str)" in src

--- a/backend/ecs/tests/test_workspace_midturn_reset.py
+++ b/backend/ecs/tests/test_workspace_midturn_reset.py
@@ -1,0 +1,239 @@
+"""Regression test: a mid-turn session reset must not lose the workspace.
+
+Found on prod 2026-08-05 (long-input e2e). The agent's own summary said
+
+    분석 문서 저장 시 세션 관련 이슈가 있었지만, 모든 스펙은 이미 디스크에 정상 저장되었습니다
+
+and the persisted history holds the real tool result::
+
+    {"success": false, "error": "Workspace not initialised (no session)"}
+
+Sequence observed in the logs, all inside one second:
+
+  1. the kickoff message starts the background agent task,
+  2. the WebSocket flaps (close 1005) 0.5s later,
+  3. the frontend reconnects and — finding no history yet — sends
+     ``createNewSession`` (useWebSocket.ts does this on reconnect-with-no-history),
+  4. ``handle_create_new_session_ws`` runs ``clear_all_specs()`` +
+     ``cleanup_session()``, dropping the ProjectWorkspace out of
+     ``session_context._workspaces`` while the agent is mid-stream.
+
+The agent kept running for another 4 minutes on a session whose workspace was
+gone. Nothing looked broken, because ``save_operation_spec`` writes NFS on its
+own fast-path and only the S3 backup goes through the workspace — so every spec
+still landed on disk. The first call that depends *solely* on the workspace,
+``save_requirement_document``, failed. Silently: the failure path returns a dict
+and logs nothing at all, which is why CloudWatch had zero matching lines. The S3
+copies of specs/ and state/ were also skipped for that whole session (verified:
+the bucket prefix has only operation_spec/*.md, while a healthy session has
+specs/*.json + state/*.json + requirement/analysis.txt).
+
+Two layers are fixed and pinned here:
+
+  1. app.py refuses to reset a session that has a live background agent task.
+  2. Workspace readers go through ``ensure_workspace()``, which rebuilds the
+     object if it went missing. A ProjectWorkspace holds only the session_id
+     plus read-through caches, so rebuilding is always safe — losing a write is
+     not.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.abspath(os.path.join(_HERE, "..", "src"))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+from tools import session_context  # noqa: E402
+from tools.project_workspace import (  # noqa: E402
+    ProjectWorkspace,
+    ensure_workspace,
+    get_workspace,
+    set_workspace_session_id,
+)
+
+SID = "session-11111111-2222-3333-4444-555555555555"
+
+
+@pytest.fixture(autouse=True)
+def _clean_session():
+    session_context.cleanup_session(SID)
+    tok = session_context.current_session_id.set(SID)
+    yield
+    session_context.current_session_id.reset(tok)
+    session_context.cleanup_session(SID)
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — ensure_workspace() survives the purge
+# ---------------------------------------------------------------------------
+
+def test_the_original_bug_is_reproducible_with_get_workspace():
+    """Pin WHY the fix exists: after a cleanup, get_workspace() returns None —
+    which is exactly the ``Workspace not initialised (no session)`` branch."""
+    set_workspace_session_id(SID)
+    assert get_workspace() is not None
+
+    session_context.cleanup_session(SID)  # what createNewSession did mid-turn
+
+    assert get_workspace() is None
+
+
+def test_ensure_workspace_rebuilds_after_a_midturn_purge():
+    """The same sequence must now yield a usable workspace."""
+    set_workspace_session_id(SID)
+    session_context.cleanup_session(SID)
+
+    ws = ensure_workspace()
+
+    assert isinstance(ws, ProjectWorkspace)
+    assert ws.session_id == SID
+    # And it is registered, so the next reader gets the same object.
+    assert get_workspace() is ws
+
+
+def test_ensure_workspace_is_idempotent_and_does_not_replace_a_live_workspace():
+    """It must not swap out the workspace an in-flight turn already holds —
+    that would drop the spec/schema/progress read-through caches."""
+    original = set_workspace_session_id(SID)
+    assert ensure_workspace() is original
+    assert ensure_workspace() is original
+
+
+def test_ensure_workspace_still_returns_none_with_no_bound_session():
+    """No session id means we genuinely cannot know where to write. Guessing a
+    path would be worse than failing, so this case must keep failing."""
+    session_context.current_session_id.set(None)
+    assert ensure_workspace() is None
+
+
+def test_a_rebuilt_workspace_targets_the_same_session_paths():
+    """A rebuild is only safe if it resolves to the SAME storage location —
+    otherwise the document would be written where nothing looks for it."""
+    before = set_workspace_session_id(SID)
+    key_before = before._s3_key("progress.json")
+    specs_before = before._specs_s3_key("check_reservation.json")
+
+    session_context.cleanup_session(SID)
+    after = ensure_workspace()
+
+    assert after is not before  # genuinely a new object
+    assert after._s3_key("progress.json") == key_before
+    assert after._specs_s3_key("check_reservation.json") == specs_before
+    assert SID in key_before  # sanity: the session id really is in the path
+
+
+def test_save_requirement_document_no_longer_hits_the_no_session_branch():
+    """The exact prod failure, end to end.
+
+    ``save_requirement_document`` is a Strands @tool, so call the undecorated
+    function. With no S3 bucket and no NFS mount configured in the test env the
+    write itself cannot succeed — but the point is that it gets PAST the
+    workspace guard and reports a real storage error instead of the misleading
+    "no session".
+    """
+    from tools import project_workspace as pw
+
+    set_workspace_session_id(SID)
+    session_context.cleanup_session(SID)  # the purge
+
+    fn = getattr(pw.save_requirement_document, "_tool_func", None) or \
+        getattr(pw.save_requirement_document, "__wrapped__", None) or \
+        pw.save_requirement_document.original_function  # type: ignore[attr-defined]
+    result = fn(doc_type="analysis", content="분석 문서 본문")
+
+    assert "no session" not in str(result.get("error", "")), (
+        f"still failing on the workspace guard: {result}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — app.py must not reset a session with a running agent
+# ---------------------------------------------------------------------------
+
+def _read_app_py() -> str:
+    with open(os.path.join(_HERE, "..", "app.py"), encoding="utf-8") as f:
+        return f.read()
+
+
+def test_create_new_session_guards_on_a_running_background_task():
+    """Guard the source: the reset handler must bail out while an agent runs.
+
+    Asserted structurally (the handler is an async WebSocket coroutine that
+    needs a live socket, session store and task registry to invoke) — the check
+    is that the guard sits BEFORE the destructive calls, since a guard placed
+    after them would read as present while changing nothing.
+    """
+    src = _read_app_py()
+    start = src.index("async def handle_create_new_session_ws")
+    end = src.index("async def handle_import_asset_ws")
+    handler = src[start:end]
+    # Skip the docstring — it names the destructive calls to explain the bug, and
+    # matching those mentions would compare positions in prose, not in code.
+    body_at = handler.index('"""', handler.index('"""') + 3) + 3
+    handler = handler[body_at:]
+
+    assert "_background_tasks.get(session_id)" in handler, (
+        "handle_create_new_session_ws no longer checks for a running agent task"
+    )
+
+    guard_at = handler.index("_background_tasks.get(session_id)")
+    for destructive in ("clear_all_specs()", "cleanup_session("):
+        assert destructive in handler
+        assert guard_at < handler.index(destructive), (
+            f"the running-task guard must come BEFORE {destructive}"
+        )
+
+    # It must return early rather than fall through into the reset.
+    assert re.search(r"_bg_running[\s\S]{0,900}?\n        return\n", handler), (
+        "the guard does not return early — the reset would still run"
+    )
+
+
+def test_the_early_return_still_answers_the_client():
+    """The frontend blocks on ``session_created`` before it lets the user type
+    (useWebSocket.ts: "DO NOT set isSessionReady here"). Bailing out silently
+    would hang the composer, so the guard must still reply."""
+    src = _read_app_py()
+    start = src.index("async def handle_create_new_session_ws")
+    handler = src[start:src.index("async def handle_import_asset_ws")]
+    guarded = handler[handler.index("_bg_running"):]
+    reply_at = guarded.index('"type": "session_created"')
+    return_at = guarded.index("\n        return\n")
+
+    assert reply_at < return_at, "the guard returns without sending session_created"
+
+
+def test_no_workspace_reader_bypasses_ensure_workspace():
+    """Every ``get_workspace()`` caller was a latent instance of this bug: it
+    returns None after a purge and each call site then silently degrades. Only
+    the accessor definitions themselves may mention it.
+    """
+    offenders = []
+    for root, _dirs, files in os.walk(_SRC):
+        for name in files:
+            if not name.endswith(".py"):
+                continue
+            path = os.path.join(root, name)
+            with open(path, encoding="utf-8") as f:
+                text = f.read()
+            for lineno, line in enumerate(text.splitlines(), 1):
+                if "get_workspace()" not in line:
+                    continue
+                if "def get_workspace()" in line or "def ensure_workspace()" in line:
+                    continue
+                # project_workspace.py defines/uses both accessors legitimately.
+                if os.path.basename(path) == "project_workspace.py":
+                    continue
+                offenders.append(f"{os.path.relpath(path, _SRC)}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        "these readers bypass ensure_workspace() and will silently no-op after a "
+        "mid-turn purge:\n" + "\n".join(offenders)
+    )

--- a/frontend/src/components/MessageBubble.tsx
+++ b/frontend/src/components/MessageBubble.tsx
@@ -332,6 +332,8 @@ export const MessageBubble = memo(function MessageBubble({ message }: MessageBub
         'flex animate-fade-in',
         isUser ? 'justify-end' : 'justify-start'
       )}
+      data-testid="chat-message"
+      data-role={message.role}
     >
       <div
         className={cn(
@@ -617,7 +619,7 @@ function ToolCallBubble({ message }: MessageBubbleProps) {
   const toolSummary = getToolSummary(toolCall.tool, toolCall.input, toolCall.result);
 
   return (
-    <div className="flex justify-start animate-fade-in">
+    <div className="flex justify-start animate-fade-in" data-testid="tool-message">
       <div
         className={cn(
           'max-w-[80%] rounded-2xl px-4 py-3 border',

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -289,6 +289,11 @@ export function useWebSocket() {
   // it once the fresh session's socket reports ready (session_created handler).
   const pendingImportRef = useRef<{ assetType: string; content: string; name: string; imageFormat?: string } | null>(null);
   const streamingMessageIdRef = useRef<string | null>(null);
+  // Race fix: the store id of the assistant bubble currently being streamed into.
+  // Stream chunks are appended to THIS message by id, so a tool_start /
+  // subagent / asset message arriving mid-stream can no longer swallow the rest
+  // of the text (which made the assistant message look cut off).
+  const streamTargetMsgIdRef = useRef<string | null>(null);
   const streamTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastStreamContentRef = useRef<string>(""); // Track last content to detect duplicates
 
@@ -309,7 +314,9 @@ export function useWebSocket() {
     setConnecting,
     setConnectionError,
     addMessage,
+    addMessageWithId,
     updateLastMessage,
+    appendToMessageById,
     setTyping,
     updateSession,
     updateProgress,
@@ -340,30 +347,38 @@ export function useWebSocket() {
     }
   }, []);
 
+  // Race-safe flush: append buffered text to the message we started streaming
+  // into, addressed by id. Falls back to updateLastMessage only when there is no
+  // known target (e.g. content arriving outside a tracked stream).
+  const flushPendingStreamContent = useCallback(() => {
+    if (!pendingStreamContentRef.current) return;
+    const content = pendingStreamContentRef.current;
+    pendingStreamContentRef.current = "";
+    const targetId = streamTargetMsgIdRef.current;
+    if (targetId && appendToMessageById(targetId, content)) return;
+    updateLastMessage(content);
+  }, [appendToMessageById, updateLastMessage]);
+
   // Helper function to set stream timeout with auto-complete fallback
   const setStreamTimeout = useCallback(() => {
     clearStreamTimeout();
     streamTimeoutRef.current = setTimeout(() => {
       console.log("[useWebSocket] Stream timeout - auto-completing");
       setTyping(false);
+      // Flush any pending stream content BEFORE dropping the target id,
+      // otherwise the tail of the message is lost.
+      flushPendingStreamContent();
       streamingMessageIdRef.current = null;
+      streamTargetMsgIdRef.current = null;
       lastStreamContentRef.current = "";
-      // Flush any pending stream content
-      if (pendingStreamContentRef.current) {
-        updateLastMessage(pendingStreamContentRef.current);
-        pendingStreamContentRef.current = "";
-      }
     }, STREAM_IDLE_TIMEOUT_MS);
-  }, [clearStreamTimeout, setTyping, updateLastMessage]);
+  }, [clearStreamTimeout, setTyping, flushPendingStreamContent]);
 
   // Performance: Batched stream update - accumulates content and flushes at 60fps
   const flushStreamBatch = useCallback(() => {
-    if (pendingStreamContentRef.current) {
-      updateLastMessage(pendingStreamContentRef.current);
-      pendingStreamContentRef.current = "";
-    }
+    flushPendingStreamContent();
     streamBatchRafRef.current = null;
-  }, [updateLastMessage]);
+  }, [flushPendingStreamContent]);
 
   const queueStreamUpdate = useCallback((content: string) => {
     pendingStreamContentRef.current += content;
@@ -371,6 +386,19 @@ export function useWebSocket() {
       streamBatchRafRef.current = requestAnimationFrame(flushStreamBatch);
     }
   }, [flushStreamBatch]);
+
+  // Race fix: any handler that inserts a NON-assistant message (tool, subagent,
+  // asset, system) while text is mid-stream must first flush the buffered text
+  // into the streaming bubble. Otherwise the buffer flushes after the insert and
+  // `updateLastMessage` would append the tail into the newly inserted card,
+  // leaving the assistant message visibly truncated.
+  const flushBeforeInsert = useCallback(() => {
+    if (streamBatchRafRef.current) {
+      cancelAnimationFrame(streamBatchRafRef.current);
+      streamBatchRafRef.current = null;
+    }
+    flushPendingStreamContent();
+  }, [flushPendingStreamContent]);
 
   // Performance: Register tool message index for O(1) lookup
   const registerToolMessage = useCallback((toolUseId: string, messageIndex: number) => {
@@ -554,6 +582,9 @@ export function useWebSocket() {
       timestamp: new Date(),
     };
 
+    // Race fix: a sub-agent card can appear while assistant text is still
+    // streaming. Flush the buffered text into the assistant bubble first.
+    flushBeforeInsert();
     addMessage({
       role: 'subagent',
       content: content || `${getSubagentDisplayName(subagent)} ${initialStatus}`,
@@ -563,7 +594,7 @@ export function useWebSocket() {
     const newIdx = useBuilderStore.getState().messages.length - 1;
     activeSubagentIndexRef.current.set(subagent, newIdx);
     return newIdx;
-  }, [addMessage, getSubagentDisplayName]);
+  }, [addMessage, getSubagentDisplayName, flushBeforeInsert]);
 
   // Update existing subagent message
   const updateSubagentMessage = useCallback((subagent: string, update: Partial<SubagentActivity>) => {
@@ -721,11 +752,14 @@ export function useWebSocket() {
         case "typing":
           setTyping(true);
           clearStreamTimeout();
+          // Flush anything still buffered for the PREVIOUS bubble before opening
+          // a new one, so its tail isn't appended to the new empty message.
+          flushBeforeInsert();
           lastStreamContentRef.current = "";
           streamingMessageIdRef.current = `msg-${Date.now()}-${Math.random()
             .toString(36)
             .slice(2, 9)}`;
-          addMessage({
+          streamTargetMsgIdRef.current = addMessageWithId({
             role: "assistant",
             content: "",
           });
@@ -752,22 +786,28 @@ export function useWebSocket() {
             // Use message_id from backend if available for precise message targeting
             const messageId = data.message_id as string | undefined;
             const messages = useBuilderStore.getState().messages;
-            const lastMessage = messages[messages.length - 1];
+            // Race fix: the streaming target is identified by id, not by "is it
+            // last?". A tool/subagent/asset message inserted mid-stream no longer
+            // forces a new bubble — text keeps flowing into the original one.
+            const targetId = streamTargetMsgIdRef.current;
+            const targetStillValid =
+              !!targetId && messages.some((m) => m.id === targetId && m.role === "assistant");
 
-            // Check if we need to create a new message
-            if (!lastMessage || lastMessage.role !== "assistant") {
-              // No assistant message exists, create one first
+            if (!targetStillValid) {
+              // No live assistant bubble to stream into — open one.
               streamingMessageIdRef.current = messageId || `msg-${Date.now()}-${Math.random()
                 .toString(36)
                 .slice(2, 9)}`;
-              addMessage({
+              streamTargetMsgIdRef.current = addMessageWithId({
                 role: "assistant",
                 content: "",
               });
             } else if (messageId && streamingMessageIdRef.current !== messageId) {
-              // Different message ID - this is a new stream, create new message
+              // Different backend message ID — genuinely a new stream. Flush the
+              // old bubble's buffer first, then open a new one.
+              flushBeforeInsert();
               streamingMessageIdRef.current = messageId;
-              addMessage({
+              streamTargetMsgIdRef.current = addMessageWithId({
                 role: "assistant",
                 content: "",
               });
@@ -781,15 +821,9 @@ export function useWebSocket() {
           clearStreamTimeout();
           setTyping(false);
           lastStreamContentRef.current = "";
-          // Performance: Flush any pending batched stream content
-          if (pendingStreamContentRef.current) {
-            updateLastMessage(pendingStreamContentRef.current);
-            pendingStreamContentRef.current = "";
-          }
-          if (streamBatchRafRef.current) {
-            cancelAnimationFrame(streamBatchRafRef.current);
-            streamBatchRafRef.current = null;
-          }
+          // Performance: Flush any pending batched stream content.
+          // Targeted by id so a mid-stream insert can't misplace the tail.
+          flushBeforeInsert();
           if (data.content && !streamingMessageIdRef.current) {
             addMessage({
               role: "assistant",
@@ -797,6 +831,7 @@ export function useWebSocket() {
             });
           }
           streamingMessageIdRef.current = null;
+          streamTargetMsgIdRef.current = null;
           break;
 
         case "message":
@@ -813,25 +848,48 @@ export function useWebSocket() {
         case "generation_cancel_noop":
           // User cancelled the in-flight generation. Stop the typing/streaming
           // indicators and surface a short notice.
+          // Flush by id (not updateLastMessage) so the tail lands in the
+          // assistant bubble that was streaming, even if a tool card was
+          // inserted after it.
+          flushBeforeInsert();
           clearStreamTimeout();
           setTyping(false);
           lastStreamContentRef.current = "";
-          if (pendingStreamContentRef.current) {
-            updateLastMessage(pendingStreamContentRef.current);
-            pendingStreamContentRef.current = "";
-          }
           streamingMessageIdRef.current = null;
+          streamTargetMsgIdRef.current = null;
           useBuilderStore.getState().setLoadingSession(false);
           if (data.message && data.type === "generation_cancelled") {
             addMessage({ role: "assistant", content: data.message as string });
           }
           break;
 
-        case "error":
+        case "max_tokens_truncated":
+          // The turn was cut off at the model's output-token cap (app.py's
+          // MaxTokensReachedException handler). Any tool calls in that turn did
+          // NOT execute. Keep the partial text and add the notice as a separate
+          // system card so the user knows nothing was saved.
+          flushBeforeInsert();
           clearStreamTimeout();
           setTyping(false);
           lastStreamContentRef.current = "";
           streamingMessageIdRef.current = null;
+          streamTargetMsgIdRef.current = null;
+          useBuilderStore.getState().setLoadingSession(false);
+          if (data.content) {
+            addMessage({ role: "system", content: `⚠️ ${data.content}` });
+          }
+          break;
+
+        case "error":
+          // Flush whatever text has streamed so far into the assistant bubble
+          // before the error card is inserted, so a partial answer isn't lost
+          // and its tail doesn't land inside the error message.
+          flushBeforeInsert();
+          clearStreamTimeout();
+          setTyping(false);
+          lastStreamContentRef.current = "";
+          streamingMessageIdRef.current = null;
+          streamTargetMsgIdRef.current = null;
           // Detect backend "Agent is still processing" guard (app.py:1652).
           // Ensure the chat input is re-enabled immediately and bump a counter
           // so the UI can offer a Reset Session affordance after repeated hits.
@@ -961,6 +1019,8 @@ export function useWebSocket() {
                 (m) => m.role === "tool" && m.toolCall?.tool === data.tool && m.toolCall?.status === "running"
               );
               if (!hasRunningToolMsg) {
+                // Race fix: flush streaming text before inserting a tool card.
+                flushBeforeInsert();
                 addMessage({
                   role: "tool",
                   content: "",
@@ -991,6 +1051,10 @@ export function useWebSocket() {
           // Add tool call message to chat - use toolUseId for deduplication (unique per invocation)
           // This allows same tool (e.g., save_operation_spec) to be called multiple times
           if (data.tool) {
+            // Race fix: a tool_start can arrive while assistant text is still
+            // streaming. Flush the buffered text into the assistant bubble FIRST
+            // so the message isn't left cut off mid-sentence.
+            flushBeforeInsert();
             const messages = useBuilderStore.getState().messages;
             // Performance: Check map first for O(1), fallback to array check
             const toolUseIdKey = data.toolUseId as string;
@@ -1116,6 +1180,8 @@ export function useWebSocket() {
               }
             } else {
               // Fallback: if tool message not found, add a completed tool message directly
+              // Race fix: flush streaming text before inserting a tool card.
+              flushBeforeInsert();
               addMessage({
                 role: "tool",
                 content: "",
@@ -1180,10 +1246,12 @@ export function useWebSocket() {
             const currentMsgs = useBuilderStore.getState().messages;
             const lastMsg = currentMsgs[currentMsgs.length - 1];
             if (lastMsg && lastMsg.role === "thinking") {
-              // Append to existing thinking message
-              updateLastMessage(data.content);
+              // Append to the existing thinking message by id — `updateLastMessage`
+              // would target whatever is last, which may no longer be this message.
+              appendToMessageById(lastMsg.id, data.content);
             } else {
-              // Create new thinking message
+              // Race fix: flush streaming text before inserting a thinking card.
+              flushBeforeInsert();
               addMessage({
                 role: "thinking",
                 content: data.content,
@@ -1469,6 +1537,7 @@ export function useWebSocket() {
                 ? `${label} 가져오기 및 검증 완료 (자동 수정 ${fixes}건)`
                 : `Imported & validated ${label} (${fixes} fix${fixes === 1 ? '' : 'es'} applied)`;
             }
+            flushBeforeInsert();
             addMessage({ role: 'system', content: summary });
           }
           break;
@@ -1675,6 +1744,7 @@ export function useWebSocket() {
             // Insert a phase divider into the chat
             const lang = useBuilderStore.getState().language;
             const label = PHASE_LABELS[data.phase as BuilderPhase]?.[lang] || data.phase;
+            flushBeforeInsert();
             addMessage({
               role: 'system',
               content: `phase_divider:${data.phase}`,
@@ -1711,6 +1781,8 @@ export function useWebSocket() {
     [
       setTyping,
       addMessage,
+      addMessageWithId,
+      appendToMessageById,
       updateLastMessage,
       updateSession,
       updateProgress,
@@ -1722,6 +1794,7 @@ export function useWebSocket() {
       setShowDownloadModal,
       clearStreamTimeout,
       setStreamTimeout,
+      flushBeforeInsert,
       // Performance optimization functions
       queueStreamUpdate,
       registerToolMessage,
@@ -2248,6 +2321,9 @@ export function useWebSocket() {
         })();
       }
 
+      // Race fix: if the previous turn's text is still buffered, flush it into
+      // its own bubble before the new user message lands after it.
+      flushBeforeInsert();
       addMessage({
         role: "user",
         content: message,
@@ -2265,7 +2341,7 @@ export function useWebSocket() {
 
       return true;
     },
-    [addMessage]
+    [addMessage, flushBeforeInsert]
   );
 
   /**
@@ -2319,6 +2395,8 @@ export function useWebSocket() {
       }
 
       // Add user message to UI immediately (with attachment metadata)
+      // Race fix: flush any buffered stream text into its own bubble first.
+      flushBeforeInsert();
       addMessage({
         role: "user",
         content: message,
@@ -2472,7 +2550,7 @@ export function useWebSocket() {
         return false;
       }
     },
-    [addMessage]
+    [addMessage, flushBeforeInsert]
   );
 
   /**

--- a/frontend/src/stores/builderStore.ts
+++ b/frontend/src/stores/builderStore.ts
@@ -167,7 +167,19 @@ interface BuilderState {
   setSessionReady: (ready: boolean) => void;
   setLoadingSession: (loading: boolean) => void;
   addMessage: (message: Omit<Message, 'id' | 'timestamp'>) => void;
+  /** Add a message and return the id it was assigned (for targeted appends). */
+  addMessageWithId: (message: Omit<Message, 'id' | 'timestamp'>) => string;
   updateLastMessage: (contentToAppend: string) => void;
+  /**
+   * Append to a specific message by id — race-safe.
+   *
+   * `updateLastMessage` appends to whichever message happens to be last, so if a
+   * tool / subagent / asset message gets inserted while text is still streaming,
+   * the remaining text lands in that card instead and the assistant bubble looks
+   * cut off. Targeting by id makes insertion order irrelevant.
+   * Returns true if the message was found and updated.
+   */
+  appendToMessageById: (id: string, contentToAppend: string) => boolean;
   setTyping: (typing: boolean) => void;
   updateSession: (session: Partial<SessionState>) => void;
   updateProgress: (itemId: string, status: ProgressItem['status'], progress?: number) => void;
@@ -426,6 +438,19 @@ export const useBuilderStore = create<BuilderState>((set) => ({
       return { messages: limitedMessages };
     }),
 
+  addMessageWithId: (message) => {
+    const id = `msg-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+    set((state) => {
+      const newMessage = { ...message, id, timestamp: new Date() };
+      const allMessages = [...state.messages, newMessage];
+      const limitedMessages = allMessages.length > MAX_MESSAGES
+        ? allMessages.slice(-MAX_MESSAGES)
+        : allMessages;
+      return { messages: limitedMessages };
+    });
+    return id;
+  },
+
   updateLastMessage: (contentToAppend) =>
     set((state) => {
       const len = state.messages.length;
@@ -441,6 +466,26 @@ export const useBuilderStore = create<BuilderState>((set) => ({
           : [...state.messages.slice(0, lastIndex), updatedMessage]
       };
     }),
+
+  appendToMessageById: (id, contentToAppend) => {
+    let found = false;
+    set((state) => {
+      // Search from the end — the streaming target is almost always recent.
+      for (let i = state.messages.length - 1; i >= 0; i--) {
+        if (state.messages[i].id !== id) continue;
+        found = true;
+        const updated = {
+          ...state.messages[i],
+          content: state.messages[i].content + contentToAppend,
+        };
+        const newMessages = state.messages.slice();
+        newMessages[i] = updated;
+        return { messages: newMessages };
+      }
+      return state;
+    });
+    return found;
+  },
 
   setTyping: (typing) => set({ isTyping: typing }),
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -170,7 +170,7 @@ export interface ErrorDebugInfo {
 }
 
 export interface WebSocketMessage {
-  type: 'message' | 'typing' | 'error' | 'attachment_error' | 'session_update' | 'assets' | 'progress' | 'stream' | 'stream_end' | 'tool_status' | 'progress_update' | 'questionnaire_status' | 'template' | 'tool_start' | 'tool_end' | 'tool_input_update' | 'thinking' | 'asset_preview' | 'asset_generating' | 'asset_complete' | 'asset_imported' | 'download_ready' | 'history' | 'history_injected' | 'context_injected' | 'session_created' | 'subagent_progress' | 'subagent_tool_use' | 'subagent_tool_result' | 'subagent_stream' | 'subagent_error' | 'heartbeat' | 'pong' | 'connected' | 'background_task_active' | 'phase_changed' | 'input_hint' | 'generation_cancelled' | 'generation_cancel_noop';
+  type: 'message' | 'typing' | 'error' | 'attachment_error' | 'session_update' | 'assets' | 'progress' | 'stream' | 'stream_end' | 'tool_status' | 'progress_update' | 'questionnaire_status' | 'template' | 'tool_start' | 'tool_end' | 'tool_input_update' | 'thinking' | 'asset_preview' | 'asset_generating' | 'asset_complete' | 'asset_imported' | 'download_ready' | 'history' | 'history_injected' | 'context_injected' | 'session_created' | 'subagent_progress' | 'subagent_tool_use' | 'subagent_tool_result' | 'subagent_stream' | 'subagent_error' | 'heartbeat' | 'pong' | 'connected' | 'background_task_active' | 'phase_changed' | 'input_hint' | 'generation_cancelled' | 'generation_cancel_noop' | 'max_tokens_truncated';
   // Chat-input placeholder hint (backend-computed)
   placeholder?: string;
   role?: 'user' | 'assistant';


### PR DESCRIPTION
Fixes from a production run. The status-code fix is verified end to end against a real deployed asset bundle.

## Business outcomes must be 200, not 4xx

Amazon Connect AI agents treat **any non-2xx tool response as an execution failure** — the body is never read, so instead of relaying the outcome the agent tells the customer "there is an issue with the tool". Generated Lambdas were returning 400/403/409 for ordinary business outcomes (SSN mismatch, policy not found, lockout, malformed input), which made authentication flows unusable without hand-editing every response.

Business outcomes are now 200 with a discriminator in the body (`verified`, `remainingAttempts`, `lockout`, `message`). Only genuine server faults stay non-2xx (5xx), where Connect's retry-on-5xx behaviour is correct. Enforced in the Lambda generator prompt, the OpenAPI generator, the spec layer and the orchestrator prompt, so the constraint isn't left to a single generator to remember.

## Contact Flow import

- Contact Lens real-time redaction is only supported for a subset of languages. Requesting it with any other `AnalyticsLanguage` makes `CreateContactFlow` reject the flow with an error that blames the language — which is a required property, so removing it can't work. The linter now disables redaction instead.
- `deploy.sh`'s import-repair loop matched only the first path segment of the reported problem, so a complaint about a nested property deleted the whole parent block and left `Parameters {}` (also invalid), turning a fixable flow into an unfixable one. It also tried to fix "missing required property" by deleting. Both corrected.

## Also here

- The orchestrator no longer hits `max_tokens` mid-interview (Strands omits `inferenceConfig.maxTokens` when `max_tokens` is `None`, and Bedrock then defaults to 4096 output tokens).
- The repeated spec-saving loop in long interviews is fixed.
- A streaming message is no longer cut off when a tool call arrives mid-stream.
- Session ids are validated before being used to build NFS paths; the session dir is resolved from the listing rather than the id.
- The workspace survives a mid-turn session reset.
- GSI names no longer render character by character.
- Login page has a password-reset entry point.

## Verification

Generated one full asset bundle, deployed it with the `deploy.sh` that ships in the download, and drove the resulting AI agent over the Amazon Connect chat API.

Every business outcome returns 200 — by direct invocation of the deployed Lambda:

| case | status |
|---|---|
| verified | 200 |
| mismatch | 200 |
| not_found | 200 |
| locked | 200 |
| missing_field | 200 |
| bad_format | 200 |
| empty_body | 200 |

And the agent relayed each outcome to the customer rather than reporting a broken tool — for a wrong SSN it said "입력하신 정보가 일치하지 않습니다. 다시 한 번 확인해 주시겠어요? 남은 시도는 두 번입니다." That path used to return 403, which the agent could not read.

Backend suite: 221 passed. The 4 failures in `test_session_isolation.py` are pre-existing (`pytest-asyncio` not installed) and reproduce on a clean tree.
