### PR TITLE
fix: unqualified SQL column check, plus DB access docs and least-privilege grants

### DIFF
--- a/backend/ecs/src/tools/validate_consistency.py
+++ b/backend/ecs/src/tools/validate_consistency.py
@@ -606,8 +606,45 @@ def _schema_column_index(schema: dict) -> Dict[str, set]:
     return index
 
 
+_SQL_SELECT_LIST_RE = re.compile(r'\bSELECT\b(?P<list>.*?)\bFROM\b', re.I | re.S)
+_SQL_FROM_TARGETS_RE = re.compile(r'\b(?:FROM|JOIN)\s+"?`?\[?([A-Za-z_]\w*)\]?`?"?', re.I)
+
+
+def _unqualified_columns(sql: str) -> list:
+    """Column identifiers used without a table qualifier.
+
+    Only the SELECT list and the INSERT column list are read — not the whole
+    statement — so SQL keywords, function names and literals are not mistaken
+    for columns.
+    """
+    names = []
+    m = _SQL_SELECT_LIST_RE.search(sql)
+    if m:
+        for item in m.group("list").split(","):
+            item = re.split(r'\s+AS\s+|\s+', item.strip(), flags=re.I)[0].strip()
+            if "." in item or "(" in item or "*" in item:
+                continue          # qualified, a function call, or SELECT *
+            ident = item.strip('"`[]')
+            if re.fullmatch(r'[A-Za-z_]\w*', ident) and ident.lower() not in _SQL_RESERVED:
+                names.append(ident)
+    for _, col_list, _ in _PARAM_INSERT_RE.findall(sql):
+        for c in col_list.split(","):
+            ident = c.strip().strip('"`[]')
+            if re.fullmatch(r'[A-Za-z_]\w*', ident) and ident.lower() not in _SQL_RESERVED:
+                names.append(ident)
+    return names
+
+
 def _check_sql_identifiers(op_id: str, code: str, col_index: Dict[str, set]) -> list:
-    """Report qualified SQL columns that belong to a different table."""
+    """Report SQL columns that belong to a different table than the one used.
+
+    Covers both `alias.column` references and unqualified columns — the latter
+    only when the statement touches exactly one known table, which makes the
+    owning table unambiguous. Observed live: a handler selected
+    `product_name` straight out of `order_items` (it lives on `products`) and
+    inserted `created_at` into `returns` (that column is `requested_at`); with
+    no alias in the SQL, a qualified-only check saw neither.
+    """
     issues = []
     if not col_index:
         return issues
@@ -615,6 +652,23 @@ def _check_sql_identifiers(op_id: str, code: str, col_index: Dict[str, set]) -> 
     for tbl, cols in col_index.items():
         for c in cols:
             owner.setdefault(c, set()).add(tbl)
+
+    def report(qualifier, column, table):
+        if column in col_index.get(table, set()):
+            return
+        real_owners = owner.get(column, set()) - {table}
+        if not real_owners:
+            return          # column not described anywhere — don't guess
+        shown = f"{qualifier}.{column}" if qualifier else column
+        issues.append({
+            "operation_id": op_id, "field": shown,
+            "asset_type": "sql_schema_mismatch",
+            "issue": f"Lambda '{op_id}' SQL references `{shown}` against `{table}`, "
+                     f"but `{column}` belongs to {sorted(real_owners)} — not to "
+                     f"`{table}`. This fails at runtime with 'column does not exist' "
+                     f"(SQLState 42703). Join through to {sorted(real_owners)[0]} or "
+                     f"use the correct column from `{table}`.",
+        })
 
     for sql in _extract_sql_statements(code):
         aliases = {}
@@ -624,28 +678,19 @@ def _check_sql_identifiers(op_id: str, code: str, col_index: Dict[str, set]) -> 
             if tbl in col_index:
                 aliases[alias] = tbl
                 aliases[tbl] = tbl
-        if not aliases:
-            continue
+
         for qualifier, column in _SQL_QUALIFIED_RE.findall(sql):
             table = aliases.get(qualifier)
