### PR TITLE
Generate assets from an existing database — any RDS or Aurora engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,60 @@ https://github.com/user-attachments/assets/64b4cd24-4653-4fed-86f9-4cd62866e1e2
 
 ---
 
+## What's New in v2.4
+
+**Build on the database you already have.** Point AICC Builder at an existing
+Aurora or DynamoDB database — or just hand it your schema document — and it
+generates Lambdas, infrastructure, and prompts against your real tables,
+columns, and business rules instead of inventing new ones.
+
+- **Existing-database scan, end to end.** `introspect_database` now reads a full
+  relational schema over the RDS Data API — tables, exact column names and SQL
+  types, single **and composite** primary keys, secondary indexes, **foreign keys
+  (plus reverse relationships)**, enum/allowed values, check constraints,
+  generated columns, table/column comments, real row counts, and sample rows —
+  for both **Aurora PostgreSQL and Aurora MySQL**. DynamoDB introspection gained
+  **local secondary indexes**, projection details, nested map/list/set typing,
+  and non-key attribute discovery. Several tables can be scanned in one call.
+- **Column comments become business rules.** A comment like *"Auto-approve under
+  500,000 KRW; above needs manager approval"* is carried into the OperationSpec,
+  so the generated Lambda enforces the threshold your DBA already documented.
+- **Sampled values become data conventions.** A phone stored as `821012345678`
+  stays in that format all the way through to the Contact Flow, instead of being
+  "helpfully" rewritten to `+8210...`.
+- **No database to connect to? Paste or upload the schema.** A new
+  *schema-as-document* path accepts a DDL dump, ERD, or data dictionary, parses
+  it into the same contract, echoes back every table and column it read for your
+  confirmation, and never invents an identifier the document did not state.
+- **Generated Lambdas read columns by name.** The RDS Data API pattern now sends
+  `includeResultMetadata=True` and maps rows to dicts, replacing positional
+  access that silently returned the wrong column whenever the schema changed.
+  Parameterized queries, typed parameter binding, `DECIMAL`-as-string casting,
+  and scoped `rds-data` / Secrets Manager IAM are part of the pattern.
+- **Four new deterministic gates** catch the mistakes an LLM makes even with a
+  correct schema in context, before anything is deployed:
+  - **SQL identifier check** — a column written onto the wrong table
+    (`order_items.product_name` when `product_name` lives on `products`).
+  - **SQL type-cast check** — a cast to a type that does not exist
+    (`::approval_status` on a plain `VARCHAR`).
+  - **Required-column check** — an `INSERT` omitting a `NOT NULL` column that
+    has no default.
+  - **RDS Data API contract check** — env var drift, a missing
+    `includeResultMetadata`, positional row access, or SQL built by string
+    interpolation.
+- **Merge-time normalization** keeps the cross-asset contract intact when
+  fragments disagree: RDS environment variables are unified on
+  `DB_CLUSTER_ARN` / `DB_SECRET_ARN` / `DB_NAME` (the names the handlers
+  actually read), and an inline Lambda whose `Handler` names a function its code
+  does not define gets the alias it needs.
+- **Actionable failures instead of empty results.** A scan that finds nothing now
+  returns an error naming the tables that *do* exist, and distinguishes
+  "Data API not enabled", "access denied", and "database not found" — with the
+  exact remediation for each. The ECS task role gained the read-only
+  `dynamodb:DescribeTable` / `Scan` permissions introspection actually needs.
+
+---
+
 ## What's New in v2.3
 
 A fully-automated workshop deploy script, live-QA permission hardening, a new

--- a/README.md
+++ b/README.md
@@ -30,34 +30,50 @@ https://github.com/user-attachments/assets/64b4cd24-4653-4fed-86f9-4cd62866e1e2
 ## What's New in v2.4
 
 **Build on the database you already have.** Point AICC Builder at an existing
-Aurora or DynamoDB database — or just hand it your schema document — and it
-generates Lambdas, infrastructure, and prompts against your real tables,
-columns, and business rules instead of inventing new ones.
+database — **any RDS or Aurora engine**, or DynamoDB — or just hand it your
+schema document, and it generates Lambdas, infrastructure and prompts against
+your real tables, columns and business rules instead of inventing new ones.
 
-- **Existing-database scan, end to end.** `introspect_database` now reads a full
-  relational schema over the RDS Data API — tables, exact column names and SQL
-  types, single **and composite** primary keys, secondary indexes, **foreign keys
-  (plus reverse relationships)**, enum/allowed values, check constraints,
-  generated columns, table/column comments, real row counts, and sample rows —
-  for both **Aurora PostgreSQL and Aurora MySQL**. DynamoDB introspection gained
-  **local secondary indexes**, projection details, nested map/list/set typing,
-  and non-key attribute discovery. Several tables can be scanned in one call.
+- **Every RDS and Aurora engine.** PostgreSQL, MySQL, MariaDB, SQL Server,
+  Oracle and Db2 — on Aurora or on plain RDS. The connection method is chosen
+  for you: Aurora with the Data API (HTTP endpoint) goes over the Data API with
+  no network path needed, everything else connects with a bundled driver
+  (`psycopg2`, `pymysql`, `pytds`, `oracledb`).
+- **One argument is enough.** Give it a DB instance or Aurora cluster
+  identifier and the engine, endpoint, port, master-user secret and connection
+  method are all resolved from RDS. Name the wrong engine and RDS is trusted
+  over the guess.
+- **Full relational detail.** Tables, exact column names and SQL types, single
+  **and composite** primary keys, secondary indexes, **foreign keys (plus reverse
+  relationships)**, enum/allowed values, check constraints, generated columns,
+  table/column comments, real row counts and sample rows. DynamoDB introspection
+  gained **local secondary indexes**, projection details, nested map/list/set
+  typing and non-key attribute discovery.
+- **Scan a whole schema, a few tables, or one.** `tables_only=True` returns a
+  cheap inventory (names, row counts, comments) of an unfamiliar database so you
+  can pick what matters; then pass `table_name="a,b,c"` for full detail on just
+  those. Names match case-insensitively, so `orders` finds Oracle's `ORDERS`.
 - **Column comments become business rules.** A comment like *"Auto-approve under
   500,000 KRW; above needs manager approval"* is carried into the OperationSpec,
   so the generated Lambda enforces the threshold your DBA already documented.
 - **Sampled values become data conventions.** A phone stored as `821012345678`
   stays in that format all the way through to the Contact Flow, instead of being
   "helpfully" rewritten to `+8210...`.
-- **No database to connect to? Paste or upload the schema.** A new
+- **Observed values instead of invented enums.** SQL Server, Oracle and Db2 have
+  no ENUM type, so the scan reports the distinct values actually present in
+  status-like columns — no more a handler validating against `LOST` when the
+  column really holds `LOSS`.
+- **No database to connect to? Paste or upload the schema.** A
   *schema-as-document* path accepts a DDL dump, ERD, or data dictionary, parses
   it into the same contract, echoes back every table and column it read for your
   confirmation, and never invents an identifier the document did not state.
 - **Generated Lambdas read columns by name.** The RDS Data API pattern now sends
   `includeResultMetadata=True` and maps rows to dicts, replacing positional
-  access that silently returned the wrong column whenever the schema changed.
-  Parameterized queries, typed parameter binding, `DECIMAL`-as-string casting,
-  and scoped `rds-data` / Secrets Manager IAM are part of the pattern.
-- **Four new deterministic gates** catch the mistakes an LLM makes even with a
+  access that silently returned the wrong column whenever the schema changed. On
+  the driver path the generated stack emits the `VpcConfig`, security-group
+  ingress and Secrets Manager VPC endpoint the function needs to reach both the
+  database and its credentials.
+- **Five new deterministic gates** catch the mistakes an LLM makes even with a
   correct schema in context, before anything is deployed:
   - **SQL identifier check** — a column written onto the wrong table
     (`order_items.product_name` when `product_name` lives on `products`).
@@ -65,6 +81,8 @@ columns, and business rules instead of inventing new ones.
     (`::approval_status` on a plain `VARCHAR`).
   - **Required-column check** — an `INSERT` omitting a `NOT NULL` column that
     has no default.
+  - **Parameter type-binding check** — a `bigint` key bound as a string, which
+    PostgreSQL rejects with `operator does not exist: bigint = text`.
   - **RDS Data API contract check** — env var drift, a missing
     `includeResultMetadata`, positional row access, or SQL built by string
     interpolation.
@@ -74,10 +92,14 @@ columns, and business rules instead of inventing new ones.
   actually read), and an inline Lambda whose `Handler` names a function its code
   does not define gets the alias it needs.
 - **Actionable failures instead of empty results.** A scan that finds nothing now
-  returns an error naming the tables that *do* exist, and distinguishes
-  "Data API not enabled", "access denied", and "database not found" — with the
-  exact remediation for each. The ECS task role gained the read-only
+  returns an error naming the tables that *do* exist and the schema it searched,
+  and distinguishes target-not-found, Data-API-off, connection-failed,
+  driver-missing, access-denied and unreadable-secret — with the remediation for
+  each. The ECS task role gained the read-only `rds:Describe*` and
   `dynamodb:DescribeTable` / `Scan` permissions introspection actually needs.
+
+> 📖 Details, per-engine notes and the verification runs:
+> [docs/existing-database.md](./docs/existing-database.md)
 
 ---
 
@@ -569,6 +591,7 @@ letter, and a number (no symbol required).
 | Doc | Description |
 |---|---|
 | [docs/agentic-ai.md](./docs/agentic-ai.md) | **How the multi-agent system keeps customer requirements intact end-to-end** — OperationSpec contract, deterministic validation, patch-only modification |
+| [docs/existing-database.md](./docs/existing-database.md) | **Building on a database you already have** — live scan vs schema-as-document, schema fidelity, and the deterministic SQL gates |
 | [docs/architecture.md](./docs/architecture.md) | Runtime architecture, WebSocket protocol, data flow |
 | [docs/architecture-asset-flow.md](./docs/architecture-asset-flow.md) | Asset read/write/stream paths, dual-write to NFS + S3 |
 | [docs/agents.md](./docs/agents.md) | 9 agents: roles, tools, model configs, generation sequence |

--- a/backend/ecs/requirements.txt
+++ b/backend/ecs/requirements.txt
@@ -31,8 +31,12 @@ PyYAML>=6.0.0
 python-jose[cryptography]>=3.3.0
 
 # Database drivers (for introspect_database tool)
-PyMySQL>=1.1.0
-psycopg2-binary>=2.9.0
+# Every RDS/Aurora engine is reachable: Aurora uses the RDS Data API when its
+# HTTP endpoint is enabled, everything else connects with one of these drivers.
+PyMySQL>=1.1.0            # MySQL, MariaDB, Aurora MySQL
+psycopg2-binary>=2.9.0    # PostgreSQL, Aurora PostgreSQL
+python-tds>=1.15.0        # SQL Server (pure Python, no FreeTDS needed)
+oracledb>=2.4.0           # Oracle (thin mode, no Instant Client needed)
 
 # HTTP client
 requests>=2.31.0

--- a/backend/ecs/src/agents/infrastructure_generator/system_prompt.py
+++ b/backend/ecs/src/agents/infrastructure_generator/system_prompt.py
@@ -473,11 +473,17 @@ moves over time). Before emitting RDS-mode infrastructure:
 
 Instead:
 - **Skip**: DynamoDB Table, Sample Data Seeder Custom Resource
-- **Add**: Lambda environment variables for RDS connection:
-  - `RDS_CLUSTER_ARN`: from data_source.cluster_arn
-  - `RDS_SECRET_ARN`: from data_source.secret_arn
-  - `RDS_DATABASE_NAME`: from data_source.database_name
-- **Add**: IAM permissions for RDS Data API + Secrets Manager:
+- **Add**: Lambda environment variables for RDS connection.
+  ⚠️ These EXACT names are the cross-asset contract — the generated Lambda code
+  reads `os.environ["DB_CLUSTER_ARN"]`, `os.environ["DB_SECRET_ARN"]` and
+  `os.environ["DB_NAME"]`. Emitting any other name (e.g. `RDS_CLUSTER_ARN`)
+  makes every Lambda fail with KeyError at import time.
+  - `DB_CLUSTER_ARN`: from data_source.cluster_arn
+  - `DB_SECRET_ARN`: from data_source.secret_arn
+  - `DB_NAME`: from data_source.database_name
+- **Add**: IAM permissions for RDS Data API + Secrets Manager, scoped to the
+  actual cluster and secret from data_source (do not leave `:cluster:*`
+  wildcards when the ARNs are known):
   ```yaml
   - PolicyName: RDSDataAPIAccess
     PolicyDocument:
@@ -490,11 +496,11 @@ Instead:
             - rds-data:BeginTransaction
             - rds-data:CommitTransaction
             - rds-data:RollbackTransaction
-          Resource: !Sub 'arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:*'
+          Resource: '<data_source.cluster_arn>'
         - Effect: Allow
           Action:
             - secretsmanager:GetSecretValue
-          Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*'
+          Resource: '<data_source.secret_arn>'
   ```
 - **Keep**: API Gateway, Lambda functions (placeholder), S3 bucket, API Key
 
@@ -508,9 +514,9 @@ Instead:
   "database_name": "production",
   "tables": [{"table_name": "reservations", "description": "from existing RDS"}],
   "environment_variables": {
-    "RDS_CLUSTER_ARN": "arn:aws:rds:...",
-    "RDS_SECRET_ARN": "arn:aws:secretsmanager:...",
-    "RDS_DATABASE_NAME": "production"
+    "DB_CLUSTER_ARN": "arn:aws:rds:...",
+    "DB_SECRET_ARN": "arn:aws:secretsmanager:...",
+    "DB_NAME": "production"
   }
 }
 ```

--- a/backend/ecs/src/agents/infrastructure_generator/system_prompt.py
+++ b/backend/ecs/src/agents/infrastructure_generator/system_prompt.py
@@ -502,6 +502,29 @@ Instead:
             - secretsmanager:GetSecretValue
           Resource: '<data_source.secret_arn>'
   ```
+
+### When the engine has NO Data API (plain RDS, or Aurora with the endpoint off)
+
+RDS PostgreSQL, MySQL, MariaDB, SQL Server, Oracle and Db2 are reached with a
+driver, so the Lambdas need real networking. Emit ALL of the following or the
+functions time out on their first invocation:
+
+- `VpcConfig` on every DB-touching function, with at least two subnets in the
+  DB's VPC and a dedicated Lambda security group.
+- An `AWS::EC2::SecurityGroupIngress` allowing that Lambda SG to reach the DB
+  security group on the engine's port (5432/3306/1433/1521/50000).
+- ⚠️ A Secrets Manager interface VPC endpoint
+  (`AWS::EC2::VPCEndpoint`, `com.amazonaws.${AWS::Region}.secretsmanager`,
+  `VpcEndpointType: Interface`, `PrivateDnsEnabled: true`, with a security group
+  allowing 443 from the Lambda SG) — UNLESS the subnets are private with a NAT
+  gateway. A VPC-attached Lambda has no route to public AWS endpoints, so
+  `GetSecretValue` hangs and the function dies at the 30s timeout before it ever
+  queries the database. This was observed end-to-end in testing.
+- Environment variables `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_SECRET_ARN`
+  (no `DB_CLUSTER_ARN` — that is Data-API-only).
+- IAM: `secretsmanager:GetSecretValue` on the credentials secret, plus the
+  managed `AWSLambdaVPCAccessExecutionRole` for ENI management.
+
 - **Keep**: API Gateway, Lambda functions (placeholder), S3 bucket, API Key
 
 ### Schema Summary JSON for RDS mode:

--- a/backend/ecs/src/agents/lambda_generator/system_prompt.py
+++ b/backend/ecs/src/agents/lambda_generator/system_prompt.py
@@ -980,42 +980,97 @@ def handler(event, context):
 
 ## RDS DATA API PATTERN
 
-When `db_type` is "rds-postgresql" or "rds-mysql", generate Lambda code using RDS Data API instead of DynamoDB.
-Use `boto3` `rds-data` client with Secrets Manager for credentials.
+When `db_type` is "rds_postgresql"/"rds-postgresql" or "rds_mysql"/"rds-mysql",
+generate Lambda code using the RDS Data API instead of DynamoDB.
+Use the `boto3` `rds-data` client with Secrets Manager for credentials.
 
 ```python
 import boto3, os, json, logging
+from decimal import Decimal
 
 logger = logging.getLogger()
+logger.setLevel(logging.INFO)
 rds_client = boto3.client("rds-data")
 
 CLUSTER_ARN = os.environ["DB_CLUSTER_ARN"]
 SECRET_ARN = os.environ["DB_SECRET_ARN"]
 DATABASE = os.environ["DB_NAME"]
 
+
 def execute_sql(sql, parameters=None):
+    '''Run a parameterized statement and return rows as dicts.'''
     params = {
         "resourceArn": CLUSTER_ARN,
         "secretArn": SECRET_ARN,
         "database": DATABASE,
         "sql": sql,
+        # REQUIRED: without this the response has no columnMetadata and rows
+        # can only be read by position, which silently breaks on schema change.
+        "includeResultMetadata": True,
     }
     if parameters:
         params["parameters"] = parameters
-    return rds_client.execute_statement(**params)
+    response = rds_client.execute_statement(**params)
+    return _rows_to_dicts(response)
 
-# Usage:
-# result = execute_sql(
-#     "SELECT * FROM customers WHERE mobile1 = :phone",
-#     parameters=[{"name": "phone", "value": {"stringValue": phone_number}}]
+
+def _rows_to_dicts(response):
+    '''Convert a Data API response into a list of {column_name: value} dicts.'''
+    columns = [c.get("label") or c.get("name") for c in response.get("columnMetadata", [])]
+    rows = []
+    for record in response.get("records", []):
+        row = {}
+        for i, field in enumerate(record):
+            name = columns[i] if i < len(columns) else f"col_{i}"
+            row[name] = _field_value(field)
+        rows.append(row)
+    return rows
+
+
+def _field_value(field):
+    if field.get("isNull"):
+        return None
+    for key in ("stringValue", "longValue", "doubleValue", "booleanValue"):
+        if key in field:
+            return field[key]
+    if "arrayValue" in field:
+        av = field["arrayValue"]
+        for key in ("stringValues", "longValues", "doubleValues", "booleanValues"):
+            if key in av:
+                return av[key]
+    return None
+
+
+# Usage — always reference columns by NAME, never by index:
+# rows = execute_sql(
+#     "SELECT order_number, status, total_amount FROM orders WHERE order_number = :order_number",
+#     parameters=[{"name": "order_number", "value": {"stringValue": order_number}}]
 # )
-# rows = result.get("records", [])
+# if not rows:
+#     return not_found_response()
+# order = rows[0]
+# status = order["status"]
 ```
 
 Rules for RDS mode:
 - Use parameterized queries (`:param_name`) — NEVER string concatenation
+  (SQL injection). Table/column names cannot be parameterized, so they must
+  come from the scanned schema, never from user input.
 - Environment variables: `DB_CLUSTER_ARN`, `DB_SECRET_ARN`, `DB_NAME`
-- Parse `records` array from response (each row is a list of typed values)
+- ALWAYS pass `includeResultMetadata=True` and read columns by name via the
+  `_rows_to_dicts` helper above. Never index `record[0]`, `record[1]`, …
+- Use the EXACT table and column names from the introspected/provided schema,
+  including case. PostgreSQL folds unquoted identifiers to lower case; MySQL
+  keeps them as declared.
+- Respect `allowed_values` from the schema when writing enum comparisons and
+  when validating input — an invalid enum value is a DB error, not a 404.
+- Numeric/DECIMAL columns come back as strings in `stringValue`; cast with
+  `Decimal(...)`/`int(...)` before arithmetic or comparison.
+- For paging/limits use `LIMIT`; never `SELECT *` on a large table in a
+  contact-center path — select the columns you need.
+- Required IAM on the Lambda role: `rds-data:ExecuteStatement`,
+  `rds-data:BatchExecuteStatement`, and `secretsmanager:GetSecretValue` on the
+  credentials secret.
 - Keep the same dual-mode handler (Contact Flow + API Gateway) structure
 
 ## EXTERNAL API INTEGRATION PATTERNS

--- a/backend/ecs/src/agents/lambda_generator/system_prompt.py
+++ b/backend/ecs/src/agents/lambda_generator/system_prompt.py
@@ -1064,6 +1064,14 @@ Rules for RDS mode:
   keeps them as declared.
 - Respect `allowed_values` from the schema when writing enum comparisons and
   when validating input — an invalid enum value is a DB error, not a 404.
+  ⚠️ When `allowed_values_source` is `"observed"` the engine has no declared
+  enum (SQL Server, Oracle and Db2 never do) and the list is the set of values
+  actually present in the column. Copy those spellings CHARACTER FOR CHARACTER
+  into any validation set. Found in live testing: a handler hardcoded
+  `{"DAMAGE", "LOST"}` for a column whose real values are `DAMAGE`, `LOSS`,
+  `DELAY`, `WRONG_DELIVERY` — the guessed `LOST` rejected every valid request
+  and would have written a value the business never uses. Never shorten,
+  pluralize, translate or "correct" a value, and never drop one you were given.
 - Numeric/DECIMAL columns come back as strings in `stringValue`; cast with
   `Decimal(...)`/`int(...)` before arithmetic or comparison.
 - For paging/limits use `LIMIT`; never `SELECT *` on a large table in a
@@ -1072,6 +1080,40 @@ Rules for RDS mode:
   `rds-data:BatchExecuteStatement`, and `secretsmanager:GetSecretValue` on the
   credentials secret.
 - Keep the same dual-mode handler (Contact Flow + API Gateway) structure
+
+### Engines WITHOUT the Data API (plain RDS, or Aurora with the HTTP endpoint off)
+
+The Data API only exists on Aurora. When `access_method` in the schema is
+`<engine>-driver` rather than `rds-data-api` — i.e. RDS PostgreSQL, MySQL,
+MariaDB, SQL Server, Oracle or Db2 — the Lambda must open a real connection
+instead:
+
+- Driver per engine: `psycopg2` (PostgreSQL), `pymysql` (MySQL/MariaDB),
+  `pytds` (SQL Server), `oracledb` (Oracle), `ibm_db_dbi` (Db2). None ship in
+  the Lambda runtime, so note in the header comment that a layer or bundled
+  dependency is required.
+- Read credentials from Secrets Manager at cold start, never from plain env
+  vars: `DB_SECRET_ARN` holds the username/password, `DB_HOST`, `DB_PORT` and
+  `DB_NAME` locate the database. Cache the parsed secret in a module-level
+  variable so it is fetched once per container.
+- The function needs `VpcConfig` (subnets + a security group allowed inbound on
+  the DB port) because it talks TCP to the endpoint. State that requirement in
+  the handler docstring so whoever deploys it knows.
+- ⚠️ A VPC-attached Lambda has NO route to public AWS endpoints unless one is
+  provided, so `secretsmanager:GetSecretValue` hangs until the function times
+  out. Found in live testing: every invocation returned
+  `Task timed out after 30.00 seconds` before a single DB query ran. Say plainly
+  in the docstring that the deployment needs EITHER a Secrets Manager interface
+  VPC endpoint (`com.amazonaws.<region>.secretsmanager`, reachable from the
+  Lambda security group on 443) OR private subnets with a NAT gateway.
+- Use the driver's own parameter style — `%(name)s` for psycopg2/pymysql/pytds,
+  `:name` for oracledb, `?` for ibm_db — and still NEVER interpolate values.
+- Read columns by name from `cursor.description`, exactly as the Data API path
+  reads `columnMetadata`; never index rows positionally.
+- Close the cursor in a `finally` block and keep the connection module-level so
+  it is reused across invocations.
+- Required IAM: `secretsmanager:GetSecretValue` on the credentials secret (no
+  `rds-data:*` needed on this path).
 
 ## EXTERNAL API INTEGRATION PATTERNS
 

--- a/backend/ecs/src/prompts/system_prompt.py
+++ b/backend/ecs/src/prompts/system_prompt.py
@@ -360,10 +360,26 @@ into the conversation.
   🟡 Placeholder: TODO comment + skeleton code only (real API wired later).
 
 #### Database type (only if they have an existing DB)