-            if not table or column.lower() in _SQL_RESERVED:
-                continue
-            known = col_index.get(table, set())
-            if column in known:
-                continue
-            real_owners = owner.get(column, set()) - {table}
-            if not real_owners:
-                continue  # column simply not listed for this table — don't guess
-            issues.append({
-                "operation_id": op_id, "field": f"{qualifier}.{column}",
-                "asset_type": "sql_schema_mismatch",
-                "issue": f"Lambda '{op_id}' SQL references `{qualifier}.{column}` "
-                         f"(alias of `{table}`), but `{column}` belongs to "
-                         f"{sorted(real_owners)} — not to `{table}`. This fails at "
-                         f"runtime with 'column does not exist' (SQLState 42703). "
-                         f"Join through to {sorted(real_owners)[0]} or use the "
-                         f"correct column from `{table}`.",
-            })
+            if table and column.lower() not in _SQL_RESERVED:
+                report(qualifier, column, table)
+
+        targets = {t for t in _SQL_FROM_TARGETS_RE.findall(sql) if t in col_index}
+        targets |= {t for t, _, _ in _PARAM_INSERT_RE.findall(sql) if t in col_index}
+        if len(targets) == 1:
+            only = next(iter(targets))
+            for column in _unqualified_columns(sql):
+                report(None, column, only)
+
     return issues
 
 

--- a/docs/existing-database.md
+++ b/docs/existing-database.md
@@ -12,6 +12,41 @@ place: a schema contract that every downstream generator reads.
 Supported: **DynamoDB**, and **every RDS and Aurora engine** — PostgreSQL,
 MySQL, MariaDB, SQL Server, Oracle and Db2.
 
+```mermaid
+flowchart LR
+    subgraph IN["Two ways in"]
+        DB[("Your database<br/>RDS · Aurora · DynamoDB")]
+        DOC["Schema document<br/>DDL · ERD · data dictionary"]
+    end
+
+    DB -->|introspect_database<br/>read-only| CONTRACT
+    DOC -->|parsed + echoed back<br/>for confirmation| CONTRACT
+
+    CONTRACT["<b>Schema contract</b><br/>exact columns · keys · FKs<br/>allowed values · comments<br/>sampled value formats"]
+
+    CONTRACT --> SPEC["OperationSpec<br/>business rules from comments"]
+    SPEC --> GEN
+
+    subgraph GEN["Generated assets"]
+        L["Lambda handlers"]
+        I["CloudFormation"]
+        P["AI prompt"]
+        F["Contact Flow"]
+    end
+
+    GEN --> GATE{"Deterministic<br/>gates"}
+    GATE -->|mismatch| SPEC
+    GATE -->|clean| OUT["Deployable bundle"]
+
+    style CONTRACT fill:#e8f0fe,stroke:#4285f4,stroke-width:2px
+    style GATE fill:#fff4e5,stroke:#f59e0b,stroke-width:2px
+    style OUT fill:#e6f4ea,stroke:#34a853,stroke-width:2px
+```
+
+The contract is the single point every generator reads from. Nothing downstream
+invents an identifier that is not in it, and the gates check the generated SQL
+back against it before anything ships.
+
 ---
 
 ## 1. Live scan