-- DynamoDB (new) or RDS MySQL/PostgreSQL (existing)?
-- For RDS: Aurora Serverless v2 + Data API. You need the Secrets Manager
-  ARN, cluster ARN, and database name.
-- Given the existing table names + region, we'll auto-introspect the schema.
+- DynamoDB (new) or an existing DynamoDB / RDS-Aurora MySQL / RDS-Aurora PostgreSQL?
+- Record `db_type` as one of: `dynamodb`, `rds_mysql`, `rds_postgresql`.
+- Always capture `region` (the DB's region, which may differ from this app's).
+- **DynamoDB**: capture `table_name` — several tables may be given as one
+  comma-separated string; the scan handles them in a single call.
+- **RDS/Aurora**: introspection goes through the RDS Data API, so you MUST
+  collect all three and store them under exactly these keys:
+  `rds_cluster_arn`, `rds_secret_arn`, `rds_database_name`.
+  Tell the user where to find them if they ask: cluster ARN from the RDS
+  console/`describe-db-clusters`, secret ARN from Secrets Manager (the
+  cluster's master-user secret), database name = the schema they query.
+  The Data API exists only on Aurora Serverless v2/provisioned clusters with
+  the HTTP endpoint enabled — if they are on a plain RDS instance, say so and
+  offer the document path below instead.
+- **No reachable DB?** They can instead paste or upload the schema (DDL dump,
+  ERD image, data dictionary, sample JSON). Accept it and follow
+  "Phase 0-ALT: Schema supplied as a DOCUMENT" — do not ask for ARNs just to
+  read a schema, only ask for them if generated Lambdas must actually connect.
+- Given the above, we auto-introspect the schema — never ask the user to retype
+  column names that a scan can discover.
 
 #### Passing discovered info to sub-agents
 - `call_direction` → contact_flow_generator (via `contact_flow_requirements`)
@@ -865,25 +881,110 @@ When collected_data includes `existing_table == true`:
 
 **Phase 0: Schema Introspection (scan the existing DB)**
 ```
-1. Call introspect_database:
+1. Call introspect_database — pass EVERY parameter the engine needs:
+
+   # DynamoDB (table_name may be a comma-separated list to scan several at once)
    introspect_database(
-       db_type=collected_data["db_type"],
-       table_name=collected_data["table_name"],
+       db_type="dynamodb",
+       dynamodb_table_name=collected_data["table_name"],
        region=collected_data["region"]
    )
-2. Convert via convert_to_infrastructure_schema():
-   - key_schema → primary_key
-   - global_secondary_indexes → gsi_indexes
-   - attributes → field list
-   - unify env var on TABLE_NAME (use the real table name since it already exists)
-3. Report scan result to the user (user-facing copy in their language), e.g.:
-   "✅ 테이블 스키마를 스캔했어요!
-   - 테이블: {table_name}
-   - PK: {primary_key}
-   - GSI: {gsi_list}
-   - 속성: {attribute_count}개
 
+   # RDS / Aurora — the three connection values are MANDATORY.
+   # Omitting them returns MISSING_PARAMETERS; there is no default.
+   introspect_database(
+       db_type=collected_data["db_type"],          # "rds_postgresql" | "rds_mysql"
+       region=collected_data["region"],
+       rds_cluster_arn=collected_data["rds_cluster_arn"],
+       rds_secret_arn=collected_data["rds_secret_arn"],
+       rds_database_name=collected_data["rds_database_name"],
+       table_name=collected_data.get("table_name")  # omit to scan the whole schema
+   )
+
+2. CHECK THE RESULT BEFORE CONTINUING. If `success == false`, do NOT proceed to
+   Phase 1 — relay `error` to the user verbatim and ask them to confirm the
+   connection details. Common `error_code` values and what to tell the user:
+   - MISSING_PARAMETERS    → ask for the cluster ARN / secret ARN / database name
+   - DATA_API_NOT_ENABLED  → the Data API must be enabled; it only exists on
+                             Aurora clusters, not on plain RDS instances
+   - ACCESS_DENIED         → the runtime role lacks rds-data / secretsmanager /
+                             dynamodb:DescribeTable permission
+   - NO_TABLES_FOUND       → the error lists the tables that DO exist; ask which
+                             ones they meant
+
+3. Convert via convert_to_infrastructure_schema(). It handles DynamoDB
+   (single or multiple tables) AND RDS/Aurora, and returns:
+   - DynamoDB: tables[].primary_key / sort_key / gsi_indexes / lsi_indexes,
+     environment_variables{<ENTITY>_TABLE_NAME}
+   - RDS:      tables[].primary_key / columns[] (exact names, sql_type,
+     allowed_values, description) / indexes / foreign_keys / referenced_by,
+     relationships[], enum_types{}, connection{cluster_arn, secret_arn,
+     database_name}, environment_variables{DB_CLUSTER_ARN, DB_SECRET_ARN,
+     DB_NAME}, iam_requirements[]
+   - both:     data_conventions{} with REAL sampled examples, access_notes[]
+
+4. ⚠️ The scanned schema is now the CONTRACT. Never rename, re-case, or invent
+   columns/attributes. Use the exact identifiers returned by the scan, honour
+   `allowed_values` for enum-like fields, and preserve `data_conventions`
+   examples (e.g. a phone stored as `821012345678` must not become `+8210...`).
+   Column/table `description` values often carry business rules
+   (e.g. "Auto-approve under 500,000 KRW") — feed those into the OperationSpec.
+
+4b. ⚠️ PERSIST THE CONVERTED SCHEMA VERBATIM — with the COMPLETE column list
+   for every table, exactly as convert_to_infrastructure_schema() returned it.
+   Do NOT hand-write an abbreviated summary listing only the columns you think
+   each operation needs. The deterministic SQL check compares generated SQL
+   identifiers against this stored schema: any column you omit becomes
+   invisible to the check, and a hallucinated column reference
+   (e.g. `order_items.product_name` when product_name lives on `products`)
+   then ships and fails at runtime with SQLState 42703. Completeness here is
+   what makes the gate work.
+
+5. Report the scan result to the user (in their language), e.g.:
+   "✅ 스키마를 스캔했어요!
+   - 테이블: {table_count}개 ({table_names})
+   - 주요 키: {primary_keys}
+   - 인덱스/GSI: {index_list}
+   - 관계: {relationship_count}개
    이 스키마를 기반으로 에셋을 생성할게요."
+
+6. ⚠️ When you later call save_operation_spec, ALWAYS fill `data_source` —
+   leaving it empty makes the spec render "Table: ?" and the reviewer cannot
+   cross-check the operation against the real schema.
+   - DynamoDB: db_type, table_name, partition_key, sort_key, gsi_indexes
+   - RDS/Aurora: db_type ("rds_postgresql"/"rds_mysql"), table_name (the
+     PRIMARY table the operation writes/reads), partition_key (its PK column),
+     database_name, lookup_column (the column used to identify the caller,
+     e.g. "customers.phone_number"), and related_tables (every other table the
+     operation joins/reads, in query order — e.g.
+     ["customers", "orders", "order_items"]).
+```
+
+**Phase 0-ALT: Schema supplied as a DOCUMENT (no live DB to scan)**
+```
+When the customer PASTES or UPLOADS the schema instead (DDL/CREATE TABLE dump,
+ERD image, Excel/CSV data dictionary, JSON sample payloads) and there is no
+reachable DB — do NOT call introspect_database. Instead:
+
+1. Read the attachment/pasted text and extract, per table:
+   exact table name, exact column names, SQL types, PK (incl. composite),
+   FKs/relationships, indexes, enum/allowed values, NOT NULL, defaults,
+   generated columns, and any comments carrying business rules.
+2. Build the SAME infrastructure_schema shape convert_to_infrastructure_schema()
+   produces (see Phase 0 step 3), setting `existing: true` on every table.
+   For RDS add connection{} + environment_variables{DB_CLUSTER_ARN,
+   DB_SECRET_ARN, DB_NAME} — ask the customer for the ARNs if the document
+   doesn't contain them, and use explicit `<REPLACE_ME>` placeholders if they
+   are not available yet, never invented values.
+3. Persist it with save_operation_spec so later phases read the same contract.
+4. ECHO BACK what you parsed as a table (table → columns → PK → FKs) and ask
+   the user to confirm BEFORE generating. Anything the document did not state
+   must be asked, not guessed — especially the lookup key used for caller
+   identification and enum value spellings.
+5. Then continue with Phase 1 exactly as in the scanned path.
+
+⚠️ Fidelity rule is identical: the document is the contract. Preserve the
+customer's spelling and casing of every identifier, character for character.
 ```
 
 **Phase 1: Infrastructure (API GW + Lambda ONLY)**

--- a/backend/ecs/src/prompts/system_prompt.py
+++ b/backend/ecs/src/prompts/system_prompt.py
@@ -360,20 +360,29 @@ into the conversation.
   🟡 Placeholder: TODO comment + skeleton code only (real API wired later).
 
 #### Database type (only if they have an existing DB)
-- DynamoDB (new) or an existing DynamoDB / RDS-Aurora MySQL / RDS-Aurora PostgreSQL?
-- Record `db_type` as one of: `dynamodb`, `rds_mysql`, `rds_postgresql`.
+- New DynamoDB, an existing DynamoDB, or an existing RDS/Aurora database?
+- **Every RDS and Aurora engine is supported**: PostgreSQL, MySQL, MariaDB,
+  SQL Server, Oracle and Db2 — on Aurora or on plain RDS.
+- Record `db_type` as one of: `dynamodb`, `rds_postgresql`, `rds_mysql`,
+  `rds_mariadb`, `rds_sqlserver`, `rds_oracle`, `rds_db2`,
+  `aurora_postgresql`, `aurora_mysql` — or just `rds` when you don't know the
+  engine and want it auto-detected.
 - Always capture `region` (the DB's region, which may differ from this app's).
 - **DynamoDB**: capture `table_name` — several tables may be given as one
   comma-separated string; the scan handles them in a single call.
-- **RDS/Aurora**: introspection goes through the RDS Data API, so you MUST
-  collect all three and store them under exactly these keys:
-  `rds_cluster_arn`, `rds_secret_arn`, `rds_database_name`.
-  Tell the user where to find them if they ask: cluster ARN from the RDS
-  console/`describe-db-clusters`, secret ARN from Secrets Manager (the
-  cluster's master-user secret), database name = the schema they query.
-  The Data API exists only on Aurora Serverless v2/provisioned clusters with
-  the HTTP endpoint enabled — if they are on a plain RDS instance, say so and
-  offer the document path below instead.
+- **RDS/Aurora — ask for the DB instance or cluster identifier first.** With
+  `rds_instance_identifier` alone the scan resolves the engine, endpoint, port,
+  master-user secret and connection method by itself, so that is the ONLY thing
+  you normally need. Store it under exactly that key, plus
+  `rds_database_name` when the instance has no default database (SQL Server and
+  Oracle usually don't).
+  - Only ask for `rds_cluster_arn` / `rds_secret_arn` / `rds_database_name`
+    explicitly if the customer cannot share an identifier.
+  - Connection method is automatic: Aurora with the Data API (HTTP endpoint)
+    enabled goes over the Data API with no network path needed; every other
+    engine connects with a driver, which requires the runtime to reach the
+    endpoint (security group + subnet route). If a scan comes back
+    CONNECTION_FAILED, relay that reachability requirement rather than retrying.
 - **No reachable DB?** They can instead paste or upload the schema (DDL dump,
   ERD image, data dictionary, sample JSON). Accept it and follow
   "Phase 0-ALT: Schema supplied as a DOCUMENT" — do not ask for ARNs just to
@@ -881,7 +890,8 @@ When collected_data includes `existing_table == true`:
 
 **Phase 0: Schema Introspection (scan the existing DB)**
 ```
-1. Call introspect_database — pass EVERY parameter the engine needs:
+1. Call introspect_database. Every RDS and Aurora engine is supported
+   (PostgreSQL, MySQL, MariaDB, SQL Server, Oracle, Db2) plus DynamoDB.
 
    # DynamoDB (table_name may be a comma-separated list to scan several at once)
    introspect_database(
@@ -890,27 +900,42 @@ When collected_data includes `existing_table == true`:
        region=collected_data["region"]
    )
 
-   # RDS / Aurora — the three connection values are MANDATORY.
-   # Omitting them returns MISSING_PARAMETERS; there is no default.
+   # RDS / Aurora — PREFERRED form. The identifier is enough: engine, endpoint,
+   # port, credentials secret and connection method are all resolved from RDS.
    introspect_database(
-       db_type=collected_data["db_type"],          # "rds_postgresql" | "rds_mysql"
+       db_type=collected_data.get("db_type", "rds"),   # or just "rds" to auto-detect
        region=collected_data["region"],
-       rds_cluster_arn=collected_data["rds_cluster_arn"],
+       rds_instance_identifier=collected_data["rds_instance_identifier"],
+       rds_database_name=collected_data.get("rds_database_name"),  # needed when
+                                            # the instance has no default DB
+       table_name=collected_data.get("table_name")     # omit to scan everything
+   )
+
+   # RDS / Aurora — fall back to explicit values only when no identifier is available
+   introspect_database(
+       db_type="aurora_postgresql",
+       region=collected_data["region"],
+       rds_cluster_arn=collected_data["rds_cluster_arn"],      # Data API path
        rds_secret_arn=collected_data["rds_secret_arn"],
        rds_database_name=collected_data["rds_database_name"],
-       table_name=collected_data.get("table_name")  # omit to scan the whole schema
    )
 
 2. CHECK THE RESULT BEFORE CONTINUING. If `success == false`, do NOT proceed to
    Phase 1 — relay `error` to the user verbatim and ask them to confirm the
    connection details. Common `error_code` values and what to tell the user:
-   - MISSING_PARAMETERS    → ask for the cluster ARN / secret ARN / database name
-   - DATA_API_NOT_ENABLED  → the Data API must be enabled; it only exists on
-                             Aurora clusters, not on plain RDS instances
-   - ACCESS_DENIED         → the runtime role lacks rds-data / secretsmanager /
-                             dynamodb:DescribeTable permission
-   - NO_TABLES_FOUND       → the error lists the tables that DO exist; ask which
-                             ones they meant
+   - MISSING_PARAMETERS    → ask for the instance/cluster identifier (or the
+                             cluster ARN + secret ARN + database name)
+   - TARGET_NOT_FOUND      → no such DB instance or cluster in that region
+   - DATA_API_NOT_ENABLED  → only relevant on Aurora; a driver connection is
+                             used instead, which needs network reachability
+   - CONNECTION_FAILED     → the endpoint is not reachable from the runtime;
+                             the security group must allow the port and the
+                             subnets need a route. Offer the document path.
+   - DRIVER_NOT_INSTALLED  → the engine's driver is missing from the image
+   - ACCESS_DENIED         → the runtime role lacks rds / rds-data /
+                             secretsmanager / dynamodb:DescribeTable permission
+   - NO_TABLES_FOUND       → the error lists the tables that DO exist, and names
+                             the schema/owner that was searched; ask which they meant
 
 3. Convert via convert_to_infrastructure_schema(). It handles DynamoDB
    (single or multiple tables) AND RDS/Aurora, and returns:
@@ -1647,7 +1672,14 @@ TOOLS_REFERENCE = """
 ## AVAILABLE TOOLS
 
 ### Utility Tools
-- `introspect_database`: Connect to and analyze database schema
+- `introspect_database`: Read an existing database's schema — DynamoDB, or any
+  RDS/Aurora engine (PostgreSQL, MySQL, MariaDB, SQL Server, Oracle, Db2).
+  It is read-only and safe to call at ANY stage, not only during the interview:
+  re-run it mid-generation or during review to confirm a column name, a type, an
+  enum's allowed values or a foreign key before patching an asset, instead of
+  guessing from the conversation. Pass `rds_instance_identifier` and everything
+  else is resolved for you; pair it with `convert_to_infrastructure_schema` to
+  refresh the stored schema contract.
 - `save_operation_spec`: Save the complete specification for an operation
 - `get_operation_spec`: Retrieve saved operation specification
 - `list_operations`: List all saved operations

--- a/backend/ecs/src/tools/db_introspector.py
+++ b/backend/ecs/src/tools/db_introspector.py
@@ -12,6 +12,8 @@ actionable error instead of a silent empty result.
 
 import json
 import re
+from datetime import date, datetime, time
+from decimal import Decimal
 from typing import Optional
 
 import boto3
@@ -21,6 +23,129 @@ from strands import tool
 # Number of rows/items sampled per table to infer real-world value formats
 SAMPLE_LIMIT = 5
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Engine registry
+#
+# Every RDS and Aurora engine is supported. Two connection methods exist and the
+# right one is chosen automatically:
+#   • RDS Data API  — Aurora only, and only when the HTTP endpoint is enabled.
+#                     Needs no network path from the caller.
+#   • direct driver — everything else. Needs TCP reachability to the endpoint.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# db_type spelling → canonical type
+_DB_TYPE_ALIASES = {
+    "ddb": "dynamodb",
+    "dynamo": "dynamodb",
+    "dynamo_db": "dynamodb",
+    # PostgreSQL
+    "postgres": "rds_postgresql",
+    "postgresql": "rds_postgresql",
+    "rds_postgres": "rds_postgresql",
+    "aurora_postgres": "aurora_postgresql",
+    "aurora_postgresql": "aurora_postgresql",
+    # MySQL
+    "mysql": "rds_mysql",
+    "aurora_mysql": "aurora_mysql",
+    "rds_aurora_mysql": "aurora_mysql",
+    # MariaDB
+    "mariadb": "rds_mariadb",
+    "maria": "rds_mariadb",
+    # SQL Server
+    "sqlserver": "rds_sqlserver",
+    "mssql": "rds_sqlserver",
+    "rds_mssql": "rds_sqlserver",
+    "sql_server": "rds_sqlserver",
+    "rds_sql_server": "rds_sqlserver",
+    # Oracle
+    "oracle": "rds_oracle",
+    # Db2
+    "db2": "rds_db2",
+    "rds_ibm_db2": "rds_db2",
+}
+
+# canonical db_type → engine family (which SQL dialect / driver to use)
+_DB_TYPE_FAMILY = {
+    "rds_postgresql": "postgresql",
+    "aurora_postgresql": "postgresql",
+    "rds_mysql": "mysql",
+    "aurora_mysql": "mysql",
+    "rds_mariadb": "mysql",       # MariaDB speaks the MySQL protocol and information_schema
+    "rds_sqlserver": "sqlserver",
+    "rds_oracle": "oracle",
+    "rds_db2": "db2",
+}
+_SQL_DB_TYPES = set(_DB_TYPE_FAMILY)
+
+# RDS `Engine` value → engine family, for auto-detection
+_RDS_ENGINE_FAMILY = {
+    "postgres": "postgresql",
+    "aurora-postgresql": "postgresql",
+    "mysql": "mysql",
+    "aurora-mysql": "mysql",
+    "aurora": "mysql",            # legacy Aurora MySQL 5.6
+    "mariadb": "mysql",
+    "sqlserver-ex": "sqlserver",
+    "sqlserver-web": "sqlserver",
+    "sqlserver-se": "sqlserver",
+    "sqlserver-ee": "sqlserver",
+    "oracle-se2": "oracle",
+    "oracle-se2-cdb": "oracle",
+    "oracle-ee": "oracle",
+    "oracle-ee-cdb": "oracle",
+    "oracle-se": "oracle",
+    "custom-oracle-ee": "oracle",
+    "db2-ae": "db2",
+    "db2-se": "db2",
+}
+
+# RDS `Engine` value → canonical db_type reported back to the caller
+_RDS_ENGINE_DB_TYPE = {
+    "postgres": "rds_postgresql",
+    "aurora-postgresql": "aurora_postgresql",
+    "mysql": "rds_mysql",
+    "aurora-mysql": "aurora_mysql",
+    "aurora": "aurora_mysql",
+    "mariadb": "rds_mariadb",
+    "sqlserver-ex": "rds_sqlserver",
+    "sqlserver-web": "rds_sqlserver",
+    "sqlserver-se": "rds_sqlserver",
+    "sqlserver-ee": "rds_sqlserver",
+    "oracle-se2": "rds_oracle",
+    "oracle-se2-cdb": "rds_oracle",
+    "oracle-ee": "rds_oracle",
+    "oracle-ee-cdb": "rds_oracle",
+    "oracle-se": "rds_oracle",
+    "db2-ae": "rds_db2",
+    "db2-se": "rds_db2",
+}
+
+_DEFAULT_PORTS = {
+    "postgresql": 5432,
+    "mysql": 3306,
+    "sqlserver": 1433,
+    "oracle": 1521,
+    "db2": 50000,
+}
+
+# identifier quoting per family
+_QUOTE = {
+    "postgresql": ('"', '"'),
+    "mysql": ("`", "`"),
+    "sqlserver": ("[", "]"),
+    "oracle": ('"', '"'),
+    "db2": ('"', '"'),
+}
+
+# pip package needed for the direct-driver path, per family
+_DRIVER_PACKAGE = {
+    "postgresql": "psycopg2-binary",
+    "mysql": "PyMySQL",
+    "sqlserver": "python-tds",
+    "oracle": "oracledb",
+    "db2": "ibm-db",
+}
+
 
 @tool
 def introspect_database(
@@ -29,10 +154,17 @@ def introspect_database(
     region: str = "us-west-2",
     # For DynamoDB
     dynamodb_table_name: Optional[str] = None,
-    # For RDS
+    # For RDS / Aurora — Data API path
     rds_secret_arn: Optional[str] = None,
     rds_database_name: Optional[str] = None,
     rds_cluster_arn: Optional[str] = None,
+    # For RDS / Aurora — any engine, resolved automatically
+    rds_instance_identifier: Optional[str] = None,
+    rds_host: Optional[str] = None,
+    rds_port: Optional[int] = None,
+    rds_username: Optional[str] = None,
+    rds_password: Optional[str] = None,
+    tables_only: bool = False,
     include_sample_rows: bool = True,
 ) -> dict:
     """
@@ -44,15 +176,51 @@ def introspect_database(
 
     Use this BEFORE generating Lambda functions to understand the data structure.
 
+    Supported databases:
+      - DynamoDB
+      - Every RDS and Aurora engine: PostgreSQL, MySQL, MariaDB,
+        SQL Server, Oracle and Db2
+
+    How it connects (chosen automatically):
+      - Aurora with the Data API (HTTP endpoint) enabled → RDS Data API,
+        no network path needed
+      - everything else → a direct driver connection to the endpoint
+
+    The simplest call passes just `rds_instance_identifier`: the engine,
+    endpoint, port and master-user secret are all resolved from RDS, and the
+    right connection method is picked for you.
+
+    Choosing what to scan:
+      - omit `table_name` to scan every table
+      - pass one name to scan just that table
+      - pass a comma-separated list to scan several
+      - set `tables_only=True` first on an unfamiliar database: it returns a
+        cheap inventory (names, row counts, column counts, comments) with no
+        column, index or sample-row queries, so you can pick the handful of
+        tables the operations actually need and then scan those by name.
+      Table names are matched case-insensitively, so 'orders' finds Oracle's
+      ORDERS without the caller having to know the storage casing.
+
     Args:
-        db_type: Database type - 'dynamodb', 'rds_mysql', or 'rds_postgresql'
+        db_type: 'dynamodb', or an RDS/Aurora engine. Accepted spellings include
+            'rds_postgresql', 'rds_mysql', 'rds_mariadb', 'rds_sqlserver',
+            'rds_oracle', 'rds_db2', 'aurora_postgresql', 'aurora_mysql', and
+            plain 'rds'/'aurora' when the engine should be auto-detected.
         table_name: Specific table(s) to introspect. Comma-separated for several.
                     Omit to introspect every table.
         region: AWS region where the database is located
         dynamodb_table_name: For DynamoDB - table name(s), comma-separated
-        rds_secret_arn: For RDS - Secrets Manager ARN with the DB credentials
-        rds_database_name: For RDS - the database (schema) name
-        rds_cluster_arn: For RDS Data API - the Aurora cluster ARN
+        rds_secret_arn: Secrets Manager ARN holding the DB credentials
+        rds_database_name: The database (schema) name to inspect
+        rds_cluster_arn: Aurora cluster ARN (Data API path)
+        rds_instance_identifier: RDS DB instance or Aurora cluster identifier —
+            everything else is resolved from it
+        rds_host: Endpoint host, if not resolving from an identifier
+        rds_port: Endpoint port (defaults to the engine's standard port)
+        rds_username: DB user, if not using a Secrets Manager secret
+        rds_password: DB password, if not using a Secrets Manager secret
+        tables_only: Return just the table inventory, skipping column/index/
+            foreign-key/sample queries. Use on a large unfamiliar schema.
         include_sample_rows: Sample a few rows/items to infer value formats
 
     Returns:
@@ -66,21 +234,7 @@ def introspect_database(
         - Sample data
     """
     db_type = (db_type or "").strip().lower().replace("-", "_")
-
-    # tolerate the aliases the interview/spec layer uses
-    aliases = {
-        "ddb": "dynamodb",
-        "dynamo": "dynamodb",
-        "mysql": "rds_mysql",
-        "aurora_mysql": "rds_mysql",
-        "rds_aurora_mysql": "rds_mysql",
-        "postgres": "rds_postgresql",
-        "postgresql": "rds_postgresql",
-        "aurora_postgresql": "rds_postgresql",
-        "rds_postgres": "rds_postgresql",
-        "aurora_postgres": "rds_postgresql",
-    }
-    db_type = aliases.get(db_type, db_type)
+    db_type = _DB_TYPE_ALIASES.get(db_type, db_type)
 
     if db_type == "dynamodb":
         names = _split_names(dynamodb_table_name or table_name)
@@ -101,21 +255,27 @@ def introspect_database(
             "errors": [r.get("error") for r in failed] or None,
         }
 
-    if db_type in ("rds_mysql", "rds_postgresql"):
-        return _introspect_rds(
+    if db_type in _SQL_DB_TYPES or db_type in ("rds", "aurora"):
+        return _introspect_sql(
             db_type=db_type,
             secret_arn=rds_secret_arn,
             database_name=rds_database_name,
             cluster_arn=rds_cluster_arn,
+            instance_identifier=rds_instance_identifier,
+            host=rds_host,
+            port=rds_port,
+            username=rds_username,
+            password=rds_password,
             table_name=table_name,
             region=region,
+            tables_only=tables_only,
             include_sample_rows=include_sample_rows,
         )
 
     return {
         "success": False,
         "error": f"Unsupported database type: {db_type}",
-        "supported_types": ["dynamodb", "rds_mysql", "rds_postgresql"],
+        "supported_types": ["dynamodb"] + sorted(_SQL_DB_TYPES),
     }
 
 
@@ -432,69 +592,829 @@ _POSTGRES_QUERIES = {
 }
 
 
-def _introspect_rds(
+_SQLSERVER_QUERIES = {
+    "tables": """
+        SELECT t.name AS table_name,
+               CASE WHEN o.type = 'V' THEN 'VIEW' ELSE 'BASE TABLE' END AS table_type,
+               CAST(p.row_count AS bigint) AS table_rows,
+               CAST(p.used_page_count * 8192 AS bigint) AS data_length,
+               CAST(ISNULL(ep.value, '') AS nvarchar(2000)) AS table_comment
+        FROM sys.objects o
+        JOIN sys.schemas s ON s.schema_id = o.schema_id
+        JOIN sys.all_objects t ON t.object_id = o.object_id
+        LEFT JOIN (
+            SELECT object_id,
+                   SUM(CASE WHEN index_id < 2 THEN row_count ELSE 0 END) AS row_count,
+                   SUM(used_page_count) AS used_page_count
+            FROM sys.dm_db_partition_stats GROUP BY object_id
+        ) p ON p.object_id = o.object_id
+        LEFT JOIN sys.extended_properties ep
+               ON ep.major_id = o.object_id AND ep.minor_id = 0 AND ep.name = 'MS_Description'
+        WHERE o.type IN ('U','V') AND s.name = 'dbo'
+        ORDER BY t.name
+    """,
+    "columns": """
+        SELECT t.name AS table_name,
+               c.name AS column_name,
+               ty.name AS data_type,
+               ty.name + CASE
+                   WHEN ty.name IN ('varchar','nvarchar','char','nchar')
+                       THEN '(' + CASE WHEN c.max_length = -1 THEN 'max'
+                                       ELSE CAST(c.max_length AS varchar(10)) END + ')'
+                   WHEN ty.name IN ('decimal','numeric')
+                       THEN '(' + CAST(c.precision AS varchar(10)) + ','
+                                + CAST(c.scale AS varchar(10)) + ')'
+                   ELSE '' END AS column_type,
+               CASE WHEN c.is_nullable = 1 THEN 'YES' ELSE 'NO' END AS is_nullable,
+               CAST(dc.definition AS nvarchar(2000)) AS column_default,
+               c.max_length AS character_maximum_length,
+               c.precision AS numeric_precision,
+               c.scale AS numeric_scale,
+               c.column_id AS ordinal_position,
+               CAST(ISNULL(ep.value, '') AS nvarchar(2000)) AS column_comment,
+               CASE WHEN c.is_identity = 1 THEN 'auto_increment' ELSE '' END AS extra,
+               CAST(cc.definition AS nvarchar(2000)) AS generation_expression
+        FROM sys.columns c
+        JOIN sys.objects o ON o.object_id = c.object_id
+        JOIN sys.schemas s ON s.schema_id = o.schema_id
+        JOIN sys.all_objects t ON t.object_id = o.object_id
+        JOIN sys.types ty ON ty.user_type_id = c.user_type_id
+        LEFT JOIN sys.default_constraints dc ON dc.object_id = c.default_object_id
+        LEFT JOIN sys.computed_columns cc
+               ON cc.object_id = c.object_id AND cc.column_id = c.column_id
+        LEFT JOIN sys.extended_properties ep
+               ON ep.major_id = c.object_id AND ep.minor_id = c.column_id
+              AND ep.name = 'MS_Description'
+        WHERE o.type IN ('U','V') AND s.name = 'dbo'
+        ORDER BY t.name, c.column_id
+    """,
+    "indexes": """
+        SELECT t.name AS table_name,
+               i.name AS index_name,
+               c.name AS column_name,
+               CASE WHEN i.is_unique = 1 THEN 0 ELSE 1 END AS non_unique,
+               ic.key_ordinal AS seq_in_index,
+               i.type_desc AS index_type,
+               CASE WHEN i.is_primary_key = 1 THEN 'true' ELSE 'false' END AS is_primary
+        FROM sys.indexes i
+        JOIN sys.objects o ON o.object_id = i.object_id
+        JOIN sys.schemas s ON s.schema_id = o.schema_id
+        JOIN sys.all_objects t ON t.object_id = i.object_id
+        JOIN sys.index_columns ic
+             ON ic.object_id = i.object_id AND ic.index_id = i.index_id
+        JOIN sys.columns c
+             ON c.object_id = ic.object_id AND c.column_id = ic.column_id
+        WHERE o.type = 'U' AND s.name = 'dbo' AND i.name IS NOT NULL
+              AND ic.is_included_column = 0
+        ORDER BY t.name, i.name, ic.key_ordinal
+    """,
+    "primary_keys": """
+        SELECT t.name AS table_name,
+               c.name AS column_name,
+               ic.key_ordinal AS ordinal_position
+        FROM sys.indexes i
+        JOIN sys.objects o ON o.object_id = i.object_id
+        JOIN sys.schemas s ON s.schema_id = o.schema_id
+        JOIN sys.all_objects t ON t.object_id = i.object_id
+        JOIN sys.index_columns ic
+             ON ic.object_id = i.object_id AND ic.index_id = i.index_id
+        JOIN sys.columns c
+             ON c.object_id = ic.object_id AND c.column_id = ic.column_id
+        WHERE i.is_primary_key = 1 AND s.name = 'dbo'
+        ORDER BY t.name, ic.key_ordinal
+    """,
+    "foreign_keys": """
+        SELECT pt.name AS table_name,
+               fk.name AS constraint_name,
+               pc.name AS column_name,
+               rt.name AS referenced_table_name,
+               rc.name AS referenced_column_name,
+               fkc.constraint_column_id AS ordinal_position
+        FROM sys.foreign_keys fk
+        JOIN sys.foreign_key_columns fkc ON fkc.constraint_object_id = fk.object_id
+        JOIN sys.all_objects pt ON pt.object_id = fk.parent_object_id
+        JOIN sys.all_objects rt ON rt.object_id = fk.referenced_object_id
+        JOIN sys.columns pc
+             ON pc.object_id = fkc.parent_object_id AND pc.column_id = fkc.parent_column_id
+        JOIN sys.columns rc
+             ON rc.object_id = fkc.referenced_object_id
+            AND rc.column_id = fkc.referenced_column_id
+        ORDER BY pt.name, fk.name, fkc.constraint_column_id
+    """,
+    "checks": """
+        SELECT t.name AS table_name,
+               cc.name AS constraint_name,
+               CAST(cc.definition AS nvarchar(2000)) AS definition
+        FROM sys.check_constraints cc
+        JOIN sys.all_objects t ON t.object_id = cc.parent_object_id
+        ORDER BY t.name, cc.name
+    """,
+}
+
+_ORACLE_QUERIES = {
+    "tables": """
+        SELECT t.table_name AS table_name,
+               'BASE TABLE' AS table_type,
+               t.num_rows AS table_rows,
+               NULL AS data_length,
+               c.comments AS table_comment
+        FROM user_tables t
+        LEFT JOIN user_tab_comments c ON c.table_name = t.table_name
+        UNION ALL
+        SELECT v.view_name, 'VIEW', NULL, NULL, vc.comments
+        FROM user_views v
+        LEFT JOIN user_tab_comments vc ON vc.table_name = v.view_name
+        ORDER BY 1
+    """,
+    "columns": """
+        SELECT c.table_name AS table_name,
+               c.column_name AS column_name,
+               c.data_type AS data_type,
+               CASE
+                 WHEN c.data_type IN ('VARCHAR2','NVARCHAR2','CHAR','NCHAR')
+                   THEN c.data_type || '(' || c.char_length || ')'
+                 WHEN c.data_type = 'NUMBER' AND c.data_precision IS NOT NULL
+                   THEN c.data_type || '(' || c.data_precision || ',' ||
+                        NVL(c.data_scale, 0) || ')'
+                 ELSE c.data_type
+               END AS column_type,
+               c.nullable AS is_nullable,
+               c.data_default AS column_default,
+               c.char_length AS character_maximum_length,
+               c.data_precision AS numeric_precision,
+               c.data_scale AS numeric_scale,
+               c.column_id AS ordinal_position,
+               cc.comments AS column_comment,
+               CASE WHEN c.identity_column = 'YES' THEN 'auto_increment' ELSE '' END AS extra,
+               c.virtual_column AS is_generated
+        FROM user_tab_cols c
+        LEFT JOIN user_col_comments cc
+               ON cc.table_name = c.table_name AND cc.column_name = c.column_name
+        WHERE c.hidden_column = 'NO'
+        ORDER BY c.table_name, c.column_id
+    """,
+    "indexes": """
+        SELECT i.table_name AS table_name,
+               i.index_name AS index_name,
+               ic.column_name AS column_name,
+               CASE WHEN i.uniqueness = 'UNIQUE' THEN 0 ELSE 1 END AS non_unique,
+               ic.column_position AS seq_in_index,
+               i.index_type AS index_type,
+               CASE WHEN cn.constraint_type = 'P' THEN 'true' ELSE 'false' END AS is_primary
+        FROM user_indexes i
+        JOIN user_ind_columns ic ON ic.index_name = i.index_name
+        LEFT JOIN user_constraints cn
+               ON cn.index_name = i.index_name AND cn.constraint_type = 'P'
+        ORDER BY i.table_name, i.index_name, ic.column_position
+    """,
+    "primary_keys": """
+        SELECT cc.table_name AS table_name,
+               cc.column_name AS column_name,
+               cc.position AS ordinal_position
+        FROM user_constraints c
+        JOIN user_cons_columns cc ON cc.constraint_name = c.constraint_name
+        WHERE c.constraint_type = 'P'
+        ORDER BY cc.table_name, cc.position
+    """,
+    "foreign_keys": """
+        SELECT cc.table_name AS table_name,
+               c.constraint_name AS constraint_name,
+               cc.column_name AS column_name,
+               rc.table_name AS referenced_table_name,
+               rc.column_name AS referenced_column_name,
+               cc.position AS ordinal_position
+        FROM user_constraints c
+        JOIN user_cons_columns cc ON cc.constraint_name = c.constraint_name
+        JOIN user_cons_columns rc
+             ON rc.constraint_name = c.r_constraint_name AND rc.position = cc.position
+        WHERE c.constraint_type = 'R'
+        ORDER BY cc.table_name, c.constraint_name, cc.position
+    """,
+    "checks": """
+        SELECT table_name AS table_name,
+               constraint_name AS constraint_name,
+               search_condition AS definition
+        FROM user_constraints
+        WHERE constraint_type = 'C' AND generated = 'USER NAME'
+        ORDER BY table_name, constraint_name
+    """,
+}
+
+_DB2_QUERIES = {
+    "tables": """
+        SELECT TABNAME AS TABLE_NAME,
+               CASE TYPE WHEN 'V' THEN 'VIEW' ELSE 'BASE TABLE' END AS TABLE_TYPE,
+               CARD AS TABLE_ROWS,
+               NULL AS DATA_LENGTH,
+               REMARKS AS TABLE_COMMENT
+        FROM SYSCAT.TABLES
+        WHERE TABSCHEMA = CURRENT SCHEMA AND TYPE IN ('T','V')
+        ORDER BY TABNAME
+    """,
+    "columns": """
+        SELECT TABNAME AS TABLE_NAME,
+               COLNAME AS COLUMN_NAME,
+               TYPENAME AS DATA_TYPE,
+               TYPENAME AS COLUMN_TYPE,
+               NULLS AS IS_NULLABLE,
+               DEFAULT AS COLUMN_DEFAULT,
+               LENGTH AS CHARACTER_MAXIMUM_LENGTH,
+               LENGTH AS NUMERIC_PRECISION,
+               SCALE AS NUMERIC_SCALE,
+               COLNO AS ORDINAL_POSITION,
+               REMARKS AS COLUMN_COMMENT,
+               CASE WHEN IDENTITY = 'Y' THEN 'auto_increment' ELSE '' END AS EXTRA,
+               GENERATED AS IS_GENERATED
+        FROM SYSCAT.COLUMNS
+        WHERE TABSCHEMA = CURRENT SCHEMA
+        ORDER BY TABNAME, COLNO
+    """,
+    "indexes": """
+        SELECT i.TABNAME AS TABLE_NAME,
+               i.INDNAME AS INDEX_NAME,
+               c.COLNAME AS COLUMN_NAME,
+               CASE WHEN i.UNIQUERULE IN ('U','P') THEN 0 ELSE 1 END AS NON_UNIQUE,
+               c.COLSEQ AS SEQ_IN_INDEX,
+               'BTREE' AS INDEX_TYPE,
+               CASE WHEN i.UNIQUERULE = 'P' THEN 'true' ELSE 'false' END AS IS_PRIMARY
+        FROM SYSCAT.INDEXES i
+        JOIN SYSCAT.INDEXCOLUSE c ON c.INDNAME = i.INDNAME AND c.INDSCHEMA = i.INDSCHEMA
+        WHERE i.TABSCHEMA = CURRENT SCHEMA
+        ORDER BY i.TABNAME, i.INDNAME, c.COLSEQ
+    """,
+    "primary_keys": """
+        SELECT k.TABNAME AS TABLE_NAME,
+               k.COLNAME AS COLUMN_NAME,
+               k.COLSEQ AS ORDINAL_POSITION
+        FROM SYSCAT.KEYCOLUSE k
+        JOIN SYSCAT.TABCONST t
+             ON t.CONSTNAME = k.CONSTNAME AND t.TABNAME = k.TABNAME
+        WHERE t.TYPE = 'P' AND k.TABSCHEMA = CURRENT SCHEMA
+        ORDER BY k.TABNAME, k.COLSEQ
+    """,
+    "foreign_keys": """
+        SELECT r.TABNAME AS TABLE_NAME,
+               r.CONSTNAME AS CONSTRAINT_NAME,
+               fk.COLNAME AS COLUMN_NAME,
+               r.REFTABNAME AS REFERENCED_TABLE_NAME,
+               pk.COLNAME AS REFERENCED_COLUMN_NAME,
+               fk.COLSEQ AS ORDINAL_POSITION
+        FROM SYSCAT.REFERENCES r
+        JOIN SYSCAT.KEYCOLUSE fk ON fk.CONSTNAME = r.CONSTNAME AND fk.TABNAME = r.TABNAME
+        JOIN SYSCAT.KEYCOLUSE pk
+             ON pk.CONSTNAME = r.REFKEYNAME AND pk.COLSEQ = fk.COLSEQ
+        WHERE r.TABSCHEMA = CURRENT SCHEMA
+        ORDER BY r.TABNAME, r.CONSTNAME, fk.COLSEQ
+    """,
+    "checks": """
+        SELECT TABNAME AS TABLE_NAME,
+               CONSTNAME AS CONSTRAINT_NAME,
+               TEXT AS DEFINITION
+        FROM SYSCAT.CHECKS
+        WHERE TABSCHEMA = CURRENT SCHEMA
+        ORDER BY TABNAME, CONSTNAME
+    """,
+}
+
+_QUERY_SETS = {
+    "postgresql": _POSTGRES_QUERIES,
+    "mysql": _MYSQL_QUERIES,
+    "sqlserver": _SQLSERVER_QUERIES,
+    "oracle": _ORACLE_QUERIES,
+    "db2": _DB2_QUERIES,
+}
+
+
+class _DriverMissing(Exception):
+    """Raised when the pip package for an engine's driver is not installed."""
+
+
+def _resolve_sql_target(
+    db_type: str,
+    region: str,
+    instance_identifier: Optional[str],
+    cluster_arn: Optional[str],
+    secret_arn: Optional[str],
+    database_name: Optional[str],
+    host: Optional[str],
+    port: Optional[int],
+    username: Optional[str],
+    password: Optional[str],
+) -> dict:
+    """Work out engine, endpoint, credentials and connection method.
+
+    Given only an instance/cluster identifier this asks RDS for everything else,
+    so the caller does not have to know whether the target is Aurora, whether
+    the Data API is on, or which port the engine listens on.
+    """
+    rds = boto3.client("rds", region_name=region)
+    resolved_engine = None
+    data_api = False
+    endpoint = host
+    endpoint_port = port
+
+    identifier = instance_identifier
+    if not identifier and cluster_arn:
+        identifier = cluster_arn.split(":")[-1]
+
+    if identifier:
+        described = _describe_rds_target(rds, identifier)
+        if described.get("error"):
+            return {"success": False, "error": described["error"],
+                    "error_code": "TARGET_NOT_FOUND"}
+        resolved_engine = described["engine"]
+        data_api = described["data_api"]
+        endpoint = endpoint or described["endpoint"]
+        endpoint_port = endpoint_port or described["port"]
+        secret_arn = secret_arn or described["secret_arn"]
+        database_name = database_name or described["database_name"]
+        cluster_arn = cluster_arn or described["cluster_arn"]
+
+    if resolved_engine:
+        family = _RDS_ENGINE_FAMILY.get(resolved_engine)
+        if not family:
+            return {
+                "success": False,
+                "error": f"Unrecognized RDS engine '{resolved_engine}'. Supported "
+                         f"engines: {sorted(set(_RDS_ENGINE_FAMILY))}.",
+                "error_code": "UNSUPPORTED_ENGINE",
+            }
+        if db_type in ("rds", "aurora"):
+            db_type = _RDS_ENGINE_DB_TYPE.get(resolved_engine, db_type)
+        elif _DB_TYPE_FAMILY.get(db_type) and _DB_TYPE_FAMILY[db_type] != family:
+            # trust what RDS reports over what the caller guessed
+            db_type = _RDS_ENGINE_DB_TYPE.get(resolved_engine, db_type)
+    else:
+        if db_type in ("rds", "aurora"):
+            return {
+                "success": False,
+                "error": "db_type 'rds'/'aurora' needs rds_instance_identifier so the "
+                         "engine can be detected, or name the engine explicitly "
+                         f"(one of {sorted(_SQL_DB_TYPES)}).",
+                "error_code": "MISSING_PARAMETERS",
+            }
+        family = _DB_TYPE_FAMILY[db_type]
+
+    if not database_name and family != "oracle":
+        return {
+            "success": False,
+            "error": "rds_database_name is required (the database/schema to inspect). "
+                     "Pass rds_instance_identifier to have it resolved automatically "
+                     "when the instance declares a default database.",
+            "error_code": "MISSING_PARAMETERS",
+        }
+
+    # Data API path — Aurora with the HTTP endpoint enabled
+    if data_api and cluster_arn and secret_arn:
+        return {
+            "success": True, "method": "data_api", "family": family,
+            "db_type": db_type, "database_name": database_name,
+            "cluster_arn": cluster_arn, "secret_arn": secret_arn,
+            "region": region, "engine": resolved_engine,
+        }
+
+    # Driver path — needs an endpoint and credentials
+    if not endpoint:
+        hint = ("The Data API is not enabled on this cluster, so a direct connection "
+                "is required. ") if cluster_arn else ""
+        return {
+            "success": False,
+            "error": f"{hint}No endpoint to connect to. Pass rds_instance_identifier "
+                     f"(preferred — the endpoint and credentials are resolved from RDS) "
+                     f"or rds_host explicitly.",
+            "error_code": "MISSING_PARAMETERS",
+        }
+
+    if not (username and password):
+        if not secret_arn:
+            return {
+                "success": False,
+                "error": "No credentials. Pass rds_secret_arn (a Secrets Manager secret "
+                         "holding username/password — RDS-managed master user secrets "
+                         "work as-is) or rds_username plus rds_password.",
+                "error_code": "MISSING_PARAMETERS",
+            }
+        creds = _read_db_secret(secret_arn, region)
+        if creds.get("error"):
+            return {"success": False, "error": creds["error"],
+                    "error_code": "SECRET_UNREADABLE"}
+        username = username or creds.get("username")
+        password = password or creds.get("password")
+        endpoint = endpoint or creds.get("host")
+        endpoint_port = endpoint_port or creds.get("port")
+        database_name = database_name or creds.get("dbname")
+
+    return {
+        "success": True, "method": "driver", "family": family, "db_type": db_type,
+        "database_name": database_name, "host": endpoint,
+        "port": int(endpoint_port or _DEFAULT_PORTS[family]),
+        "username": username, "password": password,
+        "secret_arn": secret_arn, "cluster_arn": cluster_arn,
+        "region": region, "engine": resolved_engine,
+    }
+
+
+def _describe_rds_target(rds, identifier: str) -> dict:
+    """Look up a DB instance or Aurora cluster and pull out what we need."""
+    try:
+        clusters = rds.describe_db_clusters(DBClusterIdentifier=identifier)["DBClusters"]
+        if clusters:
+            c = clusters[0]
+            return {
+                "engine": c.get("Engine"),
+                "data_api": bool(c.get("HttpEndpointEnabled")),
+                "endpoint": c.get("Endpoint"),
+                "port": c.get("Port"),
+                "secret_arn": (c.get("MasterUserSecret") or {}).get("SecretArn"),
+                "database_name": c.get("DatabaseName"),
+                "cluster_arn": c.get("DBClusterArn"),
+            }
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") not in (
+                "DBClusterNotFoundFault", "DBClusterNotFound", "InvalidParameterValue"):
+            return {"error": f"Could not describe cluster '{identifier}': {e}"}
+    except Exception as e:
+        return {"error": f"Could not describe cluster '{identifier}': {e}"}
+
+    try:
+        instances = rds.describe_db_instances(DBInstanceIdentifier=identifier)["DBInstances"]
+    except ClientError as e:
+        code = e.response.get("Error", {}).get("Code", "")
+        if code in ("DBInstanceNotFound", "DBInstanceNotFoundFault"):
+            return {"error": f"No RDS DB instance or Aurora cluster named "
+                             f"'{identifier}' in this region."}
+        return {"error": f"Could not describe instance '{identifier}': {e}"}
+    except Exception as e:
+        return {"error": f"Could not describe instance '{identifier}': {e}"}
+
+    if not instances:
+        return {"error": f"No RDS DB instance named '{identifier}' in this region."}
+    i = instances[0]
+    endpoint = i.get("Endpoint") or {}
+    cluster_id = i.get("DBClusterIdentifier")
+    data_api = False
+    cluster_arn = None
+    if cluster_id:
+        # an Aurora writer instance — the Data API lives on its cluster
+        try:
+            c = rds.describe_db_clusters(DBClusterIdentifier=cluster_id)["DBClusters"][0]
+            data_api = bool(c.get("HttpEndpointEnabled"))
+            cluster_arn = c.get("DBClusterArn")
+        except Exception:
+            pass
+    return {
+        "engine": i.get("Engine"),
+        "data_api": data_api,
+        "endpoint": endpoint.get("Address"),
+        "port": endpoint.get("Port"),
+        "secret_arn": (i.get("MasterUserSecret") or {}).get("SecretArn"),
+        "database_name": i.get("DBName"),
+        "cluster_arn": cluster_arn,
+    }
+
+
+def _read_db_secret(secret_arn: str, region: str) -> dict:
+    """Read username/password (and host/port/dbname when present) from a secret."""
+    try:
+        sm = boto3.client("secretsmanager", region_name=region)
+        raw = sm.get_secret_value(SecretId=secret_arn).get("SecretString") or "{}"
+        data = json.loads(raw)
+    except ClientError as e:
+        return {"error": f"Could not read secret {secret_arn}: "
+                         f"{e.response.get('Error', {}).get('Message', e)}. The runtime "
+                         f"role needs secretsmanager:GetSecretValue on it."}
+    except Exception as e:
+        return {"error": f"Could not parse secret {secret_arn}: {e}"}
+    if not data.get("username") or not data.get("password"):
+        return {"error": f"Secret {secret_arn} has no username/password keys. "
+                         f"Found: {sorted(data)}"}
+    return {
+        "username": data.get("username"),
+        "password": data.get("password"),
+        "host": data.get("host"),
+        "port": data.get("port"),
+        "dbname": data.get("dbname") or data.get("dbName"),
+    }
+
+
+def _make_runner(target: dict):
+    """Return (run(sql) -> list[dict], close()) for the resolved target."""
+    if target["method"] == "data_api":
+        return _data_api_runner(target)
+    return _driver_runner(target)
+
+
+def _data_api_runner(target: dict):
+    rds_data = boto3.client("rds-data", region_name=target["region"])
+
+    def run(sql: str) -> list[dict]:
+        kwargs = dict(
+            resourceArn=target["cluster_arn"],
+            secretArn=target["secret_arn"],
+            database=target["database_name"],
+            sql=sql,
+            includeResultMetadata=True,   # ← without this there is no columnMetadata
+        )
+        if ":database" in sql:
+            kwargs["parameters"] = [
+                {"name": "database", "value": {"stringValue": target["database_name"]}}
+            ]
+        return _parse_rds_result(rds_data.execute_statement(**kwargs))
+
+    return run, lambda: None
+
+
+def _driver_runner(target: dict):
+    """Open a direct connection and return a query runner over it."""
+    family = target["family"]
+    host, port = target["host"], target["port"]
+    user, pwd = target["username"], target["password"]
+    database = target["database_name"]
+
+    if family == "postgresql":
+        try:
+            import psycopg2
+        except ImportError as e:
+            raise _DriverMissing(_driver_missing_message(family)) from e
+        conn = psycopg2.connect(host=host, port=port, user=user, password=pwd,
+                                dbname=database, connect_timeout=15)
+        conn.set_session(readonly=True, autocommit=True)
+        paramstyle = "pyformat"
+
+    elif family == "mysql":
+        try:
+            import pymysql
+        except ImportError as e:
+            raise _DriverMissing(_driver_missing_message(family)) from e
+        conn = pymysql.connect(host=host, port=port, user=user, password=pwd,
+                               database=database, connect_timeout=15,
+                               charset="utf8mb4")
+        paramstyle = "pyformat"
+
+    elif family == "sqlserver":
+        try:
+            import pytds
+        except ImportError as e:
+            raise _DriverMissing(_driver_missing_message(family)) from e
+        conn = pytds.connect(server=host, port=port, user=user, password=pwd,
+                             database=database, login_timeout=15, autocommit=True)
+        paramstyle = "pyformat"
+
+    elif family == "oracle":
+        try:
+            import oracledb
+        except ImportError as e:
+            raise _DriverMissing(_driver_missing_message(family)) from e
+        conn = oracledb.connect(user=user, password=pwd,
+                                dsn=f"{host}:{port}/{database}")
+        paramstyle = "named"
+
+    elif family == "db2":
+        try:
+            import ibm_db_dbi
+        except ImportError as e:
+            raise _DriverMissing(_driver_missing_message(family)) from e
+        dsn = (f"DATABASE={database};HOSTNAME={host};PORT={port};"
+               f"PROTOCOL=TCPIP;UID={user};PWD={pwd};")
+        conn = ibm_db_dbi.connect(dsn, "", "")
+        paramstyle = "qmark"
+
+    else:  # pragma: no cover - guarded by the registry
+        raise _DriverMissing(f"No driver mapping for engine family '{family}'")
+
+    def run(sql: str) -> list[dict]:
+        statement, params = _adapt_named_params(sql, paramstyle, database)
+        cur = conn.cursor()
+        try:
+            cur.execute(statement, params) if params else cur.execute(statement)
+            if cur.description is None:
+                return []
+            names = [str(d[0]).upper() for d in cur.description]
+            return [dict(zip(names, _normalize_row(row))) for row in cur.fetchall()]
+        finally:
+            try:
+                cur.close()
+            except Exception:
+                pass
+
+    def close():
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    return run, close
+
+
+def _adapt_named_params(sql: str, paramstyle: str, database: str):
+    """Rewrite the `:database` placeholder for the driver's paramstyle."""
+    if ":database" not in sql:
+        return sql, None
+    if paramstyle == "pyformat":
+        return sql.replace(":database", "%(database)s"), {"database": database}
+    if paramstyle == "qmark":
+        return sql.replace(":database", "?"), (database,)
+    return sql, {"database": database}          # oracledb takes :named as-is
+
+
+def _normalize_row(row) -> list:
+    """Make driver row values JSON-safe (Decimal, datetime, bytes, LOBs)."""
+    out = []
+    for v in row:
+        if v is None or isinstance(v, (str, int, float, bool)):
+            out.append(v)
+        elif isinstance(v, Decimal):
+            out.append(str(v))
+        elif isinstance(v, (bytes, bytearray, memoryview)):
+            out.append("<binary>")
+        elif isinstance(v, (datetime, date, time)):
+            out.append(v.isoformat())
+        elif hasattr(v, "read"):                # Oracle LOB
+            try:
+                out.append(str(v.read())[:500])
+            except Exception:
+                out.append("<lob>")
+        else:
+            out.append(str(v))
+    return out
+
+
+def _driver_missing_message(family: str) -> str:
+    package = _DRIVER_PACKAGE[family]
+    return (f"The {family} driver is not installed, so a direct connection cannot be "
+            f"opened. Add `{package}` to backend/ecs/requirements.txt and redeploy. "
+            f"(Aurora clusters can avoid the driver entirely by enabling the RDS "
+            f"Data API.)")
+
+
+def _explain_connect_error(e: Exception, target: dict) -> str:
+    text = str(e)
+    where = f"{target.get('host')}:{target.get('port')}"
+    if "timeout" in text.lower() or "timed out" in text.lower():
+        return (f"Timed out connecting to {where}. The endpoint is not reachable from "
+                f"the runtime: check the security group allows inbound "
+                f"{target.get('port')} from this VPC/CIDR, that the subnets have a "
+                f"route, and that the instance is not private-only. Original: {text}")
+    if "password authentication" in text.lower() or "access denied" in text.lower():
+        return (f"Authentication rejected by {where}. Verify the credentials in the "
+                f"secret match this database. Original: {text}")
+    if "does not exist" in text.lower() or "unknown database" in text.lower():
+        return (f"Database '{target.get('database_name')}' does not exist on {where}. "
+                f"Original: {text}")
+    return f"Could not connect to {where}: {text}"
+
+
+def _introspect_sql(
     db_type: str,
     secret_arn: str,
     database_name: str,
     cluster_arn: str,
     table_name: Optional[str],
     region: str,
+    instance_identifier: Optional[str] = None,
+    host: Optional[str] = None,
+    port: Optional[int] = None,
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    tables_only: bool = False,
     include_sample_rows: bool = True,
 ) -> dict:
-    """Introspect an RDS/Aurora database using the Data API."""
-    missing = [
-        label for label, value in (
-            ("rds_cluster_arn", cluster_arn),
-            ("rds_secret_arn", secret_arn),
-            ("rds_database_name", database_name),
-        ) if not value
-    ]
-    if missing:
+    """Introspect any RDS or Aurora database.
+
+    Uses the RDS Data API when the target is an Aurora cluster with the HTTP
+    endpoint enabled, and a direct driver connection otherwise.
+    """
+    target = _resolve_sql_target(
+        db_type=db_type, region=region, instance_identifier=instance_identifier,
+        cluster_arn=cluster_arn, secret_arn=secret_arn, database_name=database_name,
+        host=host, port=port, username=username, password=password,
+    )
+    if not target.get("success"):
+        return target
+
+    family = target["family"]
+    db_type = target["db_type"]
+    database_name = target["database_name"]
+    queries = _QUERY_SETS[family]
+
+    try:
+        runner, close = _make_runner(target)
+    except _DriverMissing as e:
         return {
             "success": False,
-            "error": f"Missing required RDS parameter(s): {', '.join(missing)}. "
-                     f"RDS introspection uses the Data API and needs the Aurora cluster ARN, "
-                     f"the Secrets Manager ARN holding the credentials, and the database name.",
-            "error_code": "MISSING_PARAMETERS",
+            "error": str(e),
+            "error_code": "DRIVER_NOT_INSTALLED",
+            "db_type": db_type,
+        }
+    except ClientError as e:
+        return {"success": False, **_explain_rds_error(e, db_type, target.get("cluster_arn"), region)}
+    except Exception as e:
+        return {
+            "success": False,
+            "error": _explain_connect_error(e, target),
+            "error_code": "CONNECTION_FAILED",
+            "db_type": db_type,
         }
 
-    rds_data = boto3.client("rds-data", region_name=region)
-    is_mysql = db_type == "rds_mysql"
-    queries = _MYSQL_QUERIES if is_mysql else _POSTGRES_QUERIES
-
     def run(sql: str) -> list[dict]:
-        kwargs = dict(
-            resourceArn=cluster_arn,
-            secretArn=secret_arn,
-            database=database_name,
-            sql=sql,
-            includeResultMetadata=True,   # ← without this there is no columnMetadata
-        )
-        if ":database" in sql:
-            kwargs["parameters"] = [
-                {"name": "database", "value": {"stringValue": database_name}}
-            ]
-        return _parse_rds_result(rds_data.execute_statement(**kwargs))
+        return runner(sql)
 
     try:
         tables = run(queries["tables"])
+    except ClientError as e:
+        close()
+        return {"success": False, **_explain_rds_error(e, db_type, target.get("cluster_arn"), region)}
+    except Exception as e:
+        close()
+        return {
+            "success": False,
+            "error": f"Failed to list tables in {db_type} database '{database_name}': {e}",
+            "error_code": "QUERY_FAILED",
+            "db_type": db_type,
+        }
+
+    # Table names are matched case-insensitively so callers do not need to know
+    # the storage casing (Oracle and Db2 fold unquoted identifiers to upper case).
+    wanted_raw = _split_names(table_name)
+    wanted = {w.lower() for w in wanted_raw}
+    discovered = [r.get("TABLE_NAME") for r in tables if r.get("TABLE_NAME")]
+    selected = [n for n in discovered if not wanted or n.lower() in wanted]
+
+    if not selected:
+        close()
+        return {
+            "success": False,
+            "error": (
+                f"No tables found in database '{database_name}'"
+                + (f" matching {sorted(wanted_raw)}" if wanted_raw else "")
+                + f". Discovered {len(discovered)} table(s) total"
+                + (f": {sorted(discovered)}" if discovered else "")
+                + ". Check the database name and the table spelling "
+                + _schema_scope_hint(family)
+            ),
+            "error_code": "NO_TABLES_FOUND",
+            "db_type": db_type,
+            "database_name": database_name,
+            "available_tables": sorted(discovered),
+        }
+
+    if tables_only:
+        inventory = []
+        for row in tables:
+            name = row.get("TABLE_NAME")
+            if name not in selected:
+                continue
+            inventory.append({
+                "table_name": name,
+                "table_type": row.get("TABLE_TYPE"),
+                "table_comment": row.get("TABLE_COMMENT") or None,
+                "estimated_rows": row.get("TABLE_ROWS"),
+                "size_bytes": row.get("DATA_LENGTH"),
+            })
+        close()
+        return {
+            "success": True,
+            "db_type": db_type,
+            "engine": family,
+            "rds_engine": target.get("engine"),
+            "database_name": database_name,
+            "region": region,
+            "access_method": ("rds-data-api" if target["method"] == "data_api"
+                              else f"{family}-driver"),
+            "mode": "tables_only",
+            "table_count": len(inventory),
+            "tables": inventory,
+            "next_step": ("Pick the tables the operations need and call again with "
+                          "table_name='a,b,c' for the full column/index/foreign-key "
+                          "detail."),
+        }
+
+    try:
         columns = run(queries["columns"])
         indexes = run(queries["indexes"])
         foreign_keys = run(queries["foreign_keys"])
-        primary_keys = [] if is_mysql else run(queries["primary_keys"])
-        enums = {} if is_mysql else _group_enums(run(queries["enums"]))
-        checks = [] if is_mysql else run(queries["checks"])
+        primary_keys = [] if family == "mysql" else run(queries["primary_keys"])
+        enums = _group_enums(run(queries["enums"])) if family == "postgresql" else {}
+        checks = run(queries["checks"]) if "checks" in queries else []
     except ClientError as e:
-        return {"success": False, **_explain_rds_error(e, db_type, cluster_arn, region)}
+        close()
+        return {"success": False, **_explain_rds_error(e, db_type, target.get("cluster_arn"), region)}
     except Exception as e:
-        return {"success": False, "error": f"Failed to introspect RDS database: {e}"}
+        close()
+        return {
+            "success": False,
+            "error": f"Failed to introspect {db_type} database '{database_name}': {e}",
+            "error_code": "QUERY_FAILED",
+            "db_type": db_type,
+        }
 
-    wanted = set(_split_names(table_name))
+    is_mysql = family == "mysql"
+    selected_set = set(selected)
 
     table_schemas: dict[str, dict] = {}
     for row in tables:
         name = row.get("TABLE_NAME")
-        if not name or (wanted and name not in wanted):
+        if not name or name not in selected_set:
             continue
         table_schemas[name] = {
             "table_name": name,
@@ -508,22 +1428,6 @@ def _introspect_rds(
             "foreign_keys": [],
             "referenced_by": [],
             "check_constraints": [],
-        }
-
-    if not table_schemas:
-        return {
-            "success": False,
-            "error": (
-                f"No tables found in database '{database_name}'"
-                + (f" matching {sorted(wanted)}" if wanted else "")
-                + f". Discovered {len(tables)} table(s) total"
-                + (f": {sorted({r.get('TABLE_NAME') for r in tables if r.get('TABLE_NAME')})}" if tables else "")
-                + ". Check the database name and the table spelling "
-                  "(PostgreSQL introspection reads the 'public' schema)."
-            ),
-            "error_code": "NO_TABLES_FOUND",
-            "db_type": db_type,
-            "database_name": database_name,
         }
 
     # ---- columns
@@ -665,16 +1569,21 @@ def _introspect_rds(
     # ---- sample rows
     warnings = []
     if include_sample_rows:
-        quote = "`" if is_mysql else '"'
+        open_q, close_q = _QUOTE[family]
         for tname, schema in table_schemas.items():
             if schema["table_type"] not in ("BASE TABLE", "PARTITIONED TABLE", None):
                 continue
+            quoted = f"{open_q}{tname}{close_q}"
             try:
-                rows = run(f"SELECT * FROM {quote}{tname}{quote} LIMIT {SAMPLE_LIMIT}")
+                rows = run(_limited_select(family, quoted, SAMPLE_LIMIT))
                 schema["sample_rows"] = [_stringify_row(r) for r in rows]
-                schema["actual_row_count"] = _count_rows(run, quote, tname)
+                schema["actual_row_count"] = _count_rows(run, quoted)
             except Exception as e:
                 warnings.append(f"Could not sample rows from '{tname}': {e}")
+            try:
+                _collect_observed_values(run, family, schema)
+            except Exception as e:
+                warnings.append(f"Could not read distinct values for '{tname}': {e}")
 
     relationships = [
         f"{fk['table']}.{','.join(fk['columns'])} → "
@@ -682,15 +1591,20 @@ def _introspect_rds(
         for fk in grouped_fks.values()
     ]
 
+    close()
+
     result = {
         "success": True,
         "db_type": db_type,
-        "engine": "mysql" if is_mysql else "postgresql",
+        "engine": family,
+        "rds_engine": target.get("engine"),
         "database_name": database_name,
-        "cluster_arn": cluster_arn,
-        "secret_arn": secret_arn,
+        "cluster_arn": target.get("cluster_arn"),
+        "secret_arn": target.get("secret_arn"),
+        "host": target.get("host"),
+        "port": target.get("port"),
         "region": region,
-        "access_method": "rds-data-api",
+        "access_method": "rds-data-api" if target["method"] == "data_api" else f"{family}-driver",
         "table_count": len(table_schemas),
         "tables": list(table_schemas.values()),
         "relationships": sorted(relationships),
@@ -702,9 +1616,92 @@ def _introspect_rds(
     return result
 
 
-def _count_rows(run, quote: str, tname: str):
+_ENUM_LIKE_NAME_RE = re.compile(
+    r'(^|_)(status|state|type|kind|category|code|level|tier|grade|reason|'
+    r'method|channel|result|stage|priority|flag|mode)(_|$)', re.I)
+# beyond this many rows a DISTINCT scan is too expensive to be worth it
+OBSERVED_VALUES_ROW_LIMIT = 200_000
+OBSERVED_VALUES_MAX_COLUMNS = 12
+OBSERVED_VALUES_MAX_DISTINCT = 25
+
+
+def _collect_observed_values(run, family: str, schema: dict) -> None:
+    """Fill `observed_values` for enum-like columns that declare no allowed set.
+
+    PostgreSQL and MySQL expose real enum types, so the allowed values are read
+    straight from the catalog. SQL Server, Oracle and Db2 have no ENUM — a status
+    column is just VARCHAR — so without this the generator has nothing to go on
+    and invents values (observed live: it wrote `LOST` for a column whose actual
+    values are `LOSS`, `DAMAGE`, `DELAY`, `WRONG_DELIVERY`, and the INSERT then
+    stored a value the business never uses).
+
+    Deliberately cheap: only text columns whose name looks categorical, only on
+    tables small enough to scan, capped per table.
+    """
+    open_q, close_q = _QUOTE[family]
+    rows_known = schema.get("actual_row_count")
+    if isinstance(rows_known, (int, float)) and rows_known > OBSERVED_VALUES_ROW_LIMIT:
+        return
+    table = f"{open_q}{schema['table_name']}{close_q}"
+    probed = 0
+    for col in schema.get("columns", []):
+        if probed >= OBSERVED_VALUES_MAX_COLUMNS:
+            break
+        name = col.get("name") or ""
+        if col.get("allowed_values") or not _ENUM_LIKE_NAME_RE.search(name):
+            continue
+        raw_type = str(col.get("full_type") or col.get("type") or "").lower()
+        if not any(t in raw_type for t in ("char", "text", "string")):
+            continue
+        quoted_col = f"{open_q}{name}{close_q}"
+        sql = (f"SELECT DISTINCT {quoted_col} AS v FROM {table} "
+               f"WHERE {quoted_col} IS NOT NULL")
+        try:
+            values = run(_limit_distinct(family, sql, OBSERVED_VALUES_MAX_DISTINCT + 1))
+        except Exception:
+            continue
+        probed += 1
+        found = [list(r.values())[0] for r in values if list(r.values())[0] is not None]
+        if found and len(found) <= OBSERVED_VALUES_MAX_DISTINCT:
+            col["observed_values"] = sorted(str(v) for v in found)
+            col["observed_values_note"] = (
+                "distinct values currently present in the column; this engine has no "
+                "declared enum, so use these exact spellings rather than inventing any")
+
+
+def _limit_distinct(family: str, sql: str, limit: int) -> str:
+    if family == "sqlserver":
+        return sql.replace("SELECT DISTINCT", f"SELECT DISTINCT TOP {limit}", 1)
+    if family in ("oracle", "db2"):
+        return f"{sql} FETCH FIRST {limit} ROWS ONLY"
+    return f"{sql} LIMIT {limit}"
+
+
+def _schema_scope_hint(family: str) -> str:
+    """Tell the caller which schema/owner the queries actually look at."""
+    return {
+        "postgresql": "(PostgreSQL introspection reads the 'public' schema).",
+        "mysql": "(MySQL/MariaDB introspection reads the database you named).",
+        "sqlserver": "(SQL Server introspection reads the 'dbo' schema).",
+        "oracle": "(Oracle introspection reads objects owned by the connecting user).",
+        "db2": "(Db2 introspection reads CURRENT SCHEMA).",
+    }.get(family, "")
+
+
+def _limited_select(family: str, quoted_table: str, limit: int) -> str:
+    """`SELECT * ... LIMIT n` in the dialect the engine actually accepts."""
+    if family == "sqlserver":
+        return f"SELECT TOP {limit} * FROM {quoted_table}"
+    if family == "oracle":
+        return f"SELECT * FROM {quoted_table} FETCH FIRST {limit} ROWS ONLY"
+    if family == "db2":
+        return f"SELECT * FROM {quoted_table} FETCH FIRST {limit} ROWS ONLY"
+    return f"SELECT * FROM {quoted_table} LIMIT {limit}"
+
+
+def _count_rows(run, quoted_table: str):
     try:
-        rows = run(f"SELECT COUNT(*) AS row_count FROM {quote}{tname}{quote}")
+        rows = run(f"SELECT COUNT(*) AS row_count FROM {quoted_table}")
         if rows:
             return list(rows[0].values())[0]
     except Exception:
@@ -961,7 +1958,7 @@ def convert_to_infrastructure_schema(introspection_result: dict) -> dict:
             return merged
         return _convert_dynamodb(introspection_result)
 
-    if db_type in ("rds_mysql", "rds_postgresql"):
+    if db_type in _SQL_DB_TYPES:
         return _convert_rds(introspection_result)
 
     return {"error": f"Cannot convert db_type '{db_type}'", "tables": []}
@@ -1100,7 +2097,7 @@ def _convert_dynamodb(r: dict) -> dict:
 
 
 def _convert_rds(r: dict) -> dict:
-    engine = r.get("engine") or ("mysql" if r["db_type"] == "rds_mysql" else "postgresql")
+    engine = r.get("engine") or _DB_TYPE_FAMILY.get(r.get("db_type"), "postgresql")
     database_name = r.get("database_name")
 
     tables = []
@@ -1119,7 +2116,10 @@ def _convert_rds(r: dict) -> dict:
                     "sql_type": c.get("full_type") or c.get("type"),
                     "nullable": c.get("nullable"),
                     "default": c.get("default"),
-                    "allowed_values": c.get("allowed_values"),
+                    "allowed_values": c.get("allowed_values") or c.get("observed_values"),
+                    "allowed_values_source": ("declared" if c.get("allowed_values")
+                                              else ("observed" if c.get("observed_values")
+                                                    else None)),
                     "generated": c.get("generated", False),
                     "description": c.get("comment"),
                 }

--- a/backend/ecs/src/tools/db_introspector.py
+++ b/backend/ecs/src/tools/db_introspector.py
@@ -1,14 +1,25 @@
 """
 Database Introspector Tool
 
-Connects to customer databases (DynamoDB, RDS MySQL/PostgreSQL)
+Connects to customer databases (DynamoDB, RDS/Aurora MySQL & PostgreSQL)
 and discovers schema information to help generate accurate Lambda functions.
+
+RDS introspection goes through the **RDS Data API**, which is only available on
+Aurora Serverless v2 / Aurora provisioned clusters with the HTTP endpoint
+enabled. Plain RDS instances are not reachable this way and produce an
+actionable error instead of a silent empty result.
 """
 
 import json
+import re
 from typing import Optional
-from strands import tool
+
 import boto3
+from botocore.exceptions import ClientError
+from strands import tool
+
+# Number of rows/items sampled per table to infer real-world value formats
+SAMPLE_LIMIT = 5
 
 
 @tool
@@ -22,164 +33,403 @@ def introspect_database(
     rds_secret_arn: Optional[str] = None,
     rds_database_name: Optional[str] = None,
     rds_cluster_arn: Optional[str] = None,
+    include_sample_rows: bool = True,
 ) -> dict:
     """
     Introspect a database to discover its schema structure.
 
     This tool connects to the specified database and returns detailed schema
-    information including tables, columns, types, keys, and indexes.
+    information including tables, columns, types, keys, indexes, foreign keys,
+    enum values, comments and sample rows.
 
     Use this BEFORE generating Lambda functions to understand the data structure.
 
     Args:
         db_type: Database type - 'dynamodb', 'rds_mysql', or 'rds_postgresql'
-        table_name: Specific table to introspect (optional, introspects all if not specified)
+        table_name: Specific table(s) to introspect. Comma-separated for several.
+                    Omit to introspect every table.
         region: AWS region where the database is located
-        dynamodb_table_name: For DynamoDB - the table name to describe
-        rds_secret_arn: For RDS - Secrets Manager ARN containing connection credentials
-        rds_database_name: For RDS - the database name
-        rds_cluster_arn: For RDS Data API - the cluster ARN
+        dynamodb_table_name: For DynamoDB - table name(s), comma-separated
+        rds_secret_arn: For RDS - Secrets Manager ARN with the DB credentials
+        rds_database_name: For RDS - the database (schema) name
+        rds_cluster_arn: For RDS Data API - the Aurora cluster ARN
+        include_sample_rows: Sample a few rows/items to infer value formats
 
     Returns:
         Schema information including:
         - Table names
-        - Column/attribute definitions
-        - Primary keys and sort keys
-        - Global Secondary Indexes (GSIs)
-        - Sample data structure
-        - Estimated item count
+        - Column/attribute definitions (types, nullability, defaults, comments)
+        - Primary keys, sort keys, composite keys
+        - Indexes (GSIs/LSIs for DynamoDB, secondary indexes for SQL)
+        - Foreign keys / relationships (SQL)
+        - Enum / allowed values (SQL)
+        - Sample data
     """
+    db_type = (db_type or "").strip().lower().replace("-", "_")
+
+    # tolerate the aliases the interview/spec layer uses
+    aliases = {
+        "ddb": "dynamodb",
+        "dynamo": "dynamodb",
+        "mysql": "rds_mysql",
+        "aurora_mysql": "rds_mysql",
+        "rds_aurora_mysql": "rds_mysql",
+        "postgres": "rds_postgresql",
+        "postgresql": "rds_postgresql",
+        "aurora_postgresql": "rds_postgresql",
+        "rds_postgres": "rds_postgresql",
+        "aurora_postgres": "rds_postgresql",
+    }
+    db_type = aliases.get(db_type, db_type)
 
     if db_type == "dynamodb":
-        return _introspect_dynamodb(dynamodb_table_name or table_name, region)
-    elif db_type in ("rds_mysql", "rds_postgresql"):
+        names = _split_names(dynamodb_table_name or table_name)
+        if not names:
+            return {
+                "success": False,
+                "error": "dynamodb_table_name (or table_name) is required for DynamoDB introspection",
+            }
+        if len(names) == 1:
+            return _introspect_dynamodb(names[0], region, include_sample_rows)
+        results = [_introspect_dynamodb(n, region, include_sample_rows) for n in names]
+        failed = [r for r in results if not r.get("success")]
+        return {
+            "success": len(failed) < len(results),
+            "db_type": "dynamodb",
+            "table_count": len([r for r in results if r.get("success")]),
+            "tables": results,
+            "errors": [r.get("error") for r in failed] or None,
+        }
+
+    if db_type in ("rds_mysql", "rds_postgresql"):
         return _introspect_rds(
             db_type=db_type,
             secret_arn=rds_secret_arn,
             database_name=rds_database_name,
             cluster_arn=rds_cluster_arn,
             table_name=table_name,
-            region=region
+            region=region,
+            include_sample_rows=include_sample_rows,
         )
-    else:
-        return {
-            "success": False,
-            "error": f"Unsupported database type: {db_type}",
-            "supported_types": ["dynamodb", "rds_mysql", "rds_postgresql"]
-        }
+
+    return {
+        "success": False,
+        "error": f"Unsupported database type: {db_type}",
+        "supported_types": ["dynamodb", "rds_mysql", "rds_postgresql"],
+    }
 
 
-def _introspect_dynamodb(table_name: str, region: str) -> dict:
+def _split_names(value: Optional[str]) -> list[str]:
+    if not value:
+        return []
+    return [n.strip() for n in str(value).split(",") if n.strip()]
+
+
+# ======================================================================
+# DynamoDB
+# ======================================================================
+
+def _index_keys(key_schema: list) -> list[dict]:
+    out = []
+    for key in key_schema or []:
+        out.append({
+            "attribute_name": key["AttributeName"],
+            "key_type": "partition_key" if key["KeyType"] == "HASH" else "sort_key",
+        })
+    return out
+
+
+def _describe_ddb_value(attr_value: dict) -> tuple[str, object]:
+    """Return (inferred_type, plain_python_value) for a DynamoDB AttributeValue."""
+    if "S" in attr_value:
+        return "string", attr_value["S"]
+    if "N" in attr_value:
+        return "number", attr_value["N"]
+    if "BOOL" in attr_value:
+        return "boolean", attr_value["BOOL"]
+    if "NULL" in attr_value:
+        return "null", None
+    if "L" in attr_value:
+        return "list", [_describe_ddb_value(v)[1] for v in attr_value["L"]]
+    if "M" in attr_value:
+        return "map", {k: _describe_ddb_value(v)[1] for k, v in attr_value["M"].items()}
+    if "SS" in attr_value:
+        return "string_set", attr_value["SS"]
+    if "NS" in attr_value:
+        return "number_set", attr_value["NS"]
+    if "BS" in attr_value:
+        return "binary_set", ["<binary>"]
+    if "B" in attr_value:
+        return "binary", "<binary>"
+    return "unknown", None
+
+
+def _introspect_dynamodb(table_name: str, region: str, include_sample_rows: bool = True) -> dict:
     """Introspect a DynamoDB table."""
     if not table_name:
-        return {
-            "success": False,
-            "error": "table_name is required for DynamoDB introspection"
-        }
+        return {"success": False, "error": "table_name is required for DynamoDB introspection"}
 
     try:
         dynamodb = boto3.client("dynamodb", region_name=region)
+    except Exception as e:  # pragma: no cover - client construction rarely fails
+        return {"success": False, "error": f"Could not create DynamoDB client: {e}"}
 
-        # Describe the table
-        response = dynamodb.describe_table(TableName=table_name)
-        table = response["Table"]
-
-        # Extract key schema
-        key_schema = []
-        for key in table.get("KeySchema", []):
-            key_type = "partition_key" if key["KeyType"] == "HASH" else "sort_key"
-            key_schema.append({
-                "attribute_name": key["AttributeName"],
-                "key_type": key_type
-            })
-
-        # Extract attribute definitions
-        attributes = []
-        for attr in table.get("AttributeDefinitions", []):
-            attr_type_map = {"S": "string", "N": "number", "B": "binary"}
-            attributes.append({
-                "name": attr["AttributeName"],
-                "type": attr_type_map.get(attr["AttributeType"], attr["AttributeType"])
-            })
-
-        # Extract GSIs
-        gsis = []
-        for gsi in table.get("GlobalSecondaryIndexes", []):
-            gsi_keys = []
-            for key in gsi.get("KeySchema", []):
-                key_type = "partition_key" if key["KeyType"] == "HASH" else "sort_key"
-                gsi_keys.append({
-                    "attribute_name": key["AttributeName"],
-                    "key_type": key_type
-                })
-            gsis.append({
-                "index_name": gsi["IndexName"],
-                "key_schema": gsi_keys,
-                "projection_type": gsi.get("Projection", {}).get("ProjectionType", "ALL")
-            })
-
-        # Sample some items to infer full schema
-        sample_attributes = set()
-        try:
-            scan_response = dynamodb.scan(
-                TableName=table_name,
-                Limit=10
-            )
-            for item in scan_response.get("Items", []):
-                for attr_name, attr_value in item.items():
-                    # Determine type from value
-                    if "S" in attr_value:
-                        sample_attributes.add((attr_name, "string"))
-                    elif "N" in attr_value:
-                        sample_attributes.add((attr_name, "number"))
-                    elif "BOOL" in attr_value:
-                        sample_attributes.add((attr_name, "boolean"))
-                    elif "L" in attr_value:
-                        sample_attributes.add((attr_name, "list"))
-                    elif "M" in attr_value:
-                        sample_attributes.add((attr_name, "map"))
-                    elif "SS" in attr_value:
-                        sample_attributes.add((attr_name, "string_set"))
-                    elif "NS" in attr_value:
-                        sample_attributes.add((attr_name, "number_set"))
-        except Exception as scan_error:
-            # Non-fatal - we just won't have sample data
-            pass
-
-        # Combine defined attributes with sampled ones
-        all_attributes = {attr["name"]: attr["type"] for attr in attributes}
-        for attr_name, attr_type in sample_attributes:
-            if attr_name not in all_attributes:
-                all_attributes[attr_name] = attr_type
-
-        return {
-            "success": True,
-            "db_type": "dynamodb",
-            "table_name": table_name,
-            "table_status": table.get("TableStatus"),
-            "item_count": table.get("ItemCount", 0),
-            "table_size_bytes": table.get("TableSizeBytes", 0),
-            "key_schema": key_schema,
-            "attributes": [
-                {"name": name, "type": type_}
-                for name, type_ in sorted(all_attributes.items())
-            ],
-            "global_secondary_indexes": gsis,
-            "billing_mode": table.get("BillingModeSummary", {}).get("BillingMode", "PROVISIONED"),
-            "stream_enabled": table.get("StreamSpecification", {}).get("StreamEnabled", False),
-            "suggestions": _generate_dynamodb_suggestions(key_schema, gsis, all_attributes)
-        }
-
-    except dynamodb.exceptions.ResourceNotFoundException:
-        return {
-            "success": False,
-            "error": f"Table '{table_name}' not found in region {region}"
-        }
+    try:
+        table = dynamodb.describe_table(TableName=table_name)["Table"]
+    except ClientError as e:
+        code = e.response.get("Error", {}).get("Code", "")
+        if code == "ResourceNotFoundException":
+            return {
+                "success": False,
+                "error": f"Table '{table_name}' not found in region {region}. "
+                         f"Check the table name and that the region is correct.",
+            }
+        if code in ("AccessDeniedException", "AccessDenied", "UnrecognizedClientException"):
+            return {
+                "success": False,
+                "error": f"Access denied calling dynamodb:DescribeTable on '{table_name}' "
+                         f"in {region}. The runtime role needs dynamodb:DescribeTable and "
+                         f"dynamodb:Scan on arn:aws:dynamodb:{region}:*:table/{table_name}. "
+                         f"Details: {e}",
+                "error_code": "ACCESS_DENIED",
+            }
+        return {"success": False, "error": f"Failed to describe DynamoDB table: {e}"}
     except Exception as e:
-        return {
-            "success": False,
-            "error": f"Failed to introspect DynamoDB table: {str(e)}"
-        }
+        return {"success": False, "error": f"Failed to introspect DynamoDB table: {e}"}
+
+    key_schema = _index_keys(table.get("KeySchema", []))
+
+    attr_type_map = {"S": "string", "N": "number", "B": "binary"}
+    attributes = [
+        {"name": a["AttributeName"], "type": attr_type_map.get(a["AttributeType"], a["AttributeType"])}
+        for a in table.get("AttributeDefinitions", [])
+    ]
+
+    gsis = []
+    for gsi in table.get("GlobalSecondaryIndexes", []):
+        projection = gsi.get("Projection", {})
+        gsis.append({
+            "index_name": gsi["IndexName"],
+            "key_schema": _index_keys(gsi.get("KeySchema", [])),
+            "projection_type": projection.get("ProjectionType", "ALL"),
+            "projected_attributes": projection.get("NonKeyAttributes"),
+            "status": gsi.get("IndexStatus"),
+        })
+
+    lsis = []
+    for lsi in table.get("LocalSecondaryIndexes", []):
+        projection = lsi.get("Projection", {})
+        lsis.append({
+            "index_name": lsi["IndexName"],
+            "key_schema": _index_keys(lsi.get("KeySchema", [])),
+            "projection_type": projection.get("ProjectionType", "ALL"),
+            "projected_attributes": projection.get("NonKeyAttributes"),
+        })
+
+    # Sample items to discover attributes that are not part of any key
+    sampled_types: dict[str, set] = {}
+    sample_items: list[dict] = []
+    sampled_count = 0
+    sample_error = None
+    if include_sample_rows:
+        try:
+            scan = dynamodb.scan(TableName=table_name, Limit=25)
+            items = scan.get("Items", [])
+            sampled_count = len(items)
+            for item in items:
+                plain = {}
+                for name, value in item.items():
+                    inferred, py_value = _describe_ddb_value(value)
+                    sampled_types.setdefault(name, set()).add(inferred)
+                    plain[name] = py_value
+                if len(sample_items) < SAMPLE_LIMIT:
+                    sample_items.append(plain)
+        except ClientError as e:
+            sample_error = (
+                f"Could not scan '{table_name}' for sample data ({e.response.get('Error', {}).get('Code')}). "
+                f"Schema keys/indexes were still read from DescribeTable, but non-key "
+                f"attributes could not be discovered. Grant dynamodb:Scan to see them."
+            )
+        except Exception as e:  # pragma: no cover
+            sample_error = f"Could not scan '{table_name}' for sample data: {e}"
+
+    all_attributes = {a["name"]: a["type"] for a in attributes}
+    for name, types in sampled_types.items():
+        types = {t for t in types if t != "null"} or {"null"}
+        merged = sorted(types)[0] if len(types) == 1 else "|".join(sorted(types))
+        all_attributes.setdefault(name, merged)
+
+    key_attribute_names = {k["attribute_name"] for k in key_schema}
+    for idx in gsis + lsis:
+        key_attribute_names.update(k["attribute_name"] for k in idx["key_schema"])
+
+    result = {
+        "success": True,
+        "db_type": "dynamodb",
+        "table_name": table_name,
+        "table_arn": table.get("TableArn"),
+        "region": region,
+        "table_status": table.get("TableStatus"),
+        "item_count": table.get("ItemCount", 0),
+        "item_count_note": "DynamoDB updates ItemCount roughly every 6 hours; "
+                           "sampled_item_count reflects what was actually read now.",
+        "sampled_item_count": sampled_count,
+        "table_size_bytes": table.get("TableSizeBytes", 0),
+        "key_schema": key_schema,
+        "attributes": [{"name": n, "type": t} for n, t in sorted(all_attributes.items())],
+        "non_key_attributes": sorted(set(all_attributes) - key_attribute_names),
+        "global_secondary_indexes": gsis,
+        "local_secondary_indexes": lsis,
+        "billing_mode": table.get("BillingModeSummary", {}).get("BillingMode", "PROVISIONED"),
+        "stream_enabled": table.get("StreamSpecification", {}).get("StreamEnabled", False),
+        "stream_view_type": table.get("StreamSpecification", {}).get("StreamViewType"),
+        "sample_items": sample_items,
+        "suggestions": _generate_dynamodb_suggestions(key_schema, gsis, lsis, all_attributes),
+    }
+    if sample_error:
+        result["warnings"] = [sample_error]
+    return result
+
+
+# ======================================================================
+# RDS / Aurora (Data API)
+# ======================================================================
+
+_MYSQL_QUERIES = {
+    "tables": """
+        SELECT TABLE_NAME, TABLE_TYPE, TABLE_ROWS, DATA_LENGTH, TABLE_COMMENT
+        FROM INFORMATION_SCHEMA.TABLES
+        WHERE TABLE_SCHEMA = :database
+        ORDER BY TABLE_NAME
+    """,
+    "columns": """
+        SELECT TABLE_NAME, COLUMN_NAME, DATA_TYPE, COLUMN_TYPE, IS_NULLABLE,
+               COLUMN_KEY, COLUMN_DEFAULT, CHARACTER_MAXIMUM_LENGTH,
+               NUMERIC_PRECISION, NUMERIC_SCALE, COLUMN_COMMENT, EXTRA,
+               GENERATION_EXPRESSION, ORDINAL_POSITION
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = :database
+        ORDER BY TABLE_NAME, ORDINAL_POSITION
+    """,
+    "indexes": """
+        SELECT TABLE_NAME, INDEX_NAME, COLUMN_NAME, NON_UNIQUE, SEQ_IN_INDEX,
+               INDEX_TYPE
+        FROM INFORMATION_SCHEMA.STATISTICS
+        WHERE TABLE_SCHEMA = :database
+        ORDER BY TABLE_NAME, INDEX_NAME, SEQ_IN_INDEX
+    """,
+    "foreign_keys": """
+        SELECT TABLE_NAME, CONSTRAINT_NAME, COLUMN_NAME,
+               REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME, ORDINAL_POSITION
+        FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+        WHERE TABLE_SCHEMA = :database AND REFERENCED_TABLE_NAME IS NOT NULL
+        ORDER BY TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION
+    """,
+}
+
+_POSTGRES_QUERIES = {
+    "tables": """
+        SELECT c.relname AS table_name,
+               CASE c.relkind WHEN 'r' THEN 'BASE TABLE'
+                              WHEN 'p' THEN 'PARTITIONED TABLE'
+                              WHEN 'v' THEN 'VIEW'
+                              WHEN 'm' THEN 'MATERIALIZED VIEW' END AS table_type,
+               c.reltuples::bigint AS table_rows,
+               pg_total_relation_size(c.oid) AS data_length,
+               COALESCE(obj_description(c.oid, 'pg_class'), '') AS table_comment
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public' AND c.relkind IN ('r','p','v','m')
+        ORDER BY c.relname
+    """,
+    "columns": """
+        SELECT c.table_name,
+               c.column_name,
+               c.data_type,
+               CASE WHEN c.data_type = 'USER-DEFINED' THEN c.udt_name ELSE c.data_type END AS column_type,
+               c.is_nullable,
+               c.column_default,
+               c.character_maximum_length,
+               c.numeric_precision,
+               c.numeric_scale,
+               c.udt_name,
+               c.is_generated,
+               c.generation_expression,
+               c.ordinal_position,
+               COALESCE(col_description(fc.oid, c.ordinal_position::int), '') AS column_comment
+        FROM information_schema.columns c
+        JOIN pg_class fc ON fc.relname = c.table_name
+        JOIN pg_namespace fn ON fn.oid = fc.relnamespace AND fn.nspname = c.table_schema
+        WHERE c.table_schema = 'public'
+        ORDER BY c.table_name, c.ordinal_position
+    """,
+    "indexes": """
+        SELECT t.relname AS table_name,
+               i.relname AS index_name,
+               a.attname AS column_name,
+               CASE WHEN ix.indisunique THEN 0 ELSE 1 END AS non_unique,
+               k.ord AS seq_in_index,
+               am.amname AS index_type,
+               ix.indisprimary AS is_primary
+        FROM pg_index ix
+        JOIN pg_class t ON t.oid = ix.indrelid
+        JOIN pg_class i ON i.oid = ix.indexrelid
+        JOIN pg_am am ON am.oid = i.relam
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        JOIN unnest(ix.indkey) WITH ORDINALITY AS k(attnum, ord) ON TRUE
+        JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum
+        WHERE n.nspname = 'public' AND t.relkind IN ('r','p')
+        ORDER BY t.relname, i.relname, k.ord
+    """,
+    "primary_keys": """
+        SELECT t.relname AS table_name,
+               a.attname AS column_name,
+               k.ord AS ordinal_position
+        FROM pg_constraint con
+        JOIN pg_class t ON t.oid = con.conrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        JOIN unnest(con.conkey) WITH ORDINALITY AS k(attnum, ord) ON TRUE
+        JOIN pg_attribute a ON a.attrelid = t.oid AND a.attnum = k.attnum
+        WHERE con.contype = 'p' AND n.nspname = 'public'
+        ORDER BY t.relname, k.ord
+    """,
+    "foreign_keys": """
+        SELECT t.relname AS table_name,
+               con.conname AS constraint_name,
+               a.attname AS column_name,
+               rt.relname AS referenced_table_name,
+               ra.attname AS referenced_column_name,
+               k.ord AS ordinal_position
+        FROM pg_constraint con
+        JOIN pg_class t ON t.oid = con.conrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        JOIN pg_class rt ON rt.oid = con.confrelid
+        JOIN unnest(con.conkey) WITH ORDINALITY AS k(attnum, ord) ON TRUE
+        JOIN pg_attribute a ON a.attrelid = con.conrelid AND a.attnum = k.attnum
+        JOIN unnest(con.confkey) WITH ORDINALITY AS fk(attnum, ord) ON fk.ord = k.ord
+        JOIN pg_attribute ra ON ra.attrelid = con.confrelid AND ra.attnum = fk.attnum
+        WHERE con.contype = 'f' AND n.nspname = 'public'
+        ORDER BY t.relname, con.conname, k.ord
+    """,
+    "enums": """
+        SELECT t.typname AS enum_name, e.enumlabel AS enum_value
+        FROM pg_type t
+        JOIN pg_enum e ON e.enumtypid = t.oid
+        JOIN pg_namespace n ON n.oid = t.typnamespace
+        WHERE n.nspname = 'public'
+        ORDER BY t.typname, e.enumsortorder
+    """,
+    "checks": """
+        SELECT t.relname AS table_name,
+               con.conname AS constraint_name,
+               pg_get_constraintdef(con.oid) AS definition
+        FROM pg_constraint con
+        JOIN pg_class t ON t.oid = con.conrelid
+        JOIN pg_namespace n ON n.oid = t.relnamespace
+        WHERE con.contype = 'c' AND n.nspname = 'public'
+        ORDER BY t.relname, con.conname
+    """,
+}
 
 
 def _introspect_rds(
@@ -188,212 +438,371 @@ def _introspect_rds(
     database_name: str,
     cluster_arn: str,
     table_name: Optional[str],
-    region: str
+    region: str,
+    include_sample_rows: bool = True,
 ) -> dict:
-    """Introspect an RDS database using the Data API."""
-    if not all([secret_arn, database_name, cluster_arn]):
+    """Introspect an RDS/Aurora database using the Data API."""
+    missing = [
+        label for label, value in (
+            ("rds_cluster_arn", cluster_arn),
+            ("rds_secret_arn", secret_arn),
+            ("rds_database_name", database_name),
+        ) if not value
+    ]
+    if missing:
         return {
             "success": False,
-            "error": "rds_secret_arn, rds_database_name, and rds_cluster_arn are all required for RDS introspection"
+            "error": f"Missing required RDS parameter(s): {', '.join(missing)}. "
+                     f"RDS introspection uses the Data API and needs the Aurora cluster ARN, "
+                     f"the Secrets Manager ARN holding the credentials, and the database name.",
+            "error_code": "MISSING_PARAMETERS",
         }
+
+    rds_data = boto3.client("rds-data", region_name=region)
+    is_mysql = db_type == "rds_mysql"
+    queries = _MYSQL_QUERIES if is_mysql else _POSTGRES_QUERIES
+
+    def run(sql: str) -> list[dict]:
+        kwargs = dict(
+            resourceArn=cluster_arn,
+            secretArn=secret_arn,
+            database=database_name,
+            sql=sql,
+            includeResultMetadata=True,   # ← without this there is no columnMetadata
+        )
+        if ":database" in sql:
+            kwargs["parameters"] = [
+                {"name": "database", "value": {"stringValue": database_name}}
+            ]
+        return _parse_rds_result(rds_data.execute_statement(**kwargs))
 
     try:
-        rds_data = boto3.client("rds-data", region_name=region)
+        tables = run(queries["tables"])
+        columns = run(queries["columns"])
+        indexes = run(queries["indexes"])
+        foreign_keys = run(queries["foreign_keys"])
+        primary_keys = [] if is_mysql else run(queries["primary_keys"])
+        enums = {} if is_mysql else _group_enums(run(queries["enums"]))
+        checks = [] if is_mysql else run(queries["checks"])
+    except ClientError as e:
+        return {"success": False, **_explain_rds_error(e, db_type, cluster_arn, region)}
+    except Exception as e:
+        return {"success": False, "error": f"Failed to introspect RDS database: {e}"}
 
-        # Query to get table information
-        if db_type == "rds_mysql":
-            tables_query = """
-                SELECT TABLE_NAME, TABLE_TYPE, TABLE_ROWS, DATA_LENGTH
-                FROM INFORMATION_SCHEMA.TABLES
-                WHERE TABLE_SCHEMA = :database
-            """
-            columns_query = """
-                SELECT
-                    TABLE_NAME,
-                    COLUMN_NAME,
-                    DATA_TYPE,
-                    IS_NULLABLE,
-                    COLUMN_KEY,
-                    COLUMN_DEFAULT,
-                    CHARACTER_MAXIMUM_LENGTH,
-                    NUMERIC_PRECISION,
-                    NUMERIC_SCALE,
-                    COLUMN_COMMENT
-                FROM INFORMATION_SCHEMA.COLUMNS
-                WHERE TABLE_SCHEMA = :database
-                ORDER BY TABLE_NAME, ORDINAL_POSITION
-            """
-            indexes_query = """
-                SELECT
-                    TABLE_NAME,
-                    INDEX_NAME,
-                    COLUMN_NAME,
-                    NON_UNIQUE,
-                    SEQ_IN_INDEX
-                FROM INFORMATION_SCHEMA.STATISTICS
-                WHERE TABLE_SCHEMA = :database
-                ORDER BY TABLE_NAME, INDEX_NAME, SEQ_IN_INDEX
-            """
-        else:  # PostgreSQL
-            tables_query = """
-                SELECT tablename as TABLE_NAME, 'BASE TABLE' as TABLE_TYPE
-                FROM pg_tables
-                WHERE schemaname = 'public'
-            """
-            columns_query = """
-                SELECT
-                    table_name as TABLE_NAME,
-                    column_name as COLUMN_NAME,
-                    data_type as DATA_TYPE,
-                    is_nullable as IS_NULLABLE,
-                    column_default as COLUMN_DEFAULT,
-                    character_maximum_length as CHARACTER_MAXIMUM_LENGTH,
-                    numeric_precision as NUMERIC_PRECISION,
-                    numeric_scale as NUMERIC_SCALE
-                FROM information_schema.columns
-                WHERE table_schema = 'public'
-                ORDER BY table_name, ordinal_position
-            """
-            indexes_query = """
-                SELECT
-                    t.relname as TABLE_NAME,
-                    i.relname as INDEX_NAME,
-                    a.attname as COLUMN_NAME,
-                    ix.indisunique as IS_UNIQUE
-                FROM pg_class t, pg_class i, pg_index ix, pg_attribute a
-                WHERE t.oid = ix.indrelid
-                    AND i.oid = ix.indexrelid
-                    AND a.attrelid = t.oid
-                    AND a.attnum = ANY(ix.indkey)
-                    AND t.relkind = 'r'
-                ORDER BY t.relname, i.relname
-            """
+    wanted = set(_split_names(table_name))
 
-        # Execute queries
-        params = [{"name": "database", "value": {"stringValue": database_name}}]
-
-        tables_result = rds_data.execute_statement(
-            resourceArn=cluster_arn,
-            secretArn=secret_arn,
-            database=database_name,
-            sql=tables_query,
-            parameters=params
-        )
-
-        columns_result = rds_data.execute_statement(
-            resourceArn=cluster_arn,
-            secretArn=secret_arn,
-            database=database_name,
-            sql=columns_query,
-            parameters=params
-        )
-
-        indexes_result = rds_data.execute_statement(
-            resourceArn=cluster_arn,
-            secretArn=secret_arn,
-            database=database_name,
-            sql=indexes_query,
-            parameters=params
-        )
-
-        # Parse results
-        tables = _parse_rds_result(tables_result)
-        columns = _parse_rds_result(columns_result)
-        indexes = _parse_rds_result(indexes_result)
-
-        # Organize by table
-        table_schemas = {}
-        for table in tables:
-            table_name_val = table.get("TABLE_NAME")
-            if table_name and table_name_val != table_name:
-                continue
-
-            table_schemas[table_name_val] = {
-                "table_name": table_name_val,
-                "table_type": table.get("TABLE_TYPE"),
-                "estimated_rows": table.get("TABLE_ROWS"),
-                "columns": [],
-                "indexes": [],
-                "primary_key": []
-            }
-
-        # Add columns to tables
-        for col in columns:
-            table_name_val = col.get("TABLE_NAME")
-            if table_name_val not in table_schemas:
-                continue
-
-            column_info = {
-                "name": col.get("COLUMN_NAME"),
-                "type": col.get("DATA_TYPE"),
-                "nullable": col.get("IS_NULLABLE") == "YES",
-                "default": col.get("COLUMN_DEFAULT"),
-                "max_length": col.get("CHARACTER_MAXIMUM_LENGTH"),
-                "precision": col.get("NUMERIC_PRECISION"),
-                "scale": col.get("NUMERIC_SCALE"),
-                "comment": col.get("COLUMN_COMMENT")
-            }
-
-            # Check if primary key
-            if col.get("COLUMN_KEY") == "PRI":
-                table_schemas[table_name_val]["primary_key"].append(col.get("COLUMN_NAME"))
-                column_info["is_primary_key"] = True
-
-            table_schemas[table_name_val]["columns"].append(column_info)
-
-        # Add indexes to tables
-        current_index = {}
-        for idx in indexes:
-            table_name_val = idx.get("TABLE_NAME")
-            if table_name_val not in table_schemas:
-                continue
-
-            index_name = idx.get("INDEX_NAME")
-            if index_name not in current_index:
-                current_index[index_name] = {
-                    "name": index_name,
-                    "table": table_name_val,
-                    "columns": [],
-                    "unique": not idx.get("NON_UNIQUE", True)
-                }
-            current_index[index_name]["columns"].append(idx.get("COLUMN_NAME"))
-
-        for idx in current_index.values():
-            if idx["table"] in table_schemas:
-                table_schemas[idx["table"]]["indexes"].append({
-                    "name": idx["name"],
-                    "columns": idx["columns"],
-                    "unique": idx["unique"]
-                })
-
-        return {
-            "success": True,
-            "db_type": db_type,
-            "database_name": database_name,
-            "table_count": len(table_schemas),
-            "tables": list(table_schemas.values()),
-            "suggestions": _generate_rds_suggestions(table_schemas)
+    table_schemas: dict[str, dict] = {}
+    for row in tables:
+        name = row.get("TABLE_NAME")
+        if not name or (wanted and name not in wanted):
+            continue
+        table_schemas[name] = {
+            "table_name": name,
+            "table_type": row.get("TABLE_TYPE"),
+            "table_comment": row.get("TABLE_COMMENT") or None,
+            "estimated_rows": row.get("TABLE_ROWS"),
+            "size_bytes": row.get("DATA_LENGTH"),
+            "columns": [],
+            "primary_key": [],
+            "indexes": [],
+            "foreign_keys": [],
+            "referenced_by": [],
+            "check_constraints": [],
         }
 
-    except Exception as e:
+    if not table_schemas:
         return {
             "success": False,
-            "error": f"Failed to introspect RDS database: {str(e)}"
+            "error": (
+                f"No tables found in database '{database_name}'"
+                + (f" matching {sorted(wanted)}" if wanted else "")
+                + f". Discovered {len(tables)} table(s) total"
+                + (f": {sorted({r.get('TABLE_NAME') for r in tables if r.get('TABLE_NAME')})}" if tables else "")
+                + ". Check the database name and the table spelling "
+                  "(PostgreSQL introspection reads the 'public' schema)."
+            ),
+            "error_code": "NO_TABLES_FOUND",
+            "db_type": db_type,
+            "database_name": database_name,
         }
+
+    # ---- columns
+    pk_from_mysql: dict[str, list[str]] = {}
+    for col in columns:
+        tname = col.get("TABLE_NAME")
+        if tname not in table_schemas:
+            continue
+        raw_type = col.get("COLUMN_TYPE") or col.get("DATA_TYPE")
+        info = {
+            "name": col.get("COLUMN_NAME"),
+            "type": col.get("DATA_TYPE"),
+            "full_type": raw_type,
+            "nullable": str(col.get("IS_NULLABLE", "")).upper() in ("YES", "TRUE", "1"),
+            "default": col.get("COLUMN_DEFAULT"),
+            "max_length": col.get("CHARACTER_MAXIMUM_LENGTH"),
+            "precision": col.get("NUMERIC_PRECISION"),
+            "scale": col.get("NUMERIC_SCALE"),
+            "comment": col.get("COLUMN_COMMENT") or None,
+            "ordinal_position": col.get("ORDINAL_POSITION"),
+        }
+
+        allowed = _extract_allowed_values(raw_type, col.get("UDT_NAME"), enums)
+        if allowed:
+            info["allowed_values"] = allowed
+
+        extra = str(col.get("EXTRA") or "")
+        generated = str(col.get("IS_GENERATED") or "")
+        if "auto_increment" in extra.lower():
+            info["auto_increment"] = True
+        # MySQL EXTRA is 'STORED GENERATED'/'VIRTUAL GENERATED' for real generated
+        # columns; 'DEFAULT_GENERATED' merely means the column has a default
+        # expression (e.g. CURRENT_TIMESTAMP) and must not be treated as generated.
+        is_generated = (
+            generated.upper().startswith("ALWAYS")
+            or bool(re.search(r"\b(STORED|VIRTUAL)\s+GENERATED\b", extra, re.IGNORECASE))
+        )
+        if is_generated:
+            info["generated"] = True
+            expression = col.get("GENERATION_EXPRESSION") or extra
+            if expression:
+                info["generation_expression"] = expression
+
+        if is_mysql and col.get("COLUMN_KEY") == "PRI":
+            pk_from_mysql.setdefault(tname, []).append(col.get("COLUMN_NAME"))
+            info["is_primary_key"] = True
+
+        table_schemas[tname]["columns"].append(info)
+
+    # ---- primary keys
+    if is_mysql:
+        for tname, cols in pk_from_mysql.items():
+            table_schemas[tname]["primary_key"] = cols
+    else:
+        for row in primary_keys:
+            tname = row.get("TABLE_NAME")
+            if tname in table_schemas:
+                table_schemas[tname]["primary_key"].append(row.get("COLUMN_NAME"))
+        for tname, schema in table_schemas.items():
+            pk = set(schema["primary_key"])
+            for col in schema["columns"]:
+                if col["name"] in pk:
+                    col["is_primary_key"] = True
+
+    # ---- indexes (keyed by table AND index name — names repeat across tables)
+    grouped_indexes: dict[tuple, dict] = {}
+    for idx in indexes:
+        tname = idx.get("TABLE_NAME")
+        iname = idx.get("INDEX_NAME")
+        if tname not in table_schemas or not iname:
+            continue
+        key = (tname, iname)
+        if key not in grouped_indexes:
+            grouped_indexes[key] = {
+                "name": iname,
+                "table": tname,
+                "columns": [],
+                "unique": str(idx.get("NON_UNIQUE", 1)) in ("0", "False", "false"),
+                "index_type": idx.get("INDEX_TYPE"),
+                "is_primary": iname == "PRIMARY" or str(idx.get("IS_PRIMARY", "")).lower() == "true",
+            }
+        col_name = idx.get("COLUMN_NAME")
+        if col_name and col_name not in grouped_indexes[key]["columns"]:
+            grouped_indexes[key]["columns"].append(col_name)
+
+    for (tname, _), idx in grouped_indexes.items():
+        table_schemas[tname]["indexes"].append({
+            "name": idx["name"],
+            "columns": idx["columns"],
+            "unique": idx["unique"],
+            "index_type": idx["index_type"],
+            "is_primary": idx["is_primary"],
+        })
+
+    # ---- foreign keys (+ reverse relationships)
+    grouped_fks: dict[tuple, dict] = {}
+    for fk in foreign_keys:
+        tname = fk.get("TABLE_NAME")
+        cname = fk.get("CONSTRAINT_NAME") or f"fk_{tname}"
+        if tname not in table_schemas:
+            continue
+        key = (tname, cname)
+        if key not in grouped_fks:
+            grouped_fks[key] = {
+                "constraint_name": cname,
+                "table": tname,
+                "columns": [],
+                "referenced_table": fk.get("REFERENCED_TABLE_NAME"),
+                "referenced_columns": [],
+            }
+        grouped_fks[key]["columns"].append(fk.get("COLUMN_NAME"))
+        grouped_fks[key]["referenced_columns"].append(fk.get("REFERENCED_COLUMN_NAME"))
+
+    for (tname, _), fk in grouped_fks.items():
+        entry = {
+            "constraint_name": fk["constraint_name"],
+            "columns": fk["columns"],
+            "referenced_table": fk["referenced_table"],
+            "referenced_columns": fk["referenced_columns"],
+        }
+        table_schemas[tname]["foreign_keys"].append(entry)
+        parent = fk["referenced_table"]
+        if parent in table_schemas:
+            table_schemas[parent]["referenced_by"].append({
+                "table": tname,
+                "columns": fk["columns"],
+                "referenced_columns": fk["referenced_columns"],
+            })
+
+    # ---- check constraints (PostgreSQL)
+    for row in checks:
+        tname = row.get("TABLE_NAME")
+        if tname in table_schemas:
+            table_schemas[tname]["check_constraints"].append({
+                "name": row.get("CONSTRAINT_NAME"),
+                "definition": row.get("DEFINITION"),
+            })
+
+    # ---- sample rows
+    warnings = []
+    if include_sample_rows:
+        quote = "`" if is_mysql else '"'
+        for tname, schema in table_schemas.items():
+            if schema["table_type"] not in ("BASE TABLE", "PARTITIONED TABLE", None):
+                continue
+            try:
+                rows = run(f"SELECT * FROM {quote}{tname}{quote} LIMIT {SAMPLE_LIMIT}")
+                schema["sample_rows"] = [_stringify_row(r) for r in rows]
+                schema["actual_row_count"] = _count_rows(run, quote, tname)
+            except Exception as e:
+                warnings.append(f"Could not sample rows from '{tname}': {e}")
+
+    relationships = [
+        f"{fk['table']}.{','.join(fk['columns'])} → "
+        f"{fk['referenced_table']}.{','.join(fk['referenced_columns'])}"
+        for fk in grouped_fks.values()
+    ]
+
+    result = {
+        "success": True,
+        "db_type": db_type,
+        "engine": "mysql" if is_mysql else "postgresql",
+        "database_name": database_name,
+        "cluster_arn": cluster_arn,
+        "secret_arn": secret_arn,
+        "region": region,
+        "access_method": "rds-data-api",
+        "table_count": len(table_schemas),
+        "tables": list(table_schemas.values()),
+        "relationships": sorted(relationships),
+        "enum_types": enums or None,
+        "suggestions": _generate_rds_suggestions(table_schemas, grouped_fks),
+    }
+    if warnings:
+        result["warnings"] = warnings
+    return result
+
+
+def _count_rows(run, quote: str, tname: str):
+    try:
+        rows = run(f"SELECT COUNT(*) AS row_count FROM {quote}{tname}{quote}")
+        if rows:
+            return list(rows[0].values())[0]
+    except Exception:
+        return None
+    return None
+
+
+def _stringify_row(row: dict) -> dict:
+    """Keep sample rows JSON-safe and compact."""
+    out = {}
+    for k, v in row.items():
+        if isinstance(v, str) and len(v) > 200:
+            v = v[:200] + "…"
+        out[k.lower()] = v
+    return out
+
+
+def _group_enums(rows: list[dict]) -> dict:
+    enums: dict[str, list[str]] = {}
+    for row in rows:
+        name = row.get("ENUM_NAME")
+        value = row.get("ENUM_VALUE")
+        if name:
+            enums.setdefault(name, []).append(value)
+    return enums
+
+
+def _extract_allowed_values(raw_type, udt_name, enums: dict) -> Optional[list[str]]:
+    """Pull allowed values out of MySQL enum()/set() types or PG enum types."""
+    if udt_name and udt_name in enums:
+        return enums[udt_name]
+    if raw_type and raw_type in enums:
+        return enums[raw_type]
+    if raw_type:
+        m = re.match(r"^\s*(enum|set)\((.*)\)\s*$", str(raw_type), re.IGNORECASE | re.DOTALL)
+        if m:
+            return [v.strip().strip("'\"") for v in m.group(2).split("','")] if "','" in m.group(2) \
+                else [v.strip().strip("'\"") for v in m.group(2).split(",")]
+    return None
+
+
+def _explain_rds_error(e: ClientError, db_type: str, cluster_arn: str, region: str) -> dict:
+    code = e.response.get("Error", {}).get("Code", "")
+    message = e.response.get("Error", {}).get("Message", str(e))
+
+    if code in ("BadRequestException",) and "HttpEndpoint" in message or "not enabled" in message.lower():
+        return {
+            "error": f"The RDS Data API (HTTP endpoint) is not enabled on {cluster_arn}. "
+                     f"Enable it with: aws rds modify-db-cluster --db-cluster-identifier "
+                     f"<id> --enable-http-endpoint --region {region}. "
+                     f"Note the Data API is only available on Aurora clusters "
+                     f"(Serverless v2 or provisioned), not on plain RDS instances. "
+                     f"Original error: {message}",
+            "error_code": "DATA_API_NOT_ENABLED",
+        }
+    if code in ("AccessDeniedException", "AccessDenied"):
+        return {
+            "error": f"Access denied calling the RDS Data API. The runtime role needs "
+                     f"rds-data:ExecuteStatement on the cluster and "
+                     f"secretsmanager:GetSecretValue on the credentials secret. "
+                     f"Original error: {message}",
+            "error_code": "ACCESS_DENIED",
+        }
+    if code in ("DatabaseNotFoundException", "ResourceNotFoundException", "DatabaseErrorException"):
+        return {
+            "error": f"Database or cluster not reachable ({code}): {message}. "
+                     f"Verify the cluster ARN region ({region}), the database name, "
+                     f"and that the secret matches this cluster.",
+            "error_code": code,
+        }
+    if code == "StatementTimeoutException":
+        return {"error": f"Data API statement timed out: {message}", "error_code": code}
+    return {"error": f"Failed to introspect RDS database ({code}): {message}", "error_code": code}
 
 
 def _parse_rds_result(result: dict) -> list[dict]:
-    """Parse RDS Data API result into list of dicts."""
+    """
+    Parse an RDS Data API result into a list of dicts.
+
+    Column names are normalized to UPPER CASE because PostgreSQL folds
+    unquoted identifiers to lower case while MySQL's information_schema
+    returns them upper case.
+    """
     records = result.get("records", [])
     column_metadata = result.get("columnMetadata", [])
+    names = [
+        (c.get("label") or c.get("name") or f"col_{i}").upper()
+        for i, c in enumerate(column_metadata)
+    ]
 
     parsed = []
     for record in records:
         row = {}
         for i, field in enumerate(record):
-            col_name = column_metadata[i]["name"] if i < len(column_metadata) else f"col_{i}"
-            # Extract value from the typed field
-            if "stringValue" in field:
+            col_name = names[i] if i < len(names) else f"COL_{i}"
+            if field.get("isNull"):
+                row[col_name] = None
+            elif "stringValue" in field:
                 row[col_name] = field["stringValue"]
             elif "longValue" in field:
                 row[col_name] = field["longValue"]
@@ -401,40 +810,113 @@ def _parse_rds_result(result: dict) -> list[dict]:
                 row[col_name] = field["doubleValue"]
             elif "booleanValue" in field:
                 row[col_name] = field["booleanValue"]
-            elif "isNull" in field and field["isNull"]:
-                row[col_name] = None
+            elif "blobValue" in field:
+                row[col_name] = "<blob>"
+            elif "arrayValue" in field:
+                row[col_name] = _parse_array_value(field["arrayValue"])
             else:
-                row[col_name] = str(field)
+                row[col_name] = None
         parsed.append(row)
 
     return parsed
 
 
-def _generate_dynamodb_suggestions(key_schema: list, gsis: list, attributes: dict) -> list[str]:
-    """Generate helpful suggestions based on DynamoDB schema."""
-    suggestions = []
+def _parse_array_value(array_value: dict):
+    for key in ("stringValues", "longValues", "doubleValues", "booleanValues"):
+        if key in array_value:
+            return array_value[key]
+    if "arrayValues" in array_value:
+        return [_parse_array_value(v) for v in array_value["arrayValues"]]
+    return []
 
-    # Find partition key
+
+# ======================================================================
+# Suggestions
+# ======================================================================
+
+def _generate_dynamodb_suggestions(key_schema: list, gsis: list, lsis: list, attributes: dict) -> list[str]:
+    suggestions = []
     pk = next((k["attribute_name"] for k in key_schema if k["key_type"] == "partition_key"), None)
     sk = next((k["attribute_name"] for k in key_schema if k["key_type"] == "sort_key"), None)
 
     if pk:
         suggestions.append(f"Primary lookup should use '{pk}' as the main query parameter")
-
     if sk:
-        suggestions.append(f"Range queries are possible on '{sk}' within a partition")
+        suggestions.append(f"Range queries are possible on '{sk}' within a partition "
+                           f"(use Query with KeyConditionExpression, never Scan)")
     else:
         suggestions.append("No sort key defined - each partition key maps to exactly one item")
 
-    if gsis:
-        for gsi in gsis:
-            gsi_pk = next((k["attribute_name"] for k in gsi["key_schema"] if k["key_type"] == "partition_key"), None)
-            suggestions.append(f"GSI '{gsi['index_name']}' enables querying by '{gsi_pk}'")
-    else:
+    for gsi in gsis:
+        gsi_pk = next((k["attribute_name"] for k in gsi["key_schema"] if k["key_type"] == "partition_key"), None)
+        gsi_sk = next((k["attribute_name"] for k in gsi["key_schema"] if k["key_type"] == "sort_key"), None)
+        text = f"GSI '{gsi['index_name']}' enables querying by '{gsi_pk}'"
+        if gsi_sk:
+            text += f" with range on '{gsi_sk}'"
+        if gsi["projection_type"] != "ALL":
+            text += (f" (projection {gsi['projection_type']}"
+                     + (f": {gsi['projected_attributes']}" if gsi.get("projected_attributes") else "")
+                     + " — a follow-up GetItem is needed for other attributes)")
+        suggestions.append(text)
+    if not gsis:
         suggestions.append("No GSIs defined - consider adding indexes for common query patterns")
 
+    for lsi in lsis:
+        lsi_sk = next((k["attribute_name"] for k in lsi["key_schema"] if k["key_type"] == "sort_key"), None)
+        suggestions.append(f"LSI '{lsi['index_name']}' allows sorting/filtering by '{lsi_sk}' "
+                           f"within the same partition key")
+
+    phone_attrs = [a for a in attributes if "phone" in a.lower()]
+    if phone_attrs:
+        gsi_backed = [
+            a for a in phone_attrs
+            if any(k["attribute_name"] == a for g in gsis for k in g["key_schema"])
+        ]
+        if gsi_backed:
+            suggestions.append(f"Contact-center lookup by caller ID should Query the GSI on "
+                               f"{gsi_backed} instead of scanning")
+        else:
+            suggestions.append(f"Attribute(s) {phone_attrs} look like a caller-ID lookup key but "
+                               f"have no GSI — a Scan would be required")
     return suggestions
 
+
+def _generate_rds_suggestions(tables: dict, grouped_fks: dict) -> list[str]:
+    suggestions = []
+    for table_name, table_info in tables.items():
+        pk = table_info.get("primary_key", [])
+        if pk:
+            suggestions.append(f"Table '{table_name}': use {pk} for direct lookups")
+        else:
+            suggestions.append(f"Table '{table_name}': no primary key detected "
+                               f"(view or key-less table) — verify before writing UPDATE/DELETE")
+        for idx in table_info.get("indexes", []):
+            if idx.get("is_primary"):
+                continue
+            suggestions.append(
+                f"Table '{table_name}': index '{idx['name']}' on {idx['columns']}"
+                + (" (unique)" if idx["unique"] else "")
+                + " for efficient queries"
+            )
+        for col in table_info.get("columns", []):
+            if "phone" in (col["name"] or "").lower():
+                indexed = any(col["name"] in i["columns"] for i in table_info.get("indexes", []))
+                suggestions.append(
+                    f"Table '{table_name}.{col['name']}' looks like a caller-ID lookup key"
+                    + (" and is indexed" if indexed else " but is NOT indexed — add an index"
+                                                          " or expect a full table scan")
+                )
+    for fk in grouped_fks.values():
+        suggestions.append(
+            f"Join '{fk['table']}' to '{fk['referenced_table']}' on "
+            f"{fk['columns']} = {fk['referenced_columns']}"
+        )
+    return suggestions
+
+
+# ======================================================================
+# Conversion to infrastructure_schema
+# ======================================================================
 
 def convert_to_infrastructure_schema(introspection_result: dict) -> dict:
     """
@@ -443,90 +925,256 @@ def convert_to_infrastructure_schema(introspection_result: dict) -> dict:
     This allows generators (Lambda, OpenAPI, Prompt) to use existing DB schema
     in the same format as if Infrastructure Generator had produced it.
 
+    Handles DynamoDB (single or multiple tables) and RDS/Aurora results.
+
     Args:
         introspection_result: Output from introspect_database()
 
     Returns:
         infrastructure_schema compatible dict
     """
+    if not isinstance(introspection_result, dict):
+        return {"error": "introspection_result must be a dict", "tables": []}
+
     if not introspection_result.get("success"):
-        return {"error": "Introspection failed", "tables": []}
+        return {
+            "error": introspection_result.get("error", "Introspection failed"),
+            "error_code": introspection_result.get("error_code"),
+            "tables": [],
+        }
 
-    table_name = introspection_result["table_name"]
+    db_type = introspection_result.get("db_type")
 
-    # Convert to entity name for env var (e.g., "hotel-reservations" → "RESERVATIONS")
-    entity = table_name.split("-")[-1].upper() if "-" in table_name else table_name.upper()
+    if db_type == "dynamodb":
+        # multi-table result from a comma-separated request
+        if "tables" in introspection_result and "table_name" not in introspection_result:
+            merged = {"tables": [], "environment_variables": {}, "data_conventions": {},
+                      "db_type": "dynamodb"}
+            for sub in introspection_result.get("tables", []):
+                if not sub.get("success"):
+                    continue
+                part = convert_to_infrastructure_schema(sub)
+                merged["tables"].extend(part.get("tables", []))
+                merged["environment_variables"].update(part.get("environment_variables", {}))
+                merged["data_conventions"].update(part.get("data_conventions", {}))
+            _dedupe_env_vars(merged["tables"], merged["environment_variables"])
+            return merged
+        return _convert_dynamodb(introspection_result)
+
+    if db_type in ("rds_mysql", "rds_postgresql"):
+        return _convert_rds(introspection_result)
+
+    return {"error": f"Cannot convert db_type '{db_type}'", "tables": []}
+
+
+_GENERIC_NAME_TAILS = {
+    "history", "data", "info", "table", "log", "logs", "record", "records",
+    "detail", "details", "list", "item", "items", "entry", "entries", "master",
+    "summary", "audit", "archive", "tmp", "temp", "v1", "v2", "prod", "dev",
+}
+
+
+def _entity_from_name(name: str) -> str:
+    """
+    Derive a stable entity token from a table name.
+
+    'hotel-reservations'    -> RESERVATIONS
+    'telco-billing-history' -> BILLING_HISTORY   (last token is too generic alone)
+    'orders'                -> ORDERS
+    """
+    tokens = [t for t in re.split(r"[-_.\s]+", str(name)) if t]
+    if not tokens:
+        return "TABLE"
+    tail = tokens[-1]
+    if len(tokens) > 1 and (tail.lower() in _GENERIC_NAME_TAILS or len(tail) < 4):
+        tokens = tokens[-2:]
+    else:
+        tokens = tokens[-1:]
+    entity = "_".join(re.sub(r"[^A-Za-z0-9]", "", t) for t in tokens).upper()
+    return entity.strip("_") or "TABLE"
+
+
+def _logical_id(entity: str) -> str:
+    return "".join(part.capitalize() for part in entity.split("_") if part) + "Table"
+
+
+def _dedupe_env_vars(tables: list[dict], env_vars: dict) -> None:
+    """
+    Ensure env var names / logical ids are unique across tables.
+
+    Two tables like 'a-orders' and 'b-orders' both reduce to ORDERS; when that
+    happens fall back to the full table name so nothing silently overwrites.
+    """
+    seen: dict[str, dict] = {}
+    for entry in tables:
+        name = entry.get("env_var_name")
+        if not name:
+            continue
+        if name in seen:
+            for conflicting in (seen[name], entry):
+                full = re.sub(r"[^A-Za-z0-9]+", "_", str(conflicting["table_name"])).upper().strip("_")
+                old = conflicting["env_var_name"]
+                conflicting["env_var_name"] = f"{full}_TABLE_NAME"
+                conflicting["logical_id"] = _logical_id(full)
+                if old in env_vars:
+                    env_vars[conflicting["env_var_name"]] = env_vars.pop(old)
+                else:
+                    env_vars[conflicting["env_var_name"]] = conflicting["table_name"]
+        else:
+            seen[name] = entry
+
+
+def _convert_dynamodb(r: dict) -> dict:
+    table_name = r["table_name"]
+    entity = _entity_from_name(table_name)
     env_var_name = f"{entity}_TABLE_NAME"
 
-    # Convert key_schema
+    type_map = {"string": "S", "number": "N", "binary": "B"}
+    attr_types = {a["name"]: type_map.get(a["type"], "S") for a in r.get("attributes", [])}
+
     primary_key = None
     sort_key = None
-    for key in introspection_result.get("key_schema", []):
+    for key in r.get("key_schema", []):
+        entry = {"name": key["attribute_name"],
+                 "type": attr_types.get(key["attribute_name"], "S")}
         if key["key_type"] == "partition_key":
-            primary_key = {"name": key["attribute_name"], "type": "S"}
-        elif key["key_type"] == "sort_key":
-            sort_key = {"name": key["attribute_name"], "type": "S"}
+            primary_key = entry
+        else:
+            sort_key = entry
 
-    # Convert GSIs
-    gsi_indexes = []
-    for gsi in introspection_result.get("global_secondary_indexes", []):
-        gsi_entry = {
-            "name": gsi["index_name"],
-            "projection": gsi.get("projection_type", "ALL"),
-        }
-        for key in gsi.get("key_schema", []):
-            if key["key_type"] == "partition_key":
-                gsi_entry["partition_key"] = {"name": key["attribute_name"], "type": "S"}
-            elif key["key_type"] == "sort_key":
-                gsi_entry["sort_key"] = {"name": key["attribute_name"], "type": "S"}
-        gsi_indexes.append(gsi_entry)
+    def convert_index(idx):
+        entry = {"name": idx["index_name"], "projection": idx.get("projection_type", "ALL")}
+        if idx.get("projected_attributes"):
+            entry["projected_attributes"] = idx["projected_attributes"]
+        for key in idx.get("key_schema", []):
+            slot = "partition_key" if key["key_type"] == "partition_key" else "sort_key"
+            entry[slot] = {"name": key["attribute_name"],
+                           "type": attr_types.get(key["attribute_name"], "S")}
+        return entry
 
-    # Build data_conventions from attributes
+    gsi_indexes = [convert_index(g) for g in r.get("global_secondary_indexes", [])]
+    lsi_indexes = [convert_index(l) for l in r.get("local_secondary_indexes", [])]
+
+    # data conventions: derive real formats from sampled values
     data_conventions = {}
-    for attr in introspection_result.get("attributes", []):
+    samples = r.get("sample_items", [])
+    for attr in r.get("attributes", []):
         name = attr["name"]
+        example = next((s[name] for s in samples if isinstance(s.get(name), (str, int, float))), None)
         if "phone" in name.lower():
             data_conventions[name] = {
-                "format": "E.164 without +",
-                "example": "821012345678",
+                "format": "E.164 without +" if isinstance(example, str) and example.isdigit()
+                          else "as stored in the existing table",
+                "example": example,
                 "gsi": next((g["name"] for g in gsi_indexes
-                           if g.get("partition_key", {}).get("name") == name), None)
+                             if g.get("partition_key", {}).get("name") == name), None),
             }
+        elif example is not None and any(
+            token in name.lower() for token in ("date", "_at", "time", "month", "status", "id", "code")
+        ):
+            data_conventions[name] = {"example": example}
 
     table_entry = {
-        "logical_id": f"{entity.title()}Table",
+        "logical_id": _logical_id(entity),
         "table_name": table_name,
+        "table_arn": r.get("table_arn"),
         "env_var_name": env_var_name,
         "primary_key": primary_key,
         "gsi_indexes": gsi_indexes,
         "existing": True,
+        "attributes": r.get("attributes", []),
     }
     if sort_key:
         table_entry["sort_key"] = sort_key
+    if lsi_indexes:
+        table_entry["lsi_indexes"] = lsi_indexes
 
     return {
+        "db_type": "dynamodb",
+        "region": r.get("region"),
         "tables": [table_entry],
-        "environment_variables": {
-            env_var_name: table_name,  # Direct value, not !Ref
-        },
+        "environment_variables": {env_var_name: table_name},
         "data_conventions": data_conventions,
+        "access_notes": r.get("suggestions", []),
     }
 
 
-def _generate_rds_suggestions(tables: dict) -> list[str]:
-    """Generate helpful suggestions based on RDS schema."""
-    suggestions = []
+def _convert_rds(r: dict) -> dict:
+    engine = r.get("engine") or ("mysql" if r["db_type"] == "rds_mysql" else "postgresql")
+    database_name = r.get("database_name")
 
-    for table_name, table_info in tables.items():
-        pk = table_info.get("primary_key", [])
-        if pk:
-            suggestions.append(f"Table '{table_name}': Use {pk} for direct lookups")
+    tables = []
+    conventions = {}
+    for t in r.get("tables", []):
+        entity = _entity_from_name(t["table_name"])
+        entry = {
+            "logical_id": _logical_id(entity),
+            "table_name": t["table_name"],
+            "table_type": t.get("table_type"),
+            "description": t.get("table_comment"),
+            "primary_key": t.get("primary_key", []),
+            "columns": [
+                {
+                    "name": c["name"],
+                    "sql_type": c.get("full_type") or c.get("type"),
+                    "nullable": c.get("nullable"),
+                    "default": c.get("default"),
+                    "allowed_values": c.get("allowed_values"),
+                    "generated": c.get("generated", False),
+                    "description": c.get("comment"),
+                }
+                for c in t.get("columns", [])
+            ],
+            "indexes": t.get("indexes", []),
+            "foreign_keys": t.get("foreign_keys", []),
+            "referenced_by": t.get("referenced_by", []),
+            "check_constraints": t.get("check_constraints", []),
+            "row_count": t.get("actual_row_count", t.get("estimated_rows")),
+            "existing": True,
+        }
+        tables.append(entry)
 
-        indexes = table_info.get("indexes", [])
-        for idx in indexes:
-            if idx["name"] != "PRIMARY":
-                suggestions.append(
-                    f"Table '{table_name}': Index '{idx['name']}' on {idx['columns']} for efficient queries"
-                )
+        sample = (t.get("sample_rows") or [{}])[0]
+        for c in t.get("columns", []):
+            lname = (c["name"] or "").lower()
+            example = sample.get(lname)
+            if "phone" in lname and example is not None:
+                conventions[f"{t['table_name']}.{c['name']}"] = {
+                    "format": "E.164 without +" if isinstance(example, str) and example.isdigit()
+                              else "as stored in the existing column",
+                    "example": example,
+                    "indexed": any(c["name"] in i.get("columns", []) for i in t.get("indexes", [])),
+                }
+            elif c.get("allowed_values"):
+                conventions[f"{t['table_name']}.{c['name']}"] = {
+                    "allowed_values": c["allowed_values"],
+                    "example": example,
+                }
 
-    return suggestions
+    return {
+        "db_type": r["db_type"],
+        "engine": engine,
+        "region": r.get("region"),
+        "database_name": database_name,
+        "access_method": "rds-data-api",
+        "connection": {
+            "cluster_arn": r.get("cluster_arn"),
+            "secret_arn": r.get("secret_arn"),
+            "database_name": database_name,
+        },
+        "environment_variables": {
+            "DB_CLUSTER_ARN": r.get("cluster_arn"),
+            "DB_SECRET_ARN": r.get("secret_arn"),
+            "DB_NAME": database_name,
+        },
+        "iam_requirements": [
+            "rds-data:ExecuteStatement",
+            "rds-data:BatchExecuteStatement",
+            "secretsmanager:GetSecretValue",
+        ],
+        "tables": tables,
+        "relationships": r.get("relationships", []),
+        "enum_types": r.get("enum_types"),
+        "data_conventions": conventions,
+        "access_notes": r.get("suggestions", []),
+    }

--- a/backend/ecs/src/tools/merge_infrastructure.py
+++ b/backend/ecs/src/tools/merge_infrastructure.py
@@ -149,6 +149,133 @@ def _fix_qconnect_namespace(yaml_str: str) -> str:
     return new_yaml
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# RDS Data API environment-variable contract
+#
+# Generated Lambda handlers read os.environ["DB_CLUSTER_ARN"] /
+# ["DB_SECRET_ARN"] / ["DB_NAME"]. When the infrastructure generator emits a
+# different name for even one function (observed live: CreateWarrantyClaim got
+# RDS_CLUSTER_ARN, TrackShipment got CLUSTER_ARN) that function dies with
+# KeyError on cold start. Fragments are generated independently, so the naming
+# drifts per-fragment no matter what the prompt says — normalize it here.
+# ─────────────────────────────────────────────────────────────────────────────
+_RDS_ENV_ALIASES = {
+    "RDS_CLUSTER_ARN": "DB_CLUSTER_ARN",
+    "RDS_SECRET_ARN": "DB_SECRET_ARN",
+    "RDS_DATABASE_NAME": "DB_NAME",
+    "RDS_DB_NAME": "DB_NAME",
+    "RDS_DATABASE": "DB_NAME",
+    "CLUSTER_ARN": "DB_CLUSTER_ARN",
+    "SECRET_ARN": "DB_SECRET_ARN",
+    "DATABASE_NAME": "DB_NAME",
+    "DB_DATABASE_NAME": "DB_NAME",
+}
+
+
+def _fix_rds_env_var_names(yaml_str: str) -> str:
+    """Normalize RDS Data API env var keys to the DB_* contract.
+
+    Only rewrites YAML mapping KEYS (``  RDS_CLUSTER_ARN: ...``) — never values,
+    inline Python, or IAM actions — so a handler that legitimately mentions the
+    old name in a comment is left alone. Skips templates that have no RDS usage.
+    """
+    if "rds-data" not in yaml_str and "DBClusterArn" not in yaml_str:
+        return yaml_str
+
+    total = 0
+    for old, new in _RDS_ENV_ALIASES.items():
+        if old == new:
+            continue
+        pattern = re.compile(rf'^(\s+){old}(\s*:\s*)', re.MULTILINE)
+        yaml_str, n = pattern.subn(rf'\g<1>{new}\g<2>', yaml_str)
+        total += n
+        if n:
+            logger.info(f"[MERGE] Renamed {n}x env var {old} → {new} (RDS Data API contract)")
+    if total:
+        logger.info(f"[MERGE] Normalized {total} RDS env var name(s) to the DB_* contract")
+    return yaml_str
+
+
+_INLINE_FN_RE = re.compile(
+    r'^(?P<indent>\s+)(?P<logical>[A-Za-z0-9]+):\s*\n'
+    r'(?P<body>(?:.*\n)*?)'
+    r'(?=^\s{2}[A-Za-z0-9]+:\s*$|\Z)',
+    re.MULTILINE,
+)
+
+
+def _fix_inline_handler_name(yaml_str: str) -> str:
+    """Make inline ZipFile Python define the function the Handler declares.
+
+    Observed live: a placeholder Lambda declared ``Handler: index.handler`` but
+    its inline code only defined ``lambda_handler``, so the very first invoke
+    returned ``Runtime.HandlerNotFound: Handler 'handler' missing on module
+    'index'``. Rather than rewrite the code, append an alias line at the same
+    indentation, which is valid for either naming convention.
+    """
+    if "ZipFile" not in yaml_str:
+        return yaml_str
+
+    fixed = 0
+    out_lines = yaml_str.split("\n")
+    i = 0
+    while i < len(out_lines):
+        line = out_lines[i]
+        m = re.match(r'^(\s*)Handler:\s*index\.(\w+)\s*$', line)
+        if not m:
+            i += 1
+            continue
+        wanted = m.group(2)
+        # find the ZipFile block that belongs to the same resource
+        j = i
+        zip_start = None
+        while j < min(i + 60, len(out_lines)):
+            if re.match(r'^\s*ZipFile:\s*\|', out_lines[j]):
+                zip_start = j
+                break
+            if re.match(r'^\s{2}[A-Za-z0-9]+:\s*$', out_lines[j]) and j > i:
+                break
+            j += 1
+        if zip_start is None:
+            i += 1
+            continue
+        code_indent = None
+        k = zip_start + 1
+        end = k
+        while k < len(out_lines):
+            ln = out_lines[k]
+            if ln.strip() == "":
+                k += 1
+                continue
+            indent = len(ln) - len(ln.lstrip())
+            if code_indent is None:
+                code_indent = indent
+            if indent < code_indent:
+                break
+            end = k
+            k += 1
+        if code_indent is None:
+            i += 1
+            continue
+        body = "\n".join(out_lines[zip_start + 1:end + 1])
+        if re.search(rf'^\s*def\s+{re.escape(wanted)}\s*\(', body, re.MULTILINE):
+            i += 1
+            continue
+        defined = re.findall(r'^\s*def\s+(\w*handler\w*)\s*\(', body, re.MULTILINE)
+        if not defined:
+            i += 1
+            continue
+        alias = f"{' ' * code_indent}{wanted} = {defined[0]}"
+        out_lines.insert(end + 1, alias)
+        fixed += 1
+        i = end + 2
+
+    if fixed:
+        logger.info(f"[MERGE] Added {fixed}x inline Lambda handler alias "
+                    f"(Handler declared a function the inline code did not define)")
+    return "\n".join(out_lines)
+
+
 def _fix_cfnresponse_import(yaml_str: str) -> str:
     """Split comma-form imports that include cfnresponse onto their own lines.
 
@@ -489,6 +616,8 @@ def merge_infrastructure_fragments(project_name: str) -> dict:
     final_yaml = _remove_anchor_comment(merged)
     final_yaml = _fix_common_property_hallucinations(final_yaml)
     final_yaml = _fix_qconnect_namespace(final_yaml)
+    final_yaml = _fix_rds_env_var_names(final_yaml)
+    final_yaml = _fix_inline_handler_name(final_yaml)
     final_yaml = _ensure_qsession_role_permissions(final_yaml)
     final_yaml = _fix_customer_lookup_handler(final_yaml)
     final_yaml = _fix_cfnresponse_import(final_yaml)

--- a/backend/ecs/src/tools/spec_manager.py
+++ b/backend/ecs/src/tools/spec_manager.py
@@ -329,6 +329,45 @@ class DataSourceSpec(FlexibleBaseModel):
     connection_secret_arn: Optional[str] = Field(default=None)
     region: Optional[str] = Field(default=None)
 
+    # --- RDS / Aurora specific (ignored for DynamoDB) ---------------------
+    database_name: Optional[str] = Field(
+        default=None,
+        description="RDS/Aurora database (schema) name the operation queries",
+        validation_alias=AliasChoices("database_name", "databaseName", "db_name"),
+    )
+    cluster_arn: Optional[str] = Field(
+        default=None,
+        description="Aurora cluster ARN used via the RDS Data API",
+        validation_alias=AliasChoices("cluster_arn", "clusterArn"),
+    )
+    lookup_column: Optional[str] = Field(
+        default=None,
+        description="SQL column used to identify the caller/record "
+                    "(e.g. customers.phone_number)",
+        validation_alias=AliasChoices("lookup_column", "lookupColumn", "lookup_key"),
+    )
+    related_tables: Optional[list] = Field(
+        default=None,
+        description="Other tables this operation joins/reads, in query order "
+                    "(e.g. ['customers', 'orders', 'order_items'])",
+        validation_alias=AliasChoices("related_tables", "relatedTables", "join_tables", "tables"),
+    )
+
+    @field_validator("related_tables", mode="before")
+    @classmethod
+    def _coerce_related_tables(cls, v):
+        """Accept a comma-separated string or a single dict/table name."""
+        if v is None or isinstance(v, list):
+            return v
+        if isinstance(v, str):
+            s = v.strip()
+            return [p.strip() for p in s.split(",") if p.strip()] or None
+        if isinstance(v, dict):
+            return [v.get("name") or v.get("table_name") or str(v)]
+        if isinstance(v, tuple):
+            return list(v)
+        return v
+
     @field_validator("gsi_indexes", mode="before")
     @classmethod
     def _coerce_gsi_indexes(cls, v):
@@ -968,12 +1007,34 @@ def _format_spec_as_markdown(op_id: str, spec: OperationSpec) -> str:
     # Data source
     ds = spec.data_source
     if ds:
-        table = getattr(ds, 'table_name', None) or '?'
-        pk = getattr(ds, 'partition_key', None) or '?'
-        lines += ["", "### Data Source", f"- Table: `{table}` (PK: `{pk}`)"]
-        gsi = _gsi_name_list(getattr(ds, 'gsi_indexes', None))
-        if gsi:
-            lines.append(f"- GSI: {', '.join(gsi)}")
+        db_type = (getattr(ds, "db_type", None) or "").lower()
+        table = getattr(ds, "table_name", None) or "?"
+        lines += ["", "### Data Source"]
+        if db_type.startswith("rds"):
+            engine = "PostgreSQL" if "postgres" in db_type else (
+                "MySQL" if "mysql" in db_type else "RDS")
+            pk = getattr(ds, "partition_key", None)
+            detail = f"- {engine} table: `{table}`"
+            if pk:
+                detail += f" (PK: `{pk}`)"
+            lines.append(detail)
+            db_name = getattr(ds, "database_name", None)
+            if db_name:
+                lines.append(f"- Database: `{db_name}`")
+            lookup = getattr(ds, "lookup_column", None)
+            if lookup:
+                lines.append(f"- Lookup column: `{lookup}`")
+            related = getattr(ds, "related_tables", None)
+            if related:
+                names = [r if isinstance(r, str) else (r.get("name") or str(r)) for r in related]
+                lines.append(f"- Also reads: {', '.join(f'`{n}`' for n in names)}")
+            lines.append("- Access: RDS Data API (`rds-data:ExecuteStatement`)")
+        else:
+            pk = getattr(ds, "partition_key", None) or "?"
+            lines.append(f"- Table: `{table}` (PK: `{pk}`)")
+            gsi = _gsi_name_list(getattr(ds, "gsi_indexes", None))
+            if gsi:
+                lines.append(f"- GSI: {', '.join(gsi)}")
 
     # Business rules
     if spec.business_rules:

--- a/backend/ecs/src/tools/validate_consistency.py
+++ b/backend/ecs/src/tools/validate_consistency.py
@@ -363,6 +363,216 @@ def _extract_sql_statements(code: str) -> list:
     return found
 
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Data API parameter type-binding check (D5)
+#
+# Root cause this guards against (found in live E2E): the handler bound a
+# BIGINT key as a string —
+#     parameters=[{"name": "orderId", "value": {"stringValue": str(order_id)}}]
+# — and PostgreSQL rejected the query with
+#     operator does not exist: bigint = text  (SQLState 42883)
+# on the first invocation. MySQL silently coerces instead, which hides the bug
+# but throws away index usage on the compared column.
+#
+# Only unambiguous mismatches are reported. A string bound to a date/timestamp/
+# uuid/json/enum/numeric column is legitimate for the Data API and is ignored.
+# ─────────────────────────────────────────────────────────────────────────────
+_INT_TYPE_RE = re.compile(
+    r'^(small|big|tiny|medium)?(int|integer|serial)\d*(\s+unsigned)?$', re.I)
+_BOOL_TYPE_RE = re.compile(r'^(bool|boolean|bit|tinyint\(1\))$', re.I)
+_TEXT_TYPE_RE = re.compile(
+    r'^n?(var)?char(acter)?(\s+varying)?(\(\s*(\d+|max)\s*\))?$|'
+    r'^n?(tiny|medium|long)?text$', re.I)
+# columns where a stringValue binding is the correct Data API representation
+_STRING_OK_TYPE_RE = re.compile(
+    r'date|time|timestamp|uuid|json|xml|enum|set\(|numeric|decimal|money|'
+    r'interval|inet|cidr|bytea|blob|user-defined', re.I)
+
+_PARAM_COMPARISON_RE = re.compile(
+    r'\b(?:([A-Za-z_]\w*)\.)?([A-Za-z_]\w*)\s*(?:=|<>|!=|>=|<=|>|<)\s*:(\w+)')
+_PARAM_INSERT_RE = re.compile(
+    r'INSERT\s+INTO\s+"?`?([A-Za-z_]\w*)`?"?\s*\(([^)]*)\)\s*VALUES\s*\(([^)]*)\)',
+    re.I | re.S)
+_VALUE_KEYS = ("stringValue", "longValue", "doubleValue", "booleanValue",
+               "blobValue", "isNull", "arrayValue")
+
+
+def _extract_sql_with_bindings(code: str) -> list:
+    """Return [(sql_text, {param_name: dataApiValueKey})] per SQL call site."""
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return []
+
+    consts: Dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant) \
+                and isinstance(node.value.value, str):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    consts[target.id] = node.value.value
+
+    def as_text(node) -> Optional[str]:
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        if isinstance(node, ast.JoinedStr):
+            parts = []
+            for value in node.values:
+                if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                    parts.append(value.value)
+                elif isinstance(value, ast.FormattedValue) and \
+                        isinstance(value.value, ast.Name) and value.value.id in consts:
+                    parts.append(consts[value.value.id])
+                else:
+                    parts.append(" ")
+            return "".join(parts)
+        if isinstance(node, ast.Name):
+            return consts.get(node.id)
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+            left, right = as_text(node.left), as_text(node.right)
+            if left is not None and right is not None:
+                return left + right
+        return None
+
+    def bindings(node) -> Dict[str, str]:
+        """Parse a parameters=[{"name": ..., "value": {"longValue": ...}}] list."""
+        out: Dict[str, str] = {}
+        if not isinstance(node, (ast.List, ast.Tuple)):
+            return out
+        for element in node.elts:
+            if not isinstance(element, ast.Dict):
+                continue
+            name = None
+            value_key = None
+            for k, v in zip(element.keys, element.values):
+                key = k.value if isinstance(k, ast.Constant) else None
+                if key == "name" and isinstance(v, ast.Constant):
+                    name = v.value
+                elif key == "value" and isinstance(v, ast.Dict):
+                    for vk in v.keys:
+                        if isinstance(vk, ast.Constant) and vk.value in _VALUE_KEYS:
+                            value_key = vk.value
+                            break
+            if name and value_key:
+                out[name] = value_key
+        return out
+
+    pairs = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        sql = None
+        for arg in list(node.args) + [k.value for k in node.keywords if k.arg == "sql"]:
+            text = as_text(arg)
+            if text and _SQL_KEYWORD_RE.match(text):
+                sql = text
+                break
+        if not sql:
+            continue
+        binds: Dict[str, str] = {}
+        for kw in node.keywords:
+            if kw.arg in ("parameters", "params"):
+                binds = bindings(kw.value)
+        if not binds:
+            for arg in node.args:
+                if isinstance(arg, (ast.List, ast.Tuple)):
+                    binds = bindings(arg)
+                    if binds:
+                        break
+        pairs.append((sql, binds))
+    return pairs
+
+
+def _column_type_index(schema: dict) -> Dict[tuple, str]:
+    """(table, column) -> declared sql type, plus (None, column) when unambiguous."""
+    per_table: Dict[tuple, str] = {}
+    by_column: Dict[str, set] = {}
+    tables = schema.get("tables", []) if isinstance(schema, dict) else []
+    if isinstance(tables, dict):
+        tables = list(tables.values())
+    for t in tables or []:
+        if not isinstance(t, dict):
+            continue
+        table = t.get("name") or t.get("table_name")
+        for c in t.get("columns", []) or []:
+            if not isinstance(c, dict):
+                continue
+            col = c.get("name") or c.get("column_name")
+            sql_type = c.get("sql_type") or c.get("full_type") or c.get("type")
+            if not col or not sql_type:
+                continue
+            per_table[(table, col)] = str(sql_type)
+            by_column.setdefault(col, set()).add(str(sql_type))
+    for col, types in by_column.items():
+        if len(types) == 1:
+            per_table[(None, col)] = next(iter(types))
+    return per_table
+
+
+def _expected_value_key(sql_type: str) -> Optional[str]:
+    """The Data API value key a column of this type must be bound with."""
+    t = str(sql_type).strip()
+    if _STRING_OK_TYPE_RE.search(t):
+        return None          # a stringValue binding is legitimate here
+    if _BOOL_TYPE_RE.match(t):
+        return "booleanValue"
+    if _INT_TYPE_RE.match(t):
+        return "longValue"
+    if _TEXT_TYPE_RE.match(t):
+        return "stringValue"
+    return None
+
+
+def _check_sql_param_types(op_id: str, code: str, type_index: Dict[tuple, str]) -> list:
+    """Report Data API parameters bound with a type the column cannot accept."""
+    issues = []
+    if not type_index:
+        return issues
+
+    for sql, binds in _extract_sql_with_bindings(code):
+        if not binds:
+            continue
+        aliases = {}
+        for table, alias in _SQL_ALIAS_RE.findall(sql):
+            if alias.lower() not in _SQL_RESERVED:
+                aliases[alias] = table
+                aliases[table] = table
+
+        mapping = {}   # param -> (table, column)
+        for qualifier, column, param in _PARAM_COMPARISON_RE.findall(sql):
+            table = aliases.get(qualifier) if qualifier else None
+            mapping[param] = (table, column)
+        for table, col_list, val_list in _PARAM_INSERT_RE.findall(sql):
+            cols = [c.strip().strip('"`') for c in col_list.split(",") if c.strip()]
+            vals = [v.strip() for v in val_list.split(",")]
+            for col, val in zip(cols, vals):
+                m = re.match(r'^:(\w+)', val)
+                if m:
+                    mapping.setdefault(m.group(1), (table, col))
+
+        for param, (table, column) in mapping.items():
+            bound = binds.get(param)
+            if not bound or bound in ("isNull", "arrayValue", "blobValue"):
+                continue
+            sql_type = type_index.get((table, column)) or type_index.get((None, column))
+            if not sql_type:
+                continue
+            expected = _expected_value_key(sql_type)
+            if not expected or expected == bound:
+                continue
+            issues.append({
+                "operation_id": op_id, "field": f":{param}",
+                "asset_type": "sql_param_type_mismatch",
+                "issue": f"Lambda '{op_id}' binds `:{param}` as `{bound}` but "
+                         f"`{(table + '.') if table else ''}{column}` is "
+                         f"`{sql_type}`, which needs `{expected}`. PostgreSQL "
+                         f"rejects this outright (e.g. 'operator does not exist: "
+                         f"bigint = text', SQLState 42883); MySQL silently coerces "
+                         f"and stops using the index. Bind it as {expected}.",
+            })
+    return issues
+
+
 def _schema_column_index(schema: dict) -> Dict[str, set]:
     """table_name -> set(column names) from the infrastructure schema."""
     index: Dict[str, set] = {}
@@ -1003,11 +1213,14 @@ def validate_parameter_consistency(session_id: str) -> dict:
         if isinstance(_schema, dict):
             _col_index = _schema_column_index(_schema)
             _enum_types = _schema_enum_types(_schema)
+            _type_index = _column_type_index(_schema)
             for op_id, code in lambda_all_code.items():
                 mismatches.extend(_check_sql_identifiers(op_id, code, _col_index))
                 mismatches.extend(_check_sql_casts(op_id, code, _enum_types))
                 mismatches.extend(
                     _check_sql_insert_required_columns(op_id, code, _schema))
+                mismatches.extend(
+                    _check_sql_param_types(op_id, code, _type_index))
 
     summary = f"Found {len(mismatches)} mismatches across {len(expected)} operations"
     if mismatches:

--- a/backend/ecs/src/tools/validate_consistency.py
+++ b/backend/ecs/src/tools/validate_consistency.py
@@ -7,6 +7,8 @@ match the operation spec's input_fields/output_fields exactly.
 Called by Orchestrator after Phase 3b (Prompt) and by Reviewer Agent.
 """
 
+import ast
+import json
 import re
 import logging
 from typing import List, Dict, Any, Optional
@@ -272,6 +274,311 @@ def _extract_openapi_fields(yaml_content: str) -> Dict[str, Dict[str, set]]:
                             output_fields.update(_get_schema_props(spec, sw["schema"]))
             result[op_id] = {"input": input_fields, "output": output_fields}
     return result
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SQL identifier check (D4)
+#
+# Root cause this guards against (found in live E2E against a scanned Aurora
+# PostgreSQL schema): even with a correct introspection result in context, the
+# generator writes a column onto the WRONG table — e.g. `oi.product_name` when
+# product_name lives on `products`, or `pv.serial_number` when serial_number
+# lives on `warranty_claims`. The Lambda then fails at runtime with
+# "column ... does not exist" (SQLState 42703) on the very first call.
+#
+# The check is deliberately conservative: it only reports a column when the
+# schema knows that column on a DIFFERENT table. Columns the schema summary
+# simply omitted are ignored, so it cannot false-positive on an incomplete
+# column list.
+# ─────────────────────────────────────────────────────────────────────────────
+_SQL_KEYWORD_RE = re.compile(r'^\s*(SELECT|INSERT|UPDATE|DELETE|WITH)\b', re.I)
+# alias declarations:  FROM orders o  /  JOIN order_items AS oi
+_SQL_ALIAS_RE = re.compile(
+    r'\b(?:FROM|JOIN)\s+([A-Za-z_][\w]*)\s+(?:AS\s+)?([A-Za-z_][\w]*)\b', re.I)
+_SQL_QUALIFIED_RE = re.compile(r'\b([A-Za-z_][\w]*)\.([A-Za-z_][\w]*)\b')
+_SQL_RESERVED = {
+    "select", "insert", "update", "delete", "with", "from", "join", "inner",
+    "left", "right", "outer", "on", "where", "and", "or", "not", "null", "as",
+    "order", "by", "group", "having", "limit", "offset", "into", "values", "set",
+    "asc", "desc", "distinct", "case", "when", "then", "else", "end", "returning",
+    "union", "all", "exists", "in", "is", "like", "ilike", "between", "interval",
+    "coalesce", "count", "sum", "max", "min", "avg", "now", "cast",
+}
+
+
+def _extract_sql_statements(code: str) -> list:
+    """Pull SQL statements out of a generated Python handler.
+
+    Uses the AST rather than a regex so that implicit string concatenation
+    (``"SELECT a " "FROM t " "WHERE ..."`` split across lines — which is what
+    the generators actually emit) is seen as ONE statement. A regex sees each
+    fragment separately and never observes the FROM clause, so alias resolution
+    silently finds nothing.
+    """
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return []
+
+    consts: Dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant) \
+                and isinstance(node.value.value, str):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    consts[target.id] = node.value.value
+
+    def as_text(node) -> Optional[str]:
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            return node.value
+        if isinstance(node, ast.JoinedStr):   # f-string
+            parts = []
+            for value in node.values:
+                if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                    parts.append(value.value)
+                elif isinstance(value, ast.FormattedValue) and \
+                        isinstance(value.value, ast.Name) and value.value.id in consts:
+                    parts.append(consts[value.value.id])
+                else:
+                    parts.append(" ")
+            return "".join(parts)
+        if isinstance(node, ast.Name):
+            return consts.get(node.id)
+        if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+            left, right = as_text(node.left), as_text(node.right)
+            if left is not None and right is not None:
+                return left + right
+        return None
+
+    found = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            for arg in list(node.args) + [k.value for k in node.keywords if k.arg == "sql"]:
+                text = as_text(arg)
+                if text and _SQL_KEYWORD_RE.match(text):
+                    found.append(text)
+    for text in consts.values():
+        if _SQL_KEYWORD_RE.match(text) and text not in found:
+            found.append(text)
+    return found
+
+
+def _schema_column_index(schema: dict) -> Dict[str, set]:
+    """table_name -> set(column names) from the infrastructure schema."""
+    index: Dict[str, set] = {}
+    tables = schema.get("tables", []) if isinstance(schema, dict) else []
+    if isinstance(tables, dict):
+        tables = list(tables.values())
+    for t in tables or []:
+        if not isinstance(t, dict):
+            continue
+        name = t.get("name") or t.get("table_name") or t.get("tableName")
+        if not name:
+            continue
+        cols = set()
+        for c in t.get("columns", []) or []:
+            if isinstance(c, str):
+                cols.add(c)
+            elif isinstance(c, dict):
+                cn = c.get("name") or c.get("column_name")
+                if cn:
+                    cols.add(cn)
+        pk = t.get("primary_key")
+        if isinstance(pk, str):
+            for part in re.split(r'[+,]', pk):
+                part = part.strip()
+                if part:
+                    cols.add(part)
+        elif isinstance(pk, list):
+            cols.update(str(p) for p in pk)
+        if cols:
+            index[name] = cols
+    return index
+
+
+def _check_sql_identifiers(op_id: str, code: str, col_index: Dict[str, set]) -> list:
+    """Report qualified SQL columns that belong to a different table."""
+    issues = []
+    if not col_index:
+        return issues
+    owner: Dict[str, set] = {}
+    for tbl, cols in col_index.items():
+        for c in cols:
+            owner.setdefault(c, set()).add(tbl)
+
+    for sql in _extract_sql_statements(code):
+        aliases = {}
+        for tbl, alias in _SQL_ALIAS_RE.findall(sql):
+            if alias.lower() in _SQL_RESERVED:
+                continue
+            if tbl in col_index:
+                aliases[alias] = tbl
+                aliases[tbl] = tbl
+        if not aliases:
+            continue
+        for qualifier, column in _SQL_QUALIFIED_RE.findall(sql):
+            table = aliases.get(qualifier)
+            if not table or column.lower() in _SQL_RESERVED:
+                continue
+            known = col_index.get(table, set())
+            if column in known:
+                continue
+            real_owners = owner.get(column, set()) - {table}
+            if not real_owners:
+                continue  # column simply not listed for this table — don't guess
+            issues.append({
+                "operation_id": op_id, "field": f"{qualifier}.{column}",
+                "asset_type": "sql_schema_mismatch",
+                "issue": f"Lambda '{op_id}' SQL references `{qualifier}.{column}` "
+                         f"(alias of `{table}`), but `{column}` belongs to "
+                         f"{sorted(real_owners)} — not to `{table}`. This fails at "
+                         f"runtime with 'column does not exist' (SQLState 42703). "
+                         f"Join through to {sorted(real_owners)[0]} or use the "
+                         f"correct column from `{table}`.",
+            })
+    return issues
+
+
+_PG_BUILTIN_TYPES = {
+    "text", "varchar", "char", "bpchar", "citext", "name",
+    "int", "int2", "int4", "int8", "smallint", "integer", "bigint",
+    "numeric", "decimal", "real", "float4", "float8", "double precision", "money",
+    "bool", "boolean", "bytea", "uuid", "json", "jsonb", "xml",
+    "date", "time", "timetz", "timestamp", "timestamptz", "interval",
+    "inet", "cidr", "macaddr", "tsvector", "tsquery", "oid", "regclass",
+    "array", "character", "user-defined", "record", "void", "anyelement",
+}
+_SQL_CAST_RE = re.compile(r'::\s*"?([A-Za-z_][\w ]*?)"?\s*(?=[\s,)\]]|$)')
+
+
+def _check_sql_casts(op_id: str, code: str, enum_types: set) -> list:
+    """Report ``::type`` casts to a type the schema does not define.
+
+    Observed live: the generator correctly cast a real PostgreSQL enum
+    (``:reason::return_reason``) and then invented the same pattern for two
+    plain VARCHAR columns (``:approvalStatus::approval_status``,
+    ``:claimStatus::claim_status``). Postgres rejects those with
+    ``type "approval_status" does not exist`` on the first write.
+    """
+    issues = []
+    for sql in _extract_sql_statements(code):
+        for raw in _SQL_CAST_RE.findall(sql):
+            type_name = raw.strip().lower().rstrip("[]")
+            base = type_name.replace("[]", "").strip()
+            if not base or base in _PG_BUILTIN_TYPES or base in enum_types:
+                continue
+            if re.match(r'^(varchar|char|numeric|decimal|timestamp|time)\s*\(', base):
+                continue
+            issues.append({
+                "operation_id": op_id, "field": f"::{raw.strip()}",
+                "asset_type": "sql_type_mismatch",
+                "issue": f"Lambda '{op_id}' SQL casts to type `{raw.strip()}`, which is "
+                         f"neither a built-in type nor one of the schema's enum types "
+                         f"({sorted(enum_types) if enum_types else 'none'}). Postgres "
+                         f"fails with 'type \"{raw.strip()}\" does not exist' on the first "
+                         f"call. If that column is a plain VARCHAR, drop the cast.",
+            })
+    return issues
+
+
+def _schema_enum_types(schema: dict) -> set:
+    """Collect enum type names the schema declares."""
+    names = set()
+    if not isinstance(schema, dict):
+        return names
+    enum_types = schema.get("enum_types") or {}
+    if isinstance(enum_types, dict):
+        names.update(k.lower() for k in enum_types)
+    elif isinstance(enum_types, list):
+        for e in enum_types:
+            if isinstance(e, str):
+                names.add(e.lower())
+            elif isinstance(e, dict) and e.get("name"):
+                names.add(str(e["name"]).lower())
+    tables = schema.get("tables", [])
+    if isinstance(tables, dict):
+        tables = list(tables.values())
+    for t in tables or []:
+        if not isinstance(t, dict):
+            continue
+        enums = t.get("enums")
+        if isinstance(enums, dict):
+            # {"status": [...]} — the column name is not the type name, but the
+            # generator commonly casts to it, so accept it rather than false-flag.
+            names.update(k.lower() for k in enums)
+        for c in t.get("columns", []) or []:
+            if isinstance(c, dict):
+                st = (c.get("sql_type") or c.get("full_type") or "")
+                m = re.match(r'^([a-z_][\w]*)$', str(st).strip().lower())
+                if m and m.group(1) not in _PG_BUILTIN_TYPES:
+                    names.add(m.group(1))
+    return names
+
+
+_SQL_INSERT_RE = re.compile(
+    r'INSERT\s+INTO\s+"?([A-Za-z_][\w]*)"?\s*\(([^)]*)\)', re.I | re.S)
+
+
+def _check_sql_insert_required_columns(op_id: str, code: str, schema: dict) -> list:
+    """Report INSERTs that omit a NOT NULL column having no default.
+
+    Observed live: the generated `create_return` INSERT listed
+    (return_number, order_id, line_number, reason, refund_amount,
+     requires_manager_approval, approval_status) but `returns.quantity` is
+    NOT NULL with no default, so the first write fails with
+    'null value in column "quantity" violates not-null constraint'.
+    """
+    issues = []
+    required: Dict[str, set] = {}
+    tables = schema.get("tables", []) if isinstance(schema, dict) else []
+    if isinstance(tables, dict):
+        tables = list(tables.values())
+    for t in tables or []:
+        if not isinstance(t, dict):
+            continue
+        name = t.get("name") or t.get("table_name")
+        cols = t.get("columns") or []
+        if not name or not cols or not isinstance(cols[0], dict):
+            continue  # need per-column metadata to judge
+        needed = set()
+        for c in cols:
+            nullable = c.get("nullable")
+            if nullable in (True, "YES", "yes"):
+                continue
+            if nullable is None:
+                continue  # unknown → don't guess
+            if c.get("default") not in (None, "", "None"):
+                continue
+            if c.get("generated") or c.get("auto_increment"):
+                continue
+            cname = c.get("name") or c.get("column_name")
+            if cname:
+                needed.add(cname)
+        if needed:
+            required[name] = needed
+
+    if not required:
+        return issues
+
+    for sql in _extract_sql_statements(code):
+        for table, col_list in _SQL_INSERT_RE.findall(sql):
+            if table not in required:
+                continue
+            provided = {c.strip().strip('"') for c in col_list.split(",") if c.strip()}
+            missing = sorted(required[table] - provided)
+            # a single-column PK that looks generated is usually a serial
+            missing = [m for m in missing if not m.endswith("_id") or m in provided]
+            if missing:
+                issues.append({
+                    "operation_id": op_id, "field": ", ".join(missing),
+                    "asset_type": "sql_missing_required_column",
+                    "issue": f"Lambda '{op_id}' INSERTs into `{table}` without the NOT NULL "
+                             f"column(s) {missing}, which have no default. The write fails "
+                             f"with 'null value in column ... violates not-null "
+                             f"constraint'. Add them to the INSERT column list and "
+                             f"parameters.",
+                })
+    return issues
 
 
 @tool
@@ -594,6 +901,113 @@ def validate_parameter_consistency(session_id: str) -> dict:
                              f"fails with AccessDeniedException at runtime. Add an inline "
                              f"policy with these actions to the function's role.",
                 })
+
+    # D3: RDS Data API contract (only when the Lambdas actually use rds-data)
+    #     Catches, deterministically:
+    #       a) env var name drift — Lambda reads DB_CLUSTER_ARN while the
+    #          CloudFormation template exports RDS_CLUSTER_ARN → KeyError at
+    #          import time on every invocation
+    #       b) execute_statement without includeResultMetadata=True → the
+    #          response carries no columnMetadata, so rows can only be read
+    #          positionally and any schema change silently corrupts results
+    #       c) positional row access (record[0]) instead of by column name
+    #       d) SQL built by string concatenation/f-string → SQL injection
+    _RDS_ENV_CANON = ("DB_CLUSTER_ARN", "DB_SECRET_ARN", "DB_NAME")
+    _RDS_ENV_WRONG = {
+        "RDS_CLUSTER_ARN": "DB_CLUSTER_ARN",
+        "RDS_SECRET_ARN": "DB_SECRET_ARN",
+        "RDS_DATABASE_NAME": "DB_NAME",
+        "RDS_DB_NAME": "DB_NAME",
+        "CLUSTER_ARN": "DB_CLUSTER_ARN",
+        "SECRET_ARN": "DB_SECRET_ARN",
+    }
+    for op_id, code in lambda_all_code.items():
+        if "rds-data" not in code and "rds_data" not in code:
+            continue
+
+        env_reads = set(re.findall(r'os\.environ(?:\.get)?[\[\(]\s*["\']([A-Z0-9_]+)["\']', code))
+
+        for wrong, right in _RDS_ENV_WRONG.items():
+            if wrong in env_reads and right not in env_reads:
+                mismatches.append({
+                    "operation_id": op_id, "field": wrong,
+                    "asset_type": "rds_env_contract",
+                    "issue": f"Lambda '{op_id}' reads os.environ['{wrong}'] but the RDS "
+                             f"env var contract is '{right}'. Rename it in the handler and "
+                             f"make sure infrastructure.yaml sets the same name, otherwise "
+                             f"the function raises KeyError on cold start.",
+                })
+
+        if infra_yaml:
+            for env_name in sorted(env_reads & set(_RDS_ENV_CANON)):
+                if env_name not in infra_yaml:
+                    mismatches.append({
+                        "operation_id": op_id, "field": env_name,
+                        "asset_type": "rds_env_contract",
+                        "issue": f"Lambda '{op_id}' reads os.environ['{env_name}'] but "
+                                 f"infrastructure.yaml never defines it — the function "
+                                 f"fails with KeyError at runtime. Add it to the function's "
+                                 f"Environment.Variables.",
+                    })
+
+        if "execute_statement" in code and "includeResultMetadata" not in code:
+            mismatches.append({
+                "operation_id": op_id, "field": "includeResultMetadata",
+                "asset_type": "rds_data_api",
+                "issue": f"Lambda '{op_id}' calls rds-data execute_statement without "
+                         f"includeResultMetadata=True. The response then has no "
+                         f"columnMetadata, so columns can only be read by position and "
+                         f"results break on any schema change. Pass "
+                         f"includeResultMetadata=True and map rows to dicts by column name.",
+            })
+
+        positional = (
+            re.search(r'\[\s*["\']records["\']\s*\]\s*\[\s*\d+\s*\]', code)
+            or re.search(r'\brecords\s*\[\s*\d+\s*\]\s*\[\s*\d+\s*\]', code)
+            or re.search(r'\brecord\s*\[\s*\d+\s*\]', code)
+            or re.search(r'\.get\(\s*["\']records["\']\s*[^)]*\)\s*\[\s*\d+\s*\]\s*\[\s*\d+\s*\]', code)
+        )
+        if positional:
+            mismatches.append({
+                "operation_id": op_id, "field": "",
+                "asset_type": "rds_data_api",
+                "issue": f"Lambda '{op_id}' reads Data API rows by position "
+                         f"(record[0], records[0][1], …). Read columns by name using "
+                         f"columnMetadata instead — positional access silently returns the "
+                         f"wrong column when the table changes.",
+            })
+
+        # SQL text built with an f-string / concatenation / % / .format() instead
+        # of Data API named parameters
+        injection = (
+            re.search(r'\bsql\s*=\s*f["\']', code)
+            or re.search(r'\bsql\s*=\s*["\'][^"\']*["\']\s*(?:\+|%|\.format\()', code)
+            or re.search(r'(?:execute_sql|execute_statement)\s*\(\s*f["\']', code)
+            or re.search(r'(?:execute_sql|execute_statement)\s*\(\s*["\'][^"\']*["\']\s*(?:\+|%|\.format\()', code)
+        )
+        if injection:
+            mismatches.append({
+                "operation_id": op_id, "field": "",
+                "asset_type": "rds_data_api",
+                "issue": f"Lambda '{op_id}' builds SQL by string interpolation/concatenation "
+                         f"— SQL injection risk. Use Data API named parameters "
+                         f"(:param) with the parameters=[...] argument.",
+            })
+
+    # D4: SQL identifiers in generated handlers vs the scanned/provided schema
+    if infra_schema and lambda_all_code:
+        try:
+            _schema = json.loads(infra_schema) if isinstance(infra_schema, str) else infra_schema
+        except Exception:
+            _schema = None
+        if isinstance(_schema, dict):
+            _col_index = _schema_column_index(_schema)
+            _enum_types = _schema_enum_types(_schema)
+            for op_id, code in lambda_all_code.items():
+                mismatches.extend(_check_sql_identifiers(op_id, code, _col_index))
+                mismatches.extend(_check_sql_casts(op_id, code, _enum_types))
+                mismatches.extend(
+                    _check_sql_insert_required_columns(op_id, code, _schema))
 
     summary = f"Found {len(mismatches)} mismatches across {len(expected)} operations"
     if mismatches:

--- a/docs/existing-database.md
+++ b/docs/existing-database.md
@@ -1,0 +1,342 @@
+# Building on an existing database
+
+AICC Builder can generate its asset bundle against a database you already run,
+instead of creating new tables. There are two ways in, and both end at the same
+place: a schema contract that every downstream generator reads.
+
+| Path | When to use it | Entry point |
+|---|---|---|
+| **Live scan** | The database is reachable from the deploying account | `introspect_database` |
+| **Schema as document** | Direct DB access isn't permitted, or the DB doesn't exist yet | attach a DDL dump / ERD / data dictionary |
+
+Supported: **DynamoDB**, and **every RDS and Aurora engine** — PostgreSQL,
+MySQL, MariaDB, SQL Server, Oracle and Db2.
+
+---
+
+## 1. Live scan
+
+`introspect_database` reads the schema and returns it in one shape regardless of
+engine. It is read-only, so it is safe to call at any stage — during the
+interview to design against the real schema, or mid-generation to re-check a
+column name before patching an asset.
+
+### The one-argument call
+
+Pass the DB instance or Aurora cluster identifier and everything else is
+resolved from RDS — engine, endpoint, port, master-user secret, and which
+connection method to use:
+
+```python
+introspect_database(
+    db_type="rds",                       # auto-detects the engine
+    region="ap-northeast-1",
+    rds_instance_identifier="my-db",
+    rds_database_name="appdb",           # only when the instance has no default DB
+)
+```
+
+### Connection method (chosen automatically)
+
+| Target | Method | Needs a network path? |
+|---|---|---|
+| Aurora with the Data API (HTTP endpoint) enabled | RDS Data API | No |
+| Aurora without it, and all plain RDS engines | driver connection | Yes — SG + subnet route |
+
+Drivers ship in the image: `psycopg2` (PostgreSQL), `pymysql` (MySQL, MariaDB),
+`pytds` (SQL Server), `oracledb` (Oracle, thin mode). Db2 needs `ibm-db` added.
+
+To use the Data API on an Aurora cluster:
+
+```bash
+aws rds modify-db-cluster --db-cluster-identifier <id> --enable-http-endpoint
+```
+
+### Choosing what to scan
+
+A production schema can have hundreds of tables, and only a handful matter to
+the contact-center operations. Three ways to narrow it:
+
+```python
+# 1. cheap inventory first — names, row counts, comments; no column/index queries
+introspect_database(db_type="rds", region=..., rds_instance_identifier="my-db",
+                    tables_only=True)
+
+# 2. then the tables that matter, in one call
+introspect_database(db_type="rds", region=..., rds_instance_identifier="my-db",
+                    table_name="orders,order_items,customers")
+
+# 3. or a single table
+introspect_database(db_type="rds", region=..., rds_instance_identifier="my-db",
+                    table_name="orders")
+```
+
+Omitting `table_name` scans everything. Names match case-insensitively, so
+`orders` finds Oracle's `ORDERS` without the caller knowing the storage casing.
+DynamoDB takes the same comma-separated form via `dynamodb_table_name`.
+
+### What it reads
+
+**SQL engines**
+
+- tables and views, with real row counts and sample rows
+- exact column names, SQL types, nullability, defaults
+- primary keys, including **composite** keys
+- secondary indexes (unique, composite, fulltext), with index type
+- **foreign keys and the reverse relationships** (`referenced_by`)
+- allowed values — declared enums on PostgreSQL/MySQL, and for engines with no
+  ENUM type (SQL Server, Oracle, Db2) the **distinct values actually present**
+  in enum-like columns, marked `allowed_values_source: "observed"`
+- check constraints and generated columns with their expressions
+- table and column comments
+
+**DynamoDB**
+
+- key schema, including sort keys
+- global **and local** secondary indexes, with projection type and projected attributes
+- non-key attributes discovered by sampling, with nested map / list / set typing
+- stream configuration and billing mode
+
+### Requirements
+
+The runtime role needs `rds:DescribeDBInstances` / `DescribeDBClusters` for
+discovery, `secretsmanager:GetSecretValue` for credentials, plus
+`rds-data:ExecuteStatement` on the Data API path, and
+`dynamodb:DescribeTable` + `dynamodb:Scan` for DynamoDB.
+
+A scan that finds nothing returns an error listing the tables that *do* exist
+and the schema/owner it searched. Failures are distinguished so they are
+actionable: `TARGET_NOT_FOUND`, `DATA_API_NOT_ENABLED`, `CONNECTION_FAILED`,
+`DRIVER_NOT_INSTALLED`, `ACCESS_DENIED`, `SECRET_UNREADABLE`,
+`NO_TABLES_FOUND`, `MISSING_PARAMETERS`.
+
+---
+
+## 2. Schema as a document
+
+Attach a DDL dump, an ERD image, or a data dictionary and no scan is attempted.
+The agent parses the document into the same contract, then **echoes back every
+table and column it read** for confirmation before generating anything. It will
+ask rather than invent an identifier the document did not state.
+
+---
+
+## 3. Schema fidelity
+
+Once read, the schema is the contract. Two things in particular travel with it:
+
+**Column comments become business rules.** A comment like
+
+```sql
+COMMENT ON TABLE returns IS
+  'Return requests. Auto-approve under 500,000 KRW; above needs manager approval.';
+```
+
+is carried into the OperationSpec, so the generated Lambda enforces the
+threshold rather than inventing one.
+
+**Sampled values become data conventions.** A phone number stored as
+`821012345678` stays in that format through the Lambda, the AI prompt and the
+Contact Flow, instead of being normalized to `+8210...` and silently failing
+every lookup.
+
+**Observed values stop invented enums.** SQL Server, Oracle and Db2 have no
+ENUM type — a status column is just `VARCHAR` — so the scan reports the distinct
+values actually present. Without that the generator guesses: in testing it wrote
+`{"DAMAGE", "LOST"}` for a column whose real values are `DAMAGE`, `LOSS`,
+`DELAY`, `WRONG_DELIVERY`, which rejected every valid request.
+
+---
+
+## 4. Deploying against a driver-based engine
+
+On the Data API path the generated Lambdas need no networking. On the driver
+path (plain RDS, or Aurora with the HTTP endpoint off) they need three things,
+and the generated CloudFormation emits all of them:
+
+- `VpcConfig` with at least two subnets in the DB's VPC and a dedicated Lambda
+  security group
+- a `SecurityGroupIngress` letting that Lambda SG reach the DB security group on
+  the engine's port
+- a **Secrets Manager interface VPC endpoint**
+  (`com.amazonaws.<region>.secretsmanager`, 443 from the Lambda SG), or private
+  subnets behind a NAT gateway
+
+That last one is easy to miss and fails opaquely: a VPC-attached Lambda has no
+route to public AWS endpoints, so `GetSecretValue` hangs and the function dies at
+its timeout before running a single query. In testing every invocation returned
+`Task timed out after 30.00 seconds` until the endpoint existed.
+
+---
+
+## 5. Validation gates
+
+A correct schema in context is not sufficient — a language model will still
+write a column onto the wrong table. These checks run deterministically in
+`validate_parameter_consistency` before anything is deployed.
+
+| Check | What it catches | Failure it prevents |
+|---|---|---|
+| `sql_schema_mismatch` | a column referenced on a table that does not own it | `column ... does not exist` (42703) |
+| `sql_type_mismatch` | a cast to a type the schema does not define | `type "..." does not exist` |
+| `sql_missing_required_column` | an `INSERT` omitting a `NOT NULL` column with no default | `null value in column ... violates not-null constraint` |
+| `sql_param_type_mismatch` | a parameter bound with a type the column cannot accept | `operator does not exist: bigint = text` (42883) |
+| `rds_env_contract` / `rds_data_api` | env var drift, missing `includeResultMetadata`, positional row access, interpolated SQL | `KeyError` on cold start; wrong column returned after a schema change |
+
+Each check is conservative by design: it reports only when the schema gives an
+unambiguous answer. A column the schema does not describe is left alone rather
+than guessed at.
+
+Two classes of mistake are repaired at merge time instead of reported, because
+they arise from independently generated fragments disagreeing:
+
+- RDS environment variables are unified on `DB_CLUSTER_ARN` / `DB_SECRET_ARN` /
+  `DB_NAME` — the names the generated handlers actually read.
+- An inline Lambda whose `Handler` names a function its code does not define
+  gets the alias it needs.
+
+---
+
+## 6. Verifying the gates
+
+`scripts/verify_param_type_gate.py` exercises the parameter type-binding gate
+against a synthetic matrix, against real generated handlers, and — with
+`--live` — against an Aurora cluster, to confirm the database agrees with the
+gate's verdict.
+
+```bash
+python3 scripts/verify_param_type_gate.py
+
+# also cross-check the verdict against a live Aurora PostgreSQL cluster
+python3 scripts/verify_param_type_gate.py --live \
+  --cluster-arn arn:aws:rds:<region>:<account>:cluster:<id> \
+  --secret-arn  arn:aws:secretsmanager:<region>:<account>:secret:<name> \
+  --database    <db>
+```
+
+### Recorded run
+
+Against an Aurora PostgreSQL schema of 14 tables (enums, composite keys,
+foreign keys, generated columns, check constraints):
+
+```
+A. Synthetic binding matrix
+------------------------------------------------------------------------------
+  [PASS] expect flag  -> flagged  bigint bound as stringValue
+  [PASS] expect allow -> clean    bigint bound as longValue
+  [PASS] expect allow -> clean    varchar bound as stringValue
+  [PASS] expect flag  -> flagged  varchar bound as longValue
+  [PASS] expect flag  -> flagged  boolean bound as stringValue
+  [PASS] expect allow -> clean    boolean bound as booleanValue
+  [PASS] expect allow -> clean    numeric bound as stringValue (valid for the Data API)
+  [PASS] expect allow -> clean    timestamptz bound as stringValue (ISO string is correct)
+  [PASS] expect allow -> clean    PostgreSQL enum bound as stringValue
+  [PASS] expect flag  -> flagged  INSERT: bigint column fed a stringValue
+  [PASS] expect allow -> clean    INSERT: correct bindings
+  [PASS] expect flag  -> flagged  aliased table, bigint bound as stringValue
+  [PASS] expect allow -> clean    unknown column — must stay silent, never guess
+
+  13/13 synthetic cases behaved as expected
+
+C. Live Aurora PostgreSQL cross-check
+------------------------------------------------------------------------------
+  SQL: SELECT line_number FROM order_items WHERE order_id = :orderId LIMIT 1
+  [PASS] stringValue (gate flags this): database rejects — operator does not exist: bigint = text
+  [PASS] longValue   (gate allows this): database accepts — 1 row(s)
+```
+
+The synthetic matrix is the part that matters for false positives: a
+`stringValue` bound to a `numeric`, `timestamptz` or enum column is the correct
+Data API representation and must stay clean, while the same binding on a
+`bigint` key must be flagged.
+
+### All schema gates on one bundle
+
+Run against the six handlers generated for a four-operation build on the same
+schema — first as generated, then after the reported findings were addressed:
+
+```
+as generated:
+  ❌ create_return
+       sql_type_mismatch               ::approval_status
+       sql_missing_required_column     quantity
+  ❌ create_warranty_claim
+       sql_schema_mismatch             pv.serial_number
+       sql_type_mismatch               ::claim_status
+  ✅ customer_lookup
+  ❌ get_order
+       sql_schema_mismatch             oi.product_name
+  ❌ list_order_items
+       sql_param_type_mismatch         :orderId
+  ✅ track_shipment
+  → 6 finding(s)
+
+after fixes:
+  ✅ create_return
+  ✅ create_warranty_claim
+  ✅ customer_lookup
+  ✅ get_order
+  ✅ list_order_items
+  ✅ track_shipment
+  → 0 finding(s)
+```
+
+Every finding corresponds to a statement the database refuses to run:
+`product_name` lives on `products` (not `order_items`), `serial_number` lives on
+`warranty_claims` (not `product_variants`), `approval_status` and `claim_status`
+are plain `VARCHAR` columns rather than enum types, `returns.quantity` is
+`NOT NULL` without a default, and `order_items.order_id` is `bigint`.
+
+---
+
+## 7. Engine coverage
+
+`introspect_database` is exercised against a live instance of every engine the
+account can host, over both connection methods, plus the table-selection modes
+and the failure paths:
+
+```
+================================================================================
+ENGINE COVERAGE
+================================================================================
+✅ Aurora PostgreSQL — Data API, explicit ARNs
+✅ Aurora MySQL — Data API, explicit ARNs
+✅ Aurora PostgreSQL — resolved from identifier
+✅ Aurora MySQL — resolved from identifier
+✅ RDS PostgreSQL — psycopg2 driver
+✅ RDS MySQL — PyMySQL driver
+✅ RDS MariaDB — PyMySQL driver
+✅ RDS SQL Server — python-tds driver
+✅ RDS MariaDB — engine auto-detected via db_type='rds'
+✅ RDS SQL Server — engine auto-detected via db_type='rds'
+✅ RDS PostgreSQL — caller said mysql, RDS corrects it
+✅ RDS PostgreSQL — single table filter
+✅ DynamoDB — three tables in one call
+✅ DynamoDB — single table
+✅ RDS PostgreSQL — multi-table filter (3 of 6)
+✅ RDS MySQL — multi-table filter
+✅ RDS SQL Server — multi-table filter
+✅ Aurora PostgreSQL — multi-table filter over Data API
+✅ RDS PostgreSQL — case-insensitive table name (ACCOUNTS)
+✅ RDS MariaDB — mixed-case list (Patients, DOCTORS)
+✅ RDS PostgreSQL — tables_only inventory
+✅ Aurora MySQL — tables_only inventory over Data API
+✅ RDS SQL Server — tables_only inventory
+✅ RDS MariaDB — include_sample_rows=False
+================================================================================
+ERROR HANDLING (every one of these must fail cleanly, with a code)
+================================================================================
+✅ unknown engine name: [None] Unsupported database type: cassandra
+✅ rds without an identifier: [MISSING_PARAMETERS] db_type 'rds'/'aurora' needs rds_instance_identifier so the engine can be detected, or name the engine explicitly (one o
+✅ identifier that does not exist: [TARGET_NOT_FOUND] No RDS DB instance or Aurora cluster named 'no-such-db-xyz' in this region.
+✅ table filter matching nothing: [NO_TABLES_FOUND] No tables found in database 'retaildb2' matching ['nope']. Discovered 6 table(s) total: ['accounts', 'bills', 'meters', 
+✅ driver path with no credentials at all: [MISSING_PARAMETERS] No credentials. Pass rds_secret_arn (a Secrets Manager secret holding username/password — RDS-managed master user secret
+ENGINES OK: 24   FAILED: 0
+ERROR CASES HANDLED: 5/5
+```
+
+Not covered by a live run: **Oracle** and **Db2** query sets are implemented but
+the engines were unavailable in the test account (`oracle-se2` is not offered
+there, and Db2 needs the `ibm-db` driver added to the image). Everything above
+ran against real databases.
+

--- a/infrastructure/lib/ecs-stack.ts
+++ b/infrastructure/lib/ecs-stack.ts
@@ -215,6 +215,22 @@ export class EcsStack extends cdk.Stack {
       })
     );
 