@@ -37,6 +72,27 @@ introspect_database(
 ```
 
 ### Connection method (chosen automatically)
+
+```mermaid
+flowchart TD
+    ID["rds_instance_identifier"] --> DESC["rds:DescribeDBInstances<br/>rds:DescribeDBClusters"]
+    DESC --> RESOLVED["engine · endpoint · port<br/>master-user secret"]
+    RESOLVED --> Q{"Aurora, and the<br/>HTTP endpoint enabled?"}
+
+    Q -->|yes| API["<b>RDS Data API</b><br/>HTTPS · no VPC needed"]
+    Q -->|no| DRV["<b>Driver connection</b><br/>needs TCP reachability"]
+
+    API --> PG1["Aurora PostgreSQL<br/>Aurora MySQL"]
+    DRV --> PG2["psycopg2 · PostgreSQL"]
+    DRV --> MY2["pymysql · MySQL, MariaDB"]
+    DRV --> MS2["pytds · SQL Server"]
+    DRV --> OR2["oracledb · Oracle"]
+    DRV --> DB2["ibm_db · Db2"]
+
+    style API fill:#e6f4ea,stroke:#34a853,stroke-width:2px
+    style DRV fill:#fce8e6,stroke:#ea4335,stroke-width:2px
+    style Q fill:#fff4e5,stroke:#f59e0b
+```
 
 | Target | Method | Needs a network path? |
 |---|---|---|
@@ -161,6 +217,35 @@ The builder itself never touches your database at runtime, and the generated
 Lambdas never call the discovery APIs. Neither principal needs the other's
 permissions.
 
+```mermaid
+sequenceDiagram
+    autonumber
+    actor SA as SA / customer
+    participant B as AICC Builder<br/>(ECS task role)
+    participant SM as Secrets Manager
+    participant DB as Your database
+    participant L as Generated Lambda<br/>(its own role)
+
+    rect rgba(66,133,244,0.08)
+        note over SA,DB: A. Scan — during the interview, read-only
+        SA->>B: "here's my DB identifier"
+        B->>B: rds:DescribeDB* → engine, endpoint, secret
+        B->>SM: GetSecretValue
+        B->>DB: catalog SELECTs · COUNT(*) · 5-row sample · SELECT DISTINCT
+        DB-->>B: schema + example values
+        B-->>SA: schema summary, confirm before generating
+    end
+
+    rect rgba(52,168,83,0.08)
+        note over L,DB: B. Runtime — on every call, after deployment
+        L->>SM: GetSecretValue (cached per container)
+        L->>DB: the operation's parameterized query
+        DB-->>L: rows, read by column name
+    end
+
+    note over B,L: the builder never runs at call time —<br/>the Lambda never calls the discovery APIs
+```
+
 ### A. Scan-time — the AICC Builder task role
 
 **This is read-only by construction.** The scan issues catalog `SELECT`s
@@ -274,6 +359,34 @@ of being rewritten to `+8210...`), but it means:
 
 The scan decides which of two runtime patterns gets generated, and says so in
 `access_method`.
+
+```mermaid
+flowchart LR
+    CALLER(["Caller"]) --> CF["Contact Flow"]
+    CF --> AGENT["Q in Connect<br/>AI agent"]
+    AGENT -->|tool call| LAM["Generated Lambda"]
+
+    LAM --> M{"access_method"}
+
+    M -->|rds-data-api| A1["rds-data:ExecuteStatement<br/>over HTTPS"]
+    A1 --> A2["includeResultMetadata=True<br/>rows → dicts by column name"]
+    A2 --> TARGET
+
+    M -->|engine-driver| D1["Secrets Manager<br/>credentials at cold start"]
+    D1 --> D2["driver connect over TCP<br/>inside the VPC"]
+    D2 --> D3["cursor.description<br/>rows → dicts by column name"]
+    D3 --> TARGET
+
+    TARGET[("Your existing tables")]
+
+    style A1 fill:#e6f4ea,stroke:#34a853
+    style D2 fill:#fce8e6,stroke:#ea4335
+    style M fill:#fff4e5,stroke:#f59e0b
+    style TARGET fill:#e8f0fe,stroke:#4285f4,stroke-width:2px
+```
+
+Both paths land on the same discipline: parameterized queries, columns read by
+name, and identifiers taken from the scanned schema.
 
 ### Data API pattern — `access_method: "rds-data-api"`
 

--- a/docs/existing-database.md
+++ b/docs/existing-database.md
@@ -99,10 +99,9 @@ DynamoDB takes the same comma-separated form via `dynamodb_table_name`.
 
 ### Requirements
 
-The runtime role needs `rds:DescribeDBInstances` / `DescribeDBClusters` for
-discovery, `secretsmanager:GetSecretValue` for credentials, plus
-`rds-data:ExecuteStatement` on the Data API path, and
-`dynamodb:DescribeTable` + `dynamodb:Scan` for DynamoDB.
+Two different principals touch your database, at two different times. They need
+different permissions and it is worth keeping them separate when a security team
+reviews this — see [§4 Access and permissions](#4-access-and-permissions).
 
 A scan that finds nothing returns an error listing the tables that *do* exist
 and the schema/owner it searched. Failures are distinguished so they are
@@ -148,7 +147,201 @@ values actually present. Without that the generator guesses: in testing it wrote
 
 ---
 
-## 4. Deploying against a driver-based engine
+## 4. Access and permissions
+
+Two principals touch the database, at two different times. Keeping them apart is
+what makes a least-privilege review tractable.
+
+| | Who | When | What it does |
+|---|---|---|---|
+| **A. Scan** | the AICC Builder ECS task role | during the interview | reads schema metadata + samples a few rows |
+| **B. Runtime** | each generated Lambda's own role | on every call | runs the operation's queries |
+
+The builder itself never touches your database at runtime, and the generated
+Lambdas never call the discovery APIs. Neither principal needs the other's
+permissions.
+
+### A. Scan-time — the AICC Builder task role
+
+**This is read-only by construction.** The scan issues catalog `SELECT`s
+(`information_schema`, `pg_catalog`, `sys.*`, `user_tab_cols`, `SYSCAT.*`), a
+`SELECT COUNT(*)`, a `SELECT * ... LIMIT 5` per table, and `SELECT DISTINCT` on
+enum-like columns. It issues no `INSERT`, `UPDATE`, `DELETE` or DDL of any kind.
+For DynamoDB it calls `DescribeTable` and a 25-item `Scan`.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "ResolveTheTarget",
+      "Effect": "Allow",
+      "Action": [
+        "rds:DescribeDBInstances",
+        "rds:DescribeDBClusters"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ReadCredentials",
+      "Effect": "Allow",
+      "Action": "secretsmanager:GetSecretValue",
+      "Resource": "arn:aws:secretsmanager:REGION:ACCOUNT:secret:rds!cluster-EXAMPLE-*"
+    },
+    {
+      "Sid": "QueryOverDataApi",
+      "Effect": "Allow",
+      "Action": "rds-data:ExecuteStatement",
+      "Resource": "arn:aws:rds:REGION:ACCOUNT:cluster:YOUR-CLUSTER"
+    },
+    {
+      "Sid": "IntrospectDynamoDb",
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:DescribeTable",
+        "dynamodb:Scan"
+      ],
+      "Resource": "arn:aws:dynamodb:REGION:ACCOUNT:table/YOUR-TABLE"
+    }
+  ]
+}
+```
+
+`rds:Describe*` cannot be resource-scoped by AWS, which is why it is `"*"`.
+Everything else should be pinned to the specific cluster, secret and tables you
+are willing to expose. Drop the statements you do not need — the DynamoDB block
+is unnecessary for an RDS-only engagement and vice versa.
+
+On the driver path there is no `rds-data` call at all; the task instead needs
+TCP reachability to the endpoint (security group + subnet route), which is a
+network permission rather than an IAM one.
+
+**If you cannot grant even read access**, use the schema-as-document path in §2.
+Nothing connects to the database and no IAM change is required.
+
+### B. Runtime — the generated Lambda's role
+
+The generated CloudFormation creates one role per function. What it grants
+depends on which connection method the schema was read with.
+
+Data API path (Aurora with the HTTP endpoint enabled):
+
+```yaml
+- Effect: Allow
+  Action:
+    - rds-data:ExecuteStatement
+    - rds-data:BatchExecuteStatement
+  Resource: <the cluster ARN from the scan>
+- Effect: Allow
+  Action: secretsmanager:GetSecretValue
+  Resource: <the credentials secret ARN>
+```
+
+Driver path (plain RDS, or Aurora without the HTTP endpoint):
+
+```yaml
+- Effect: Allow
+  Action: secretsmanager:GetSecretValue
+  Resource: <the credentials secret ARN>
+# plus the managed AWSLambdaVPCAccessExecutionRole for ENI management
+```
+
+No `rds-data` permission is needed on the driver path. Both are scoped to the
+one cluster and the one secret the scan resolved — not `"*"`.
+
+### Data handling — what the scan reads out of your tables
+
+Worth flagging explicitly, because it is easy to miss: the scan does not only
+read metadata. To get value formats right it samples **up to 5 rows per table**
+and the **distinct values of enum-like columns**, and those sampled values are
+carried into the generated assets — the OperationSpec's data conventions, the AI
+prompt's examples, and sometimes a comment in the Lambda.
+
+That is deliberate (it is how a phone stored as `821012345678` survives instead
+of being rewritten to `+8210...`), but it means:
+
+- Run the scan against a **non-production copy** when the tables contain real
+  personal data, or point it at a schema-only replica.
+- Set `include_sample_rows=False` to skip row sampling entirely. You still get
+  every table, column, key, index, foreign key and comment — only the example
+  values and the observed enum values are lost.
+- Review the generated AI prompt and OperationSpec before deploying, the same as
+  any other generated asset.
+
+---
+
+## 5. How the generated assets query the database
+
+The scan decides which of two runtime patterns gets generated, and says so in
+`access_method`.
+
+### Data API pattern — `access_method: "rds-data-api"`
+
+No VPC, no driver, no connection pooling. The handler calls `rds-data` over
+HTTPS with the cluster ARN and secret ARN it was given as environment variables.
+
+```python
+CLUSTER_ARN = os.environ["DB_CLUSTER_ARN"]
+SECRET_ARN  = os.environ["DB_SECRET_ARN"]
+DATABASE    = os.environ["DB_NAME"]
+
+response = rds_client.execute_statement(
+    resourceArn=CLUSTER_ARN, secretArn=SECRET_ARN, database=DATABASE,
+    sql="SELECT order_number, status FROM orders WHERE order_number = :orderNumber",
+    parameters=[{"name": "orderNumber", "value": {"stringValue": order_number}}],
+    includeResultMetadata=True,          # required — see below
+)
+```
+
+`includeResultMetadata=True` is not optional. Without it the response carries no
+`columnMetadata`, rows can only be read by position, and the handler silently
+returns the wrong column the moment someone adds a column to the table. With it,
+rows are mapped to dicts and read by name. A deterministic gate rejects any
+generated handler that omits it.
+
+Those three environment variable names are a hard contract: the handler reads
+exactly `DB_CLUSTER_ARN` / `DB_SECRET_ARN` / `DB_NAME`, and the merge step
+renames any fragment that drifted (e.g. `RDS_CLUSTER_ARN`) so a function cannot
+ship with a `KeyError` on cold start.
+
+### Driver pattern — `access_method: "<engine>-driver"`
+
+For every other engine the handler opens a real connection.
+
+```python
+secret = json.loads(sm.get_secret_value(SecretId=os.environ["DB_SECRET_ARN"])["SecretString"])
+conn = pytds.connect(server=os.environ["DB_HOST"], port=int(os.environ["DB_PORT"]),
+                     user=secret["username"], password=secret["password"],
+                     database=os.environ["DB_NAME"])
+```
+
+- Credentials come from Secrets Manager at cold start and are cached in a
+  module-level variable — never passed as plaintext environment variables.
+- Environment variables are `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_SECRET_ARN`
+  (no `DB_CLUSTER_ARN` — that is Data-API-only).
+- Columns are read from `cursor.description`, the same by-name discipline as the
+  Data API path.
+- The connection is module-level so it is reused across invocations.
+- Deployment needs `VpcConfig`, a security-group ingress on the engine's port,
+  and a Secrets Manager VPC endpoint — see §6.
+
+### Query discipline, both paths
+
+Applies regardless of engine, and each item is enforced by a gate rather than
+left to the model:
+
+| Rule | Why |
+|---|---|
+| Parameterized queries only (`:name`, `%(name)s`, `?`) | SQL injection. Table and column names come from the scanned schema, never from caller input |
+| Parameters bound with the column's own type | PostgreSQL rejects `bigint = text` outright; MySQL coerces silently and stops using the index |
+| Columns read by name | a positional read returns the wrong value after any schema change |
+| Exact identifiers from the scan | a column written onto the wrong table fails with SQLState 42703 |
+| `allowed_values` honoured verbatim | an invalid enum value is a database error, not a 404 |
+| `DECIMAL` cast before arithmetic | the Data API returns numerics as strings |
+
+---
+
+## 6. Deploying against a driver-based engine
 
 On the Data API path the generated Lambdas need no networking. On the driver
 path (plain RDS, or Aurora with the HTTP endpoint off) they need three things,
@@ -169,7 +362,7 @@ its timeout before running a single query. In testing every invocation returned
 
 ---
 
-## 5. Validation gates
+## 7. Validation gates
 
 A correct schema in context is not sufficient — a language model will still
 write a column onto the wrong table. These checks run deterministically in
@@ -197,7 +390,7 @@ they arise from independently generated fragments disagreeing:
 
 ---
 
-## 6. Verifying the gates
+## 8. Verifying the gates
 
 `scripts/verify_param_type_gate.py` exercises the parameter type-binding gate
 against a synthetic matrix, against real generated handlers, and — with
@@ -289,7 +482,7 @@ are plain `VARCHAR` columns rather than enum types, `returns.quantity` is
 
 ---
 
-## 7. Engine coverage
+## 9. Engine coverage
 
 `introspect_database` is exercised against a live instance of every engine the
 account can host, over both connection methods, plus the table-selection modes

--- a/infrastructure/lib/ecs-stack.ts
+++ b/infrastructure/lib/ecs-stack.ts
@@ -177,18 +177,15 @@ export class EcsStack extends cdk.Stack {
     );
 
     // DynamoDB read-only introspection of the customer's EXISTING tables
-    // (introspect_database tool). Read-only on purpose: the tool only needs to
-    // describe the schema and sample a few items — it must never mutate
-    // customer data.
+    // (introspect_database tool). Exactly the two calls the tool makes —
+    // DescribeTable for the schema and a capped Scan to sample attributes.
+    // Read-only on purpose: introspection must never mutate customer data.
     taskRole.addToPolicy(
       new iam.PolicyStatement({
         sid: "DynamoDbIntrospectionReadOnly",
         actions: [
           "dynamodb:DescribeTable",
-          "dynamodb:ListTables",
           "dynamodb:Scan",
-          "dynamodb:Query",
-          "dynamodb:GetItem",
         ],
         resources: ["*"],
       })
@@ -218,14 +215,14 @@ export class EcsStack extends cdk.Stack {
     // RDS discovery for DB introspection. introspect_database resolves the
     // engine, endpoint, port and master-user secret from a DB instance or
     // cluster identifier, so it can pick the Data API or a driver connection
-    // without the operator supplying any of it. Read-only.
+    // without the operator supplying any of it. Read-only, and rds:Describe*
+    // cannot be resource-scoped by AWS.
     taskRole.addToPolicy(
       new iam.PolicyStatement({
         sid: "RdsDiscoveryReadOnly",
         actions: [
           "rds:DescribeDBInstances",
           "rds:DescribeDBClusters",
-          "rds:DescribeDBClusterEndpoints",
         ],
         resources: ["*"],
       })


### PR DESCRIPTION
Follow-up to #37.

### The gate fix

The SQL identifier gate only inspected `alias.column` references, so a statement
written without an alias was never checked. Against a scanned schema that let two
runtime failures through:

- `SELECT ... product_name ... FROM order_items` — `product_name` lives on `products`
- `INSERT INTO returns (..., created_at)` — the column is `requested_at`

Both fail with `column ... does not exist` (SQLState 42703) on the first call.

Unqualified columns are now resolved when the statement touches exactly one known
table, which makes the owning table unambiguous. Only the SELECT list and the
INSERT column list are read, so keywords and function calls are not mistaken for
columns, and a column the schema does not describe is still left alone rather than
guessed at.

Verified: both defects are reported, a bundle with no schema mismatches stays
clean, and the parameter type-binding matrix still passes 13/13.

### Access documentation

Customers deploying into their own account ask what this touches and what it
needs, and the answer was four lines that conflated two different principals.
`docs/existing-database.md` now separates them:

| | Who | When | What it does |
|---|---|---|---|
| Scan | the builder's ECS task role | during the interview | reads schema metadata, samples a few rows |
| Runtime | each generated Lambda's own role | on every call | runs the operation's queries |

Neither needs the other's permissions. Includes a scoped example policy, notes
that `rds:Describe*` cannot be resource-scoped, and states plainly that the scan
issues only catalog `SELECT`s, `COUNT(*)`, a 5-row sample and `SELECT DISTINCT` —
no writes, no DDL.

Also documents what the scan reads *out of* the tables: sampled values are carried
into the generated assets on purpose, so a phone stored as `821012345678` survives
instead of being rewritten, but that is a data-handling decision the reader has to
be able to make — run against a non-production copy, or pass
`include_sample_rows=False` to keep the schema and drop the examples.

A new section covers how the generated assets actually query at runtime: the Data
API and driver patterns, the environment-variable contract, why
`includeResultMetadata` is required, where credentials come from, and the query
discipline each gate enforces.

### Least privilege

Narrows the introspection grants to the calls the tool actually makes —
`dynamodb:DescribeTable` + `Scan`, and `rds:DescribeDBInstances` +
`DescribeDBClusters`. `ListTables`, `Query`, `GetItem` and
`DescribeDBClusterEndpoints` were granted but never called. Verified both
discovery paths still resolve after the change.

### Diagrams

Four mermaid diagrams, since the useful parts here are structural: the two ways a
schema gets in and how they converge on one contract, how the connection method is
chosen per engine, who touches the database and when, and the runtime query path
for both patterns. All validated against the mermaid parser.