+    // RDS discovery for DB introspection. introspect_database resolves the
+    // engine, endpoint, port and master-user secret from a DB instance or
+    // cluster identifier, so it can pick the Data API or a driver connection
+    // without the operator supplying any of it. Read-only.
+    taskRole.addToPolicy(
+      new iam.PolicyStatement({
+        sid: "RdsDiscoveryReadOnly",
+        actions: [
+          "rds:DescribeDBInstances",
+          "rds:DescribeDBClusters",
+          "rds:DescribeDBClusterEndpoints",
+        ],
+        resources: ["*"],
+      })
+    );
+
     // CloudWatch metrics (for custom metrics)
     taskRole.addToPolicy(
       new iam.PolicyStatement({

--- a/infrastructure/lib/ecs-stack.ts
+++ b/infrastructure/lib/ecs-stack.ts
@@ -170,8 +170,27 @@ export class EcsStack extends cdk.Stack {
           "dynamodb:DeleteItem",
           "dynamodb:Query",
           "dynamodb:Scan",
+          "dynamodb:DescribeTable",
         ],
         resources: ["arn:aws:dynamodb:*:*:table/aiccbuilder*"],
+      })
+    );
+
+    // DynamoDB read-only introspection of the customer's EXISTING tables
+    // (introspect_database tool). Read-only on purpose: the tool only needs to
+    // describe the schema and sample a few items — it must never mutate
+    // customer data.
+    taskRole.addToPolicy(
+      new iam.PolicyStatement({
+        sid: "DynamoDbIntrospectionReadOnly",
+        actions: [
+          "dynamodb:DescribeTable",
+          "dynamodb:ListTables",
+          "dynamodb:Scan",
+          "dynamodb:Query",
+          "dynamodb:GetItem",
+        ],
+        resources: ["*"],
       })
     );
 

--- a/scripts/verify_param_type_gate.py
+++ b/scripts/verify_param_type_gate.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""
+Verification for the Data API parameter type-binding gate
+(validate_consistency._check_sql_param_types).
+
+Runs three things:
+  A. the gate against synthetic handlers covering every binding combination
+  B. the gate against the handlers the generator actually produced
+  C. the same SQL executed on a live Aurora PostgreSQL cluster, to confirm the
+     database really does reject what the gate flags and accept what it passes
+
+Usage:
+    python3 verify_param_type_gate.py                 # A + B
+    python3 verify_param_type_gate.py --live          # A + B + C (needs AWS creds)
+"""
+import argparse
+import ast
+import glob
+import json
+import pathlib
+import re
+import sys
+from typing import Dict, Optional
+
+REPO = pathlib.Path(__file__).resolve().parents[1]
+VALIDATOR = REPO / "backend/ecs/src/tools/validate_consistency.py"
+
+
+def load_gate():
+    """Exec just the helper block out of validate_consistency (no heavy imports)."""
+    src = VALIDATOR.read_text()
+    start = src.index("_SQL_KEYWORD_RE = re.compile(")
+    end = src.index("@tool")
+    ns = {"re": re, "ast": ast, "json": json, "Dict": Dict, "Optional": Optional}
+    exec(src[start:end], ns)
+    return ns
+
+
+# --------------------------------------------------------------------------- A
+# A schema mirroring the shapes that matter: bigint key, varchar, numeric,
+# boolean, date, and a PostgreSQL enum.
+SYNTHETIC_SCHEMA = {
+    "tables": [{
+        "name": "orders",
+        "columns": [
+            {"name": "order_id", "sql_type": "bigint"},
+            {"name": "order_number", "sql_type": "character varying"},
+            {"name": "total_amount", "sql_type": "numeric"},
+            {"name": "is_paid", "sql_type": "boolean"},
+            {"name": "placed_at", "sql_type": "timestamp with time zone"},
+            {"name": "status", "sql_type": "order_status"},
+        ],
+    }],
+    "enum_types": {"order_status": ["PENDING", "PAID"]},
+}
+
+CASES = [
+    # (name, should_flag, code)
+    ("bigint bound as stringValue (the live production failure)", True, '''
+def q(order_id):
+    return execute_sql(
+        "SELECT line_number FROM orders WHERE order_id = :orderId",
+        parameters=[{"name": "orderId", "value": {"stringValue": str(order_id)}}],
+    )
+'''),
+    ("bigint bound as longValue", False, '''
+def q(order_id):
+    return execute_sql(
+        "SELECT line_number FROM orders WHERE order_id = :orderId",
+        parameters=[{"name": "orderId", "value": {"longValue": int(order_id)}}],
+    )
+'''),
+    ("varchar bound as stringValue", False, '''
+def q(n):
+    return execute_sql(
+        "SELECT order_id FROM orders WHERE order_number = :orderNumber",
+        parameters=[{"name": "orderNumber", "value": {"stringValue": n}}],
+    )
+'''),
+    ("varchar bound as longValue", True, '''
+def q(n):
+    return execute_sql(
+        "SELECT order_id FROM orders WHERE order_number = :orderNumber",
+        parameters=[{"name": "orderNumber", "value": {"longValue": n}}],
+    )
+'''),
+    ("boolean bound as stringValue", True, '''
+def q(p):
+    return execute_sql(
+        "SELECT order_id FROM orders WHERE is_paid = :isPaid",
+        parameters=[{"name": "isPaid", "value": {"stringValue": p}}],
+    )
+'''),
+    ("boolean bound as booleanValue", False, '''
+def q(p):
+    return execute_sql(
+        "SELECT order_id FROM orders WHERE is_paid = :isPaid",
+        parameters=[{"name": "isPaid", "value": {"booleanValue": bool(p)}}],
+    )
+'''),
+    ("numeric bound as stringValue (valid for the Data API)", False, '''
+def q(a):
+    return execute_sql(
+        "SELECT order_id FROM orders WHERE total_amount = :totalAmount",
+        parameters=[{"name": "totalAmount", "value": {"stringValue": str(a)}}],
+    )
+'''),
+    ("timestamptz bound as stringValue (ISO string is correct)", False, '''
+def q(t):
+    return execute_sql(
+        "SELECT order_id FROM orders WHERE placed_at = :placedAt",
+        parameters=[{"name": "placedAt", "value": {"stringValue": t}}],
+    )
+'''),
+    ("PostgreSQL enum bound as stringValue", False, '''
+def q(s):
+    return execute_sql(
+        "SELECT order_id FROM orders WHERE status = :status",
+        parameters=[{"name": "status", "value": {"stringValue": s}}],
+    )
+'''),
+    ("INSERT: bigint column fed a stringValue", True, '''
+def q(oid, num):
+    return execute_sql(
+        "INSERT INTO orders (order_id, order_number) VALUES (:orderId, :orderNumber)",
+        parameters=[
+            {"name": "orderId", "value": {"stringValue": str(oid)}},
+            {"name": "orderNumber", "value": {"stringValue": num}},
+        ],
+    )
+'''),
+    ("INSERT: correct bindings", False, '''
+def q(oid, num):
+    return execute_sql(
+        "INSERT INTO orders (order_id, order_number) VALUES (:orderId, :orderNumber)",
+        parameters=[
+            {"name": "orderId", "value": {"longValue": int(oid)}},
+            {"name": "orderNumber", "value": {"stringValue": num}},
+        ],
+    )
+'''),
+    ("aliased table, bigint bound as stringValue", True, '''
+def q(oid):
+    return execute_sql(
+        "SELECT o.order_number FROM orders o WHERE o.order_id = :orderId",
+        parameters=[{"name": "orderId", "value": {"stringValue": str(oid)}}],
+    )
+'''),
+    ("unknown column — must stay silent, never guess", False, '''
+def q(x):
+    return execute_sql(
+        "SELECT 1 FROM orders WHERE some_unmapped_column = :x",
+        parameters=[{"name": "x", "value": {"stringValue": x}}],
+    )
+'''),
+]
+
+
+def run_synthetic(gate) -> tuple:
+    tidx = gate["_column_type_index"](SYNTHETIC_SCHEMA)
+    passed = failed = 0
+    print("A. Synthetic binding matrix")
+    print("-" * 78)
+    for name, should_flag, code in CASES:
+        issues = gate["_check_sql_param_types"]("t", code, tidx)
+        flagged = len(issues) > 0
+        ok = flagged == should_flag
+        passed += ok
+        failed += not ok
+        verdict = "PASS" if ok else "FAIL"
+        want = "flag" if should_flag else "allow"
+        print(f"  [{verdict}] expect {want:5s} -> {'flagged' if flagged else 'clean':7s}  {name}")
+        if not ok and issues:
+            print(f"          unexpected: {issues[0]['issue'][:120]}")
+    print(f"\n  {passed}/{passed + failed} synthetic cases behaved as expected\n")
+    return passed, failed
+
+
+# --------------------------------------------------------------------------- B
+def build_live_schema(introspection_path) -> Optional[dict]:
+    p = pathlib.Path(introspection_path)
+    if not p.exists():
+        return None
+    res = json.loads(p.read_text())
+    key = next((k for k in res if "PostgreSQL" in k and "all" in k), None)
+    if not key or not res[key].get("success"):
+        return None
+    pg = res[key]
+    return {
+        "tables": [{
+            "name": t["table_name"],
+            "columns": [{"name": c["name"], "sql_type": c.get("full_type")}
+                        for c in t["columns"]],
+        } for t in pg["tables"]],
+        "enum_types": pg.get("enum_types"),
+    }
+
+
+def run_generated(gate, schema, pattern, label) -> int:
+    files = sorted(glob.glob(pattern))
+    if not files:
+        print(f"  (no handlers at {pattern})")
+        return 0
+    tidx = gate["_column_type_index"](schema)
+    total = 0
+    print(f"  {label}")
+    for f in files:
+        op = pathlib.Path(f).parent.name
+        issues = gate["_check_sql_param_types"](op, pathlib.Path(f).read_text(), tidx)
+        mark = "❌" if issues else "✅"
+        print(f"    {mark} {op}")
+        for i in issues:
+            total += 1
+            print(f"        {i['field']} — {i['issue'][:150]}")
+    print(f"    → {total} finding(s)\n")
+    return total
+
+
+# --------------------------------------------------------------------------- C
+def run_live(cluster_arn, secret_arn, database):
+    """Prove the database agrees with the gate."""
+    import boto3
+    rds = boto3.client("rds-data", region_name="ap-northeast-1")
+
+    def run(sql, params):
+        return rds.execute_statement(
+            resourceArn=cluster_arn, secretArn=secret_arn, database=database,
+            sql=sql, parameters=params, includeResultMetadata=True)
+
+    sql = "SELECT line_number FROM order_items WHERE order_id = :orderId LIMIT 1"
+    print("C. Live Aurora PostgreSQL cross-check")
+    print("-" * 78)
+    print(f"  SQL: {sql}")
+    for label, value, expect in (
+        ("stringValue (gate flags this)", {"stringValue": "1"}, "reject"),
+        ("longValue   (gate allows this)", {"longValue": 1}, "accept"),
+    ):
+        try:
+            r = run(sql, [{"name": "orderId", "value": value}])
+            got = "accept"
+            detail = f"{len(r.get('records', []))} row(s)"
+        except Exception as e:
+            got = "reject"
+            m = re.search(r"ERROR: (.*?);", str(e))
+            detail = (m.group(1) if m else str(e))[:110]
+        agree = "PASS" if got == expect else "FAIL"
+        print(f"  [{agree}] {label}: database {got}s — {detail}")
+    print()
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--live", action="store_true")
+    ap.add_argument("--introspection", default="/tmp/aicc-dbtest/introspect_results.json")
+    ap.add_argument("--before", default="/tmp/aicc-dbtest/orig/*/index.py")
+    ap.add_argument("--after", default="/tmp/aicc-dbtest/gen/lambda/*/index.py")
+    ap.add_argument("--cluster-arn", default="")
+    ap.add_argument("--secret-arn", default="")
+    ap.add_argument("--database", default="retaildb")
+    a = ap.parse_args()
+
+    gate = load_gate()
+    _, failed = run_synthetic(gate)
+
+    schema = build_live_schema(a.introspection)
+    print("B. Handlers produced by the generator")
+    print("-" * 78)
+    if schema:
+        before = run_generated(gate, schema, a.before, "as generated:")
+        after = run_generated(gate, schema, a.after, "after the fix:")
+        print(f"  {before} finding(s) before, {after} after\n")
+    else:
+        print(f"  (skipped — no introspection result at {a.introspection})\n")
+
+    if a.live and a.cluster_arn and a.secret_arn:
+        run_live(a.cluster_arn, a.secret_arn, a.database)
+
+    sys.exit(1 if failed else 0)

--- a/skills/aicc-builder-skill/resources/orchestrator/system_prompt.md
+++ b/skills/aicc-builder-skill/resources/orchestrator/system_prompt.md
@@ -335,10 +335,26 @@ into the conversation.
   🟡 Placeholder: TODO comment + skeleton code only (real API wired later).
 
 #### Database type (only if they have an existing DB)
-- DynamoDB (new) or RDS MySQL/PostgreSQL (existing)?
-- For RDS: Aurora Serverless v2 + Data API. You need the Secrets Manager
-  ARN, cluster ARN, and database name.
-- Given the existing table names + region, we'll auto-introspect the schema.
+- DynamoDB (new) or an existing DynamoDB / RDS-Aurora MySQL / RDS-Aurora PostgreSQL?
+- Record `db_type` as one of: `dynamodb`, `rds_mysql`, `rds_postgresql`.
+- Always capture `region` (the DB's region, which may differ from this app's).
+- **DynamoDB**: capture `table_name` — several tables may be given as one
+  comma-separated string; the scan handles them in a single call.
+- **RDS/Aurora**: introspection goes through the RDS Data API, so you MUST
+  collect all three and store them under exactly these keys:
+  `rds_cluster_arn`, `rds_secret_arn`, `rds_database_name`.
+  Tell the user where to find them if they ask: cluster ARN from the RDS
+  console/`describe-db-clusters`, secret ARN from Secrets Manager (the
+  cluster's master-user secret), database name = the schema they query.
+  The Data API exists only on Aurora Serverless v2/provisioned clusters with
+  the HTTP endpoint enabled — if they are on a plain RDS instance, say so and
+  offer the document path below instead.
+- **No reachable DB?** They can instead paste or upload the schema (DDL dump,
+  ERD image, data dictionary, sample JSON). Accept it and follow
+  "Phase 0-ALT: Schema supplied as a DOCUMENT" — do not ask for ARNs just to
+  read a schema, only ask for them if generated Lambdas must actually connect.
+- Given the above, we auto-introspect the schema — never ask the user to retype
+  column names that a scan can discover.
 
 #### Passing discovered info to sub-agents
 - `call_direction` → contact_flow_generator (via `contact_flow_requirements`)
@@ -839,25 +855,89 @@ When collected_data includes `existing_table == true`:
 
 **Phase 0: Schema Introspection (scan the existing DB)**
 ```
-1. Call introspect_database:
+1. Call introspect_database — pass EVERY parameter the engine needs:
+
+   # DynamoDB (table_name may be a comma-separated list to scan several at once)
    introspect_database(
-       db_type=collected_data["db_type"],
-       table_name=collected_data["table_name"],
+       db_type="dynamodb",
+       dynamodb_table_name=collected_data["table_name"],
        region=collected_data["region"]
    )
-2. Convert via convert_to_infrastructure_schema():
-   - key_schema → primary_key
-   - global_secondary_indexes → gsi_indexes
-   - attributes → field list
-   - unify env var on TABLE_NAME (use the real table name since it already exists)
-3. Report scan result to the user (user-facing copy in their language), e.g.:
-   "✅ 테이블 스키마를 스캔했어요!
-   - 테이블: {table_name}
-   - PK: {primary_key}
-   - GSI: {gsi_list}
-   - 속성: {attribute_count}개
 
+   # RDS / Aurora — the three connection values are MANDATORY.
+   # Omitting them returns MISSING_PARAMETERS; there is no default.
+   introspect_database(
+       db_type=collected_data["db_type"],          # "rds_postgresql" | "rds_mysql"
+       region=collected_data["region"],
+       rds_cluster_arn=collected_data["rds_cluster_arn"],
+       rds_secret_arn=collected_data["rds_secret_arn"],
+       rds_database_name=collected_data["rds_database_name"],
+       table_name=collected_data.get("table_name")  # omit to scan the whole schema
+   )
+
+2. CHECK THE RESULT BEFORE CONTINUING. If `success == false`, do NOT proceed to
+   Phase 1 — relay `error` to the user verbatim and ask them to confirm the
+   connection details. Common `error_code` values and what to tell the user:
+   - MISSING_PARAMETERS    → ask for the cluster ARN / secret ARN / database name
+   - DATA_API_NOT_ENABLED  → the Data API must be enabled; it only exists on
+                             Aurora clusters, not on plain RDS instances
+   - ACCESS_DENIED         → the runtime role lacks rds-data / secretsmanager /
+                             dynamodb:DescribeTable permission
+   - NO_TABLES_FOUND       → the error lists the tables that DO exist; ask which
+                             ones they meant
+
+3. Convert via convert_to_infrastructure_schema(). It handles DynamoDB
+   (single or multiple tables) AND RDS/Aurora, and returns:
+   - DynamoDB: tables[].primary_key / sort_key / gsi_indexes / lsi_indexes,
+     environment_variables{<ENTITY>_TABLE_NAME}
+   - RDS:      tables[].primary_key / columns[] (exact names, sql_type,
+     allowed_values, description) / indexes / foreign_keys / referenced_by,
+     relationships[], enum_types{}, connection{cluster_arn, secret_arn,
+     database_name}, environment_variables{DB_CLUSTER_ARN, DB_SECRET_ARN,
+     DB_NAME}, iam_requirements[]
+   - both:     data_conventions{} with REAL sampled examples, access_notes[]
+
+4. ⚠️ The scanned schema is now the CONTRACT. Never rename, re-case, or invent
+   columns/attributes. Use the exact identifiers returned by the scan, honour
+   `allowed_values` for enum-like fields, and preserve `data_conventions`
+   examples (e.g. a phone stored as `821012345678` must not become `+8210...`).
+   Column/table `description` values often carry business rules
+   (e.g. "Auto-approve under 500,000 KRW") — feed those into the OperationSpec.
+
+5. Report the scan result to the user (in their language), e.g.:
+   "✅ 스키마를 스캔했어요!
+   - 테이블: {table_count}개 ({table_names})
+   - 주요 키: {primary_keys}
+   - 인덱스/GSI: {index_list}
+   - 관계: {relationship_count}개
    이 스키마를 기반으로 에셋을 생성할게요."
+```
+
+**Phase 0-ALT: Schema supplied as a DOCUMENT (no live DB to scan)**
+```
+When the customer PASTES or UPLOADS the schema instead (DDL/CREATE TABLE dump,
+ERD image, Excel/CSV data dictionary, JSON sample payloads) and there is no
+reachable DB — do NOT call introspect_database. Instead:
+
+1. Read the attachment/pasted text and extract, per table:
+   exact table name, exact column names, SQL types, PK (incl. composite),
+   FKs/relationships, indexes, enum/allowed values, NOT NULL, defaults,
+   generated columns, and any comments carrying business rules.
+2. Build the SAME infrastructure_schema shape convert_to_infrastructure_schema()
+   produces (see Phase 0 step 3), setting `existing: true` on every table.
+   For RDS add connection{} + environment_variables{DB_CLUSTER_ARN,
+   DB_SECRET_ARN, DB_NAME} — ask the customer for the ARNs if the document
+   doesn't contain them, and use explicit `<REPLACE_ME>` placeholders if they
+   are not available yet, never invented values.
+3. Persist it with save_operation_spec so later phases read the same contract.
+4. ECHO BACK what you parsed as a table (table → columns → PK → FKs) and ask
+   the user to confirm BEFORE generating. Anything the document did not state
+   must be asked, not guessed — especially the lookup key used for caller
+   identification and enum value spellings.
+5. Then continue with Phase 1 exactly as in the scanned path.
+
+⚠️ Fidelity rule is identical: the document is the contract. Preserve the
+customer's spelling and casing of every identifier, character for character.
 ```
 
 **Phase 1: Infrastructure (API GW + Lambda ONLY)**

--- a/skills/aicc-builder-skill/resources/orchestrator/system_prompt.md
+++ b/skills/aicc-builder-skill/resources/orchestrator/system_prompt.md
@@ -335,20 +335,29 @@ into the conversation.
   🟡 Placeholder: TODO comment + skeleton code only (real API wired later).
 
 #### Database type (only if they have an existing DB)
-- DynamoDB (new) or an existing DynamoDB / RDS-Aurora MySQL / RDS-Aurora PostgreSQL?
-- Record `db_type` as one of: `dynamodb`, `rds_mysql`, `rds_postgresql`.
+- New DynamoDB, an existing DynamoDB, or an existing RDS/Aurora database?
+- **Every RDS and Aurora engine is supported**: PostgreSQL, MySQL, MariaDB,
+  SQL Server, Oracle and Db2 — on Aurora or on plain RDS.
+- Record `db_type` as one of: `dynamodb`, `rds_postgresql`, `rds_mysql`,
+  `rds_mariadb`, `rds_sqlserver`, `rds_oracle`, `rds_db2`,
+  `aurora_postgresql`, `aurora_mysql` — or just `rds` when you don't know the
+  engine and want it auto-detected.
 - Always capture `region` (the DB's region, which may differ from this app's).
 - **DynamoDB**: capture `table_name` — several tables may be given as one
   comma-separated string; the scan handles them in a single call.
-- **RDS/Aurora**: introspection goes through the RDS Data API, so you MUST
-  collect all three and store them under exactly these keys:
-  `rds_cluster_arn`, `rds_secret_arn`, `rds_database_name`.
-  Tell the user where to find them if they ask: cluster ARN from the RDS
-  console/`describe-db-clusters`, secret ARN from Secrets Manager (the
-  cluster's master-user secret), database name = the schema they query.
-  The Data API exists only on Aurora Serverless v2/provisioned clusters with
-  the HTTP endpoint enabled — if they are on a plain RDS instance, say so and
-  offer the document path below instead.
+- **RDS/Aurora — ask for the DB instance or cluster identifier first.** With
+  `rds_instance_identifier` alone the scan resolves the engine, endpoint, port,
+  master-user secret and connection method by itself, so that is the ONLY thing
+  you normally need. Store it under exactly that key, plus
+  `rds_database_name` when the instance has no default database (SQL Server and
+  Oracle usually don't).
+  - Only ask for `rds_cluster_arn` / `rds_secret_arn` / `rds_database_name`
+    explicitly if the customer cannot share an identifier.
+  - Connection method is automatic: Aurora with the Data API (HTTP endpoint)
+    enabled goes over the Data API with no network path needed; every other
+    engine connects with a driver, which requires the runtime to reach the
+    endpoint (security group + subnet route). If a scan comes back
+    CONNECTION_FAILED, relay that reachability requirement rather than retrying.
 - **No reachable DB?** They can instead paste or upload the schema (DDL dump,
   ERD image, data dictionary, sample JSON). Accept it and follow
   "Phase 0-ALT: Schema supplied as a DOCUMENT" — do not ask for ARNs just to
@@ -855,7 +864,8 @@ When collected_data includes `existing_table == true`:
 
 **Phase 0: Schema Introspection (scan the existing DB)**
 ```
-1. Call introspect_database — pass EVERY parameter the engine needs:
+1. Call introspect_database. Every RDS and Aurora engine is supported
+   (PostgreSQL, MySQL, MariaDB, SQL Server, Oracle, Db2) plus DynamoDB.
 
    # DynamoDB (table_name may be a comma-separated list to scan several at once)
    introspect_database(
@@ -864,27 +874,42 @@ When collected_data includes `existing_table == true`:
        region=collected_data["region"]
    )
 
-   # RDS / Aurora — the three connection values are MANDATORY.
-   # Omitting them returns MISSING_PARAMETERS; there is no default.
+   # RDS / Aurora — PREFERRED form. The identifier is enough: engine, endpoint,
+   # port, credentials secret and connection method are all resolved from RDS.
    introspect_database(
-       db_type=collected_data["db_type"],          # "rds_postgresql" | "rds_mysql"
+       db_type=collected_data.get("db_type", "rds"),   # or just "rds" to auto-detect
        region=collected_data["region"],
-       rds_cluster_arn=collected_data["rds_cluster_arn"],
+       rds_instance_identifier=collected_data["rds_instance_identifier"],
+       rds_database_name=collected_data.get("rds_database_name"),  # needed when
+                                            # the instance has no default DB
+       table_name=collected_data.get("table_name")     # omit to scan everything
+   )
+
+   # RDS / Aurora — fall back to explicit values only when no identifier is available
+   introspect_database(
+       db_type="aurora_postgresql",
+       region=collected_data["region"],
+       rds_cluster_arn=collected_data["rds_cluster_arn"],      # Data API path
        rds_secret_arn=collected_data["rds_secret_arn"],
        rds_database_name=collected_data["rds_database_name"],
-       table_name=collected_data.get("table_name")  # omit to scan the whole schema
    )
 
 2. CHECK THE RESULT BEFORE CONTINUING. If `success == false`, do NOT proceed to
    Phase 1 — relay `error` to the user verbatim and ask them to confirm the
    connection details. Common `error_code` values and what to tell the user:
-   - MISSING_PARAMETERS    → ask for the cluster ARN / secret ARN / database name
-   - DATA_API_NOT_ENABLED  → the Data API must be enabled; it only exists on
-                             Aurora clusters, not on plain RDS instances
-   - ACCESS_DENIED         → the runtime role lacks rds-data / secretsmanager /
-                             dynamodb:DescribeTable permission
-   - NO_TABLES_FOUND       → the error lists the tables that DO exist; ask which
-                             ones they meant
+   - MISSING_PARAMETERS    → ask for the instance/cluster identifier (or the
+                             cluster ARN + secret ARN + database name)
+   - TARGET_NOT_FOUND      → no such DB instance or cluster in that region
+   - DATA_API_NOT_ENABLED  → only relevant on Aurora; a driver connection is
+                             used instead, which needs network reachability
+   - CONNECTION_FAILED     → the endpoint is not reachable from the runtime;
+                             the security group must allow the port and the
+                             subnets need a route. Offer the document path.
+   - DRIVER_NOT_INSTALLED  → the engine's driver is missing from the image
+   - ACCESS_DENIED         → the runtime role lacks rds / rds-data /
+                             secretsmanager / dynamodb:DescribeTable permission
+   - NO_TABLES_FOUND       → the error lists the tables that DO exist, and names
+                             the schema/owner that was searched; ask which they meant
 
 3. Convert via convert_to_infrastructure_schema(). It handles DynamoDB
    (single or multiple tables) AND RDS/Aurora, and returns:
@@ -904,6 +929,16 @@ When collected_data includes `existing_table == true`:
    Column/table `description` values often carry business rules
    (e.g. "Auto-approve under 500,000 KRW") — feed those into the OperationSpec.
 
+4b. ⚠️ PERSIST THE CONVERTED SCHEMA VERBATIM — with the COMPLETE column list
+   for every table, exactly as convert_to_infrastructure_schema() returned it.
+   Do NOT hand-write an abbreviated summary listing only the columns you think
+   each operation needs. The deterministic SQL check compares generated SQL
+   identifiers against this stored schema: any column you omit becomes
+   invisible to the check, and a hallucinated column reference
+   (e.g. `order_items.product_name` when product_name lives on `products`)
+   then ships and fails at runtime with SQLState 42703. Completeness here is
+   what makes the gate work.
+
 5. Report the scan result to the user (in their language), e.g.:
    "✅ 스키마를 스캔했어요!
    - 테이블: {table_count}개 ({table_names})
@@ -911,6 +946,17 @@ When collected_data includes `existing_table == true`:
    - 인덱스/GSI: {index_list}
    - 관계: {relationship_count}개
    이 스키마를 기반으로 에셋을 생성할게요."
+
+6. ⚠️ When you later call save_operation_spec, ALWAYS fill `data_source` —
+   leaving it empty makes the spec render "Table: ?" and the reviewer cannot
+   cross-check the operation against the real schema.
+   - DynamoDB: db_type, table_name, partition_key, sort_key, gsi_indexes
+   - RDS/Aurora: db_type ("rds_postgresql"/"rds_mysql"), table_name (the
+     PRIMARY table the operation writes/reads), partition_key (its PK column),
+     database_name, lookup_column (the column used to identify the caller,
+     e.g. "customers.phone_number"), and related_tables (every other table the
+     operation joins/reads, in query order — e.g.
+     ["customers", "orders", "order_items"]).
 ```
 
 **Phase 0-ALT: Schema supplied as a DOCUMENT (no live DB to scan)**
@@ -1932,7 +1978,14 @@ DO NOT silently run a pipeline. Be conversational:
 ## AVAILABLE TOOLS
 
 ### Utility Tools
-- `introspect_database`: Connect to and analyze database schema
+- `introspect_database`: Read an existing database's schema — DynamoDB, or any
+  RDS/Aurora engine (PostgreSQL, MySQL, MariaDB, SQL Server, Oracle, Db2).
+  It is read-only and safe to call at ANY stage, not only during the interview:
+  re-run it mid-generation or during review to confirm a column name, a type, an
+  enum's allowed values or a foreign key before patching an asset, instead of
+  guessing from the conversation. Pass `rds_instance_identifier` and everything
+  else is resolved for you; pair it with `convert_to_infrastructure_schema` to
+  refresh the stored schema contract.
 - `save_operation_spec`: Save the complete specification for an operation
 - `get_operation_spec`: Retrieve saved operation specification
 - `list_operations`: List all saved operations

--- a/skills/aicc-builder-skill/resources/sub-agents/infrastructure_generator.md
+++ b/skills/aicc-builder-skill/resources/sub-agents/infrastructure_generator.md
@@ -706,6 +706,28 @@ Instead:
             - secretsmanager:GetSecretValue
           Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*'
   ```
+### When the engine has NO Data API (plain RDS, or Aurora with the endpoint off)
+
+RDS PostgreSQL, MySQL, MariaDB, SQL Server, Oracle and Db2 are reached with a
+driver, so the Lambdas need real networking. Emit ALL of the following or the
+functions time out on their first invocation:
+
+- `VpcConfig` on every DB-touching function, with at least two subnets in the
+  DB's VPC and a dedicated Lambda security group.
+- An `AWS::EC2::SecurityGroupIngress` allowing that Lambda SG to reach the DB
+  security group on the engine's port (5432/3306/1433/1521/50000).
+- ⚠️ A Secrets Manager interface VPC endpoint
+  (`AWS::EC2::VPCEndpoint`, `com.amazonaws.${AWS::Region}.secretsmanager`,
+  `VpcEndpointType: Interface`, `PrivateDnsEnabled: true`, with a security group
+  allowing 443 from the Lambda SG) — UNLESS the subnets are private with a NAT
+  gateway. A VPC-attached Lambda has no route to public AWS endpoints, so
+  `GetSecretValue` hangs and the function dies at the 30s timeout before it ever
+  queries the database. This was observed end-to-end in testing.
+- Environment variables `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_SECRET_ARN`
+  (no `DB_CLUSTER_ARN` — that is Data-API-only).
+- IAM: `secretsmanager:GetSecretValue` on the credentials secret, plus the
+  managed `AWSLambdaVPCAccessExecutionRole` for ENI management.
+
 - **Keep**: API Gateway, Lambda functions (placeholder), S3 bucket, API Key
 
 ### Schema Summary JSON for RDS mode:

--- a/skills/aicc-builder-skill/resources/sub-agents/infrastructure_generator.md
+++ b/skills/aicc-builder-skill/resources/sub-agents/infrastructure_generator.md
@@ -679,10 +679,14 @@ moves over time). Before emitting RDS-mode infrastructure:
 
 Instead:
 - **Skip**: DynamoDB Table, Sample Data Seeder Custom Resource
-- **Add**: Lambda environment variables for RDS connection:
-  - `RDS_CLUSTER_ARN`: from data_source.cluster_arn
-  - `RDS_SECRET_ARN`: from data_source.secret_arn
-  - `RDS_DATABASE_NAME`: from data_source.database_name
+- **Add**: Lambda environment variables for RDS connection.
+  ⚠️ These EXACT names are the cross-asset contract — the generated Lambda code
+  reads `os.environ["DB_CLUSTER_ARN"]`, `os.environ["DB_SECRET_ARN"]` and
+  `os.environ["DB_NAME"]`. Emitting any other name (e.g. `RDS_CLUSTER_ARN`)
+  makes every Lambda fail with KeyError at import time.
+  - `DB_CLUSTER_ARN`: from data_source.cluster_arn
+  - `DB_SECRET_ARN`: from data_source.secret_arn
+  - `DB_NAME`: from data_source.database_name
 - **Add**: IAM permissions for RDS Data API + Secrets Manager:
   ```yaml
   - PolicyName: RDSDataAPIAccess
@@ -714,9 +718,9 @@ Instead:
   "database_name": "production",
   "tables": [{"table_name": "reservations", "description": "from existing RDS"}],
   "environment_variables": {
-    "RDS_CLUSTER_ARN": "arn:aws:rds:...",
-    "RDS_SECRET_ARN": "arn:aws:secretsmanager:...",
-    "RDS_DATABASE_NAME": "production"
+    "DB_CLUSTER_ARN": "arn:aws:rds:...",
+    "DB_SECRET_ARN": "arn:aws:secretsmanager:...",
+    "DB_NAME": "production"
   }
 }
 ```

--- a/skills/aicc-builder-skill/resources/sub-agents/lambda_generator.md
+++ b/skills/aicc-builder-skill/resources/sub-agents/lambda_generator.md
@@ -1197,6 +1197,14 @@ Rules for RDS mode:
   keeps them as declared.
 - Respect `allowed_values` from the schema when writing enum comparisons and
   when validating input — an invalid enum value is a DB error, not a 404.
+  ⚠️ When `allowed_values_source` is `"observed"` the engine has no declared
+  enum (SQL Server, Oracle and Db2 never do) and the list is the set of values
+  actually present in the column. Copy those spellings CHARACTER FOR CHARACTER
+  into any validation set. Found in live testing: a handler hardcoded
+  `{"DAMAGE", "LOST"}` for a column whose real values are `DAMAGE`, `LOSS`,
+  `DELAY`, `WRONG_DELIVERY` — the guessed `LOST` rejected every valid request
+  and would have written a value the business never uses. Never shorten,
+  pluralize, translate or "correct" a value, and never drop one you were given.
 - Numeric/DECIMAL columns come back as strings in `stringValue`; cast with
   `Decimal(...)`/`int(...)` before arithmetic or comparison.
 - For paging/limits use `LIMIT`; never `SELECT *` on a large table in a
@@ -1205,6 +1213,40 @@ Rules for RDS mode:
   `rds-data:BatchExecuteStatement`, and `secretsmanager:GetSecretValue` on the
   credentials secret.
 - Keep the same dual-mode handler (Contact Flow + API Gateway) structure
+
+### Engines WITHOUT the Data API (plain RDS, or Aurora with the HTTP endpoint off)
+
+The Data API only exists on Aurora. When `access_method` in the schema is
+`<engine>-driver` rather than `rds-data-api` — i.e. RDS PostgreSQL, MySQL,
+MariaDB, SQL Server, Oracle or Db2 — the Lambda must open a real connection
+instead:
+
+- Driver per engine: `psycopg2` (PostgreSQL), `pymysql` (MySQL/MariaDB),
+  `pytds` (SQL Server), `oracledb` (Oracle), `ibm_db_dbi` (Db2). None ship in
+  the Lambda runtime, so note in the header comment that a layer or bundled
+  dependency is required.
+- Read credentials from Secrets Manager at cold start, never from plain env
+  vars: `DB_SECRET_ARN` holds the username/password, `DB_HOST`, `DB_PORT` and
+  `DB_NAME` locate the database. Cache the parsed secret in a module-level
+  variable so it is fetched once per container.
+- The function needs `VpcConfig` (subnets + a security group allowed inbound on
+  the DB port) because it talks TCP to the endpoint. State that requirement in
+  the handler docstring so whoever deploys it knows.
+- ⚠️ A VPC-attached Lambda has NO route to public AWS endpoints unless one is
+  provided, so `secretsmanager:GetSecretValue` hangs until the function times
+  out. Found in live testing: every invocation returned
+  `Task timed out after 30.00 seconds` before a single DB query ran. Say plainly
+  in the docstring that the deployment needs EITHER a Secrets Manager interface
+  VPC endpoint (`com.amazonaws.<region>.secretsmanager`, reachable from the
+  Lambda security group on 443) OR private subnets with a NAT gateway.
+- Use the driver's own parameter style — `%(name)s` for psycopg2/pymysql/pytds,
+  `:name` for oracledb, `?` for ibm_db — and still NEVER interpolate values.
+- Read columns by name from `cursor.description`, exactly as the Data API path
+  reads `columnMetadata`; never index rows positionally.
+- Close the cursor in a `finally` block and keep the connection module-level so
+  it is reused across invocations.
+- Required IAM: `secretsmanager:GetSecretValue` on the credentials secret (no
+  `rds-data:*` needed on this path).
 
 ## EXTERNAL API INTEGRATION PATTERNS
 

--- a/skills/aicc-builder-skill/resources/sub-agents/lambda_generator.md
+++ b/skills/aicc-builder-skill/resources/sub-agents/lambda_generator.md
@@ -1113,42 +1113,97 @@ def handler(event, context):
 
 ## RDS DATA API PATTERN
 
-When `db_type` is "rds-postgresql" or "rds-mysql", generate Lambda code using RDS Data API instead of DynamoDB.
-Use `boto3` `rds-data` client with Secrets Manager for credentials.
+When `db_type` is "rds_postgresql"/"rds-postgresql" or "rds_mysql"/"rds-mysql",
+generate Lambda code using the RDS Data API instead of DynamoDB.
+Use the `boto3` `rds-data` client with Secrets Manager for credentials.
 
 ```python
 import boto3, os, json, logging
+from decimal import Decimal
 
 logger = logging.getLogger()
+logger.setLevel(logging.INFO)
 rds_client = boto3.client("rds-data")
 
 CLUSTER_ARN = os.environ["DB_CLUSTER_ARN"]
 SECRET_ARN = os.environ["DB_SECRET_ARN"]
 DATABASE = os.environ["DB_NAME"]
 
+
 def execute_sql(sql, parameters=None):
+    '''Run a parameterized statement and return rows as dicts.'''
     params = {
         "resourceArn": CLUSTER_ARN,
         "secretArn": SECRET_ARN,
         "database": DATABASE,
         "sql": sql,
+        # REQUIRED: without this the response has no columnMetadata and rows
+        # can only be read by position, which silently breaks on schema change.
+        "includeResultMetadata": True,
     }
     if parameters:
         params["parameters"] = parameters
-    return rds_client.execute_statement(**params)
+    response = rds_client.execute_statement(**params)
+    return _rows_to_dicts(response)
 
-# Usage:
-# result = execute_sql(
-#     "SELECT * FROM customers WHERE mobile1 = :phone",
-#     parameters=[{"name": "phone", "value": {"stringValue": phone_number}}]
+
+def _rows_to_dicts(response):
+    '''Convert a Data API response into a list of {column_name: value} dicts.'''
+    columns = [c.get("label") or c.get("name") for c in response.get("columnMetadata", [])]
+    rows = []
+    for record in response.get("records", []):
+        row = {}
+        for i, field in enumerate(record):
+            name = columns[i] if i < len(columns) else f"col_{i}"
+            row[name] = _field_value(field)
+        rows.append(row)
+    return rows
+
+
+def _field_value(field):
+    if field.get("isNull"):
+        return None
+    for key in ("stringValue", "longValue", "doubleValue", "booleanValue"):
+        if key in field:
+            return field[key]
+    if "arrayValue" in field:
+        av = field["arrayValue"]
+        for key in ("stringValues", "longValues", "doubleValues", "booleanValues"):
+            if key in av:
+                return av[key]
+    return None
+
+
+# Usage — always reference columns by NAME, never by index:
+# rows = execute_sql(
+#     "SELECT order_number, status, total_amount FROM orders WHERE order_number = :order_number",
+#     parameters=[{"name": "order_number", "value": {"stringValue": order_number}}]
 # )
-# rows = result.get("records", [])
+# if not rows:
+#     return not_found_response()
+# order = rows[0]
+# status = order["status"]
 ```
 
 Rules for RDS mode:
 - Use parameterized queries (`:param_name`) — NEVER string concatenation
+  (SQL injection). Table/column names cannot be parameterized, so they must
+  come from the scanned schema, never from user input.
 - Environment variables: `DB_CLUSTER_ARN`, `DB_SECRET_ARN`, `DB_NAME`
-- Parse `records` array from response (each row is a list of typed values)
+- ALWAYS pass `includeResultMetadata=True` and read columns by name via the
+  `_rows_to_dicts` helper above. Never index `record[0]`, `record[1]`, …
+- Use the EXACT table and column names from the introspected/provided schema,
+  including case. PostgreSQL folds unquoted identifiers to lower case; MySQL
+  keeps them as declared.
+- Respect `allowed_values` from the schema when writing enum comparisons and
+  when validating input — an invalid enum value is a DB error, not a 404.
+- Numeric/DECIMAL columns come back as strings in `stringValue`; cast with
+  `Decimal(...)`/`int(...)` before arithmetic or comparison.
+- For paging/limits use `LIMIT`; never `SELECT *` on a large table in a
+  contact-center path — select the columns you need.
+- Required IAM on the Lambda role: `rds-data:ExecuteStatement`,
+  `rds-data:BatchExecuteStatement`, and `secretsmanager:GetSecretValue` on the
+  credentials secret.
 - Keep the same dual-mode handler (Contact Flow + API Gateway) structure
 
 ## EXTERNAL API INTEGRATION PATTERNS


### PR DESCRIPTION
## Summary

Point AICC Builder at a database you already run — **any RDS or Aurora engine**,
or DynamoDB — or hand it a schema document, and it generates Lambdas,
infrastructure and prompts against the real tables, columns and business rules.

### Engines

PostgreSQL, MySQL, MariaDB, SQL Server, Oracle and Db2, on Aurora or on plain
RDS, plus DynamoDB. The connection method is chosen automatically:

| Target | Method | Needs a network path? |
|---|---|---|
| Aurora with the Data API enabled | RDS Data API | No |
| Aurora without it, and all plain RDS engines | driver connection | Yes |

Drivers ship in the image (`psycopg2`, `pymysql`, `pytds`, `oracledb`).

A DB instance or cluster identifier is the only required argument — engine,
endpoint, port, master-user secret and Data API availability are resolved from
RDS. If the caller names the wrong engine, what RDS reports wins.

### Schema discovery

Per-dialect catalog queries return one shape regardless of engine: tables and
views, exact column names and SQL types, single and **composite** primary keys,
secondary indexes, **foreign keys plus reverse relationships**, allowed values,
check constraints, generated columns, comments, real row counts and sample rows.
DynamoDB gains **local secondary indexes**, projection detail, nested
map/list/set typing and non-key attribute discovery.

SQL Server, Oracle and Db2 have no ENUM type, so enum-like columns report the
**distinct values actually present**, marked `allowed_values_source: "observed"`.
Without it the generator guesses — in testing it validated against `LOST` for a
column whose real values are `DAMAGE`, `LOSS`, `DELAY`, `WRONG_DELIVERY`.

### Choosing what to scan

`tables_only=True` returns a cheap inventory (names, row counts, comments) of an
unfamiliar schema; `table_name="a,b,c"` then scans just those. Names match
case-insensitively, so `orders` finds Oracle's `ORDERS`.

### Schema fidelity

Column comments become business rules in the OperationSpec, so a documented
threshold is enforced by the generated Lambda. Sampled values become data
conventions, so a phone stored as `821012345678` keeps that format through to
the Contact Flow. A **schema-as-document** path builds the same contract from a
DDL dump, ERD or data dictionary when no database is reachable, echoing back
every parsed identifier for confirmation.

### Generated code

Data API path: `includeResultMetadata=True` with rows mapped to dicts so columns
are read **by name**. Driver path: credentials from Secrets Manager at cold
start, the driver's own parameter style, columns read from `cursor.description`,
and the `VpcConfig` + security-group ingress + Secrets Manager VPC endpoint the
function needs. That endpoint is easy to miss and fails opaquely — a VPC-attached
Lambda has no route to public AWS endpoints, so `GetSecretValue` hangs until the
function times out.

### New deterministic gates

| Gate | Catches |
|---|---|
| SQL identifier check | a column written onto the wrong table |
| SQL type-cast check | a cast to a type the schema does not define |
| Required-column check | an `INSERT` omitting a `NOT NULL` column with no default |
| Parameter type-binding check | a `bigint` key bound as a string (`operator does not exist: bigint = text`) |
| RDS Data API contract check | env var drift, missing `includeResultMetadata`, positional row access, interpolated SQL |

Merge-time normalization unifies RDS environment variables on
`DB_CLUSTER_ARN` / `DB_SECRET_ARN` / `DB_NAME` and aliases an inline Lambda
handler whose declared name is absent from its code.

### Infrastructure

The ECS task role gains read-only `rds:DescribeDBInstances` /
`DescribeDBClusters` for discovery and `dynamodb:DescribeTable` / `Scan` for
DynamoDB introspection.

### Docs

`docs/existing-database.md` covers both paths, per-engine notes, the deployment
requirements for driver-based engines, and the gate/engine verification runs.
`scripts/verify_param_type_gate.py` reproduces the type-binding gate check,
optionally cross-checking its verdict against a live Aurora cluster.
