### PR TITLE
fix: read MySQL check constraints, tighten the SQL column gate

### DIFF
--- a/backend/ecs/src/tools/db_introspector.py
+++ b/backend/ecs/src/tools/db_introspector.py
@@ -485,6 +485,21 @@ _MYSQL_QUERIES = {
         WHERE TABLE_SCHEMA = :database AND REFERENCED_TABLE_NAME IS NOT NULL
         ORDER BY TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION
     """,
+    # CHECK constraints. MySQL exposes these from 8.0.16 and MariaDB from 10.2;
+    # the join onto TABLE_CONSTRAINTS is what supplies the table name, which
+    # CHECK_CONSTRAINTS itself does not carry. Older servers have no such view,
+    # so the caller tolerates this query failing.
+    "checks": """
+        SELECT tc.TABLE_NAME AS table_name,
+               cc.CONSTRAINT_NAME AS constraint_name,
+               cc.CHECK_CLAUSE AS definition
+        FROM INFORMATION_SCHEMA.CHECK_CONSTRAINTS cc
+        JOIN INFORMATION_SCHEMA.TABLE_CONSTRAINTS tc
+          ON tc.CONSTRAINT_NAME = cc.CONSTRAINT_NAME
+         AND tc.CONSTRAINT_SCHEMA = cc.CONSTRAINT_SCHEMA
+        WHERE cc.CONSTRAINT_SCHEMA = :database
+        ORDER BY tc.TABLE_NAME, cc.CONSTRAINT_NAME
+    """,
 }
 
 _POSTGRES_QUERIES = {
@@ -1395,7 +1410,6 @@ def _introspect_sql(
         foreign_keys = run(queries["foreign_keys"])
         primary_keys = [] if family == "mysql" else run(queries["primary_keys"])
         enums = _group_enums(run(queries["enums"])) if family == "postgresql" else {}
-        checks = run(queries["checks"]) if "checks" in queries else []
     except ClientError as e:
         close()
         return {"success": False, **_explain_rds_error(e, db_type, target.get("cluster_arn"), region)}
@@ -1407,6 +1421,16 @@ def _introspect_sql(
             "error_code": "QUERY_FAILED",
             "db_type": db_type,
         }
+
+    # CHECK constraints are best-effort: MySQL only exposes them from 8.0.16 and
+    # MariaDB from 10.2, so on an older server the view simply does not exist.
+    # A missing view must not fail the whole scan.
+    checks = []
+    if "checks" in queries:
+        try:
+            checks = run(queries["checks"])
+        except Exception:
+            checks = []
 
     is_mysql = family == "mysql"
     selected_set = set(selected)
@@ -1557,7 +1581,7 @@ def _introspect_sql(
                 "referenced_columns": fk["referenced_columns"],
             })
 
-    # ---- check constraints (PostgreSQL)
+    # ---- check constraints (PostgreSQL, MySQL 8.0.16+/MariaDB 10.2+)
     for row in checks:
         tname = row.get("TABLE_NAME")
         if tname in table_schemas:

--- a/backend/ecs/src/tools/validate_consistency.py
+++ b/backend/ecs/src/tools/validate_consistency.py
@@ -608,14 +608,21 @@ def _schema_column_index(schema: dict) -> Dict[str, set]:
 
 _SQL_SELECT_LIST_RE = re.compile(r'\bSELECT\b(?P<list>.*?)\bFROM\b', re.I | re.S)
 _SQL_FROM_TARGETS_RE = re.compile(r'\b(?:FROM|JOIN)\s+"?`?\[?([A-Za-z_]\w*)\]?`?"?', re.I)
+# Left-hand side of a predicate: after WHERE/AND/OR, an unqualified identifier
+# followed by a comparison operator. The negative lookahead on '(' keeps
+# function calls out; requiring the operator keeps bare keywords out.
+_SQL_PREDICATE_LHS_RE = re.compile(
+    r'\b(?:WHERE|AND|OR)\s+"?`?\[?([A-Za-z_]\w*)\]?`?"?\s*'
+    r'(?:=|<>|!=|>=|<=|>|<|\bIS\b|\bIN\b|\bLIKE\b|\bBETWEEN\b)(?!\s*\()',
+    re.I)
 
 
 def _unqualified_columns(sql: str) -> list:
     """Column identifiers used without a table qualifier.
 
-    Only the SELECT list and the INSERT column list are read — not the whole
-    statement — so SQL keywords, function names and literals are not mistaken
-    for columns.
+    Read from the SELECT list, the INSERT column list, and the left-hand side of
+    WHERE/AND/OR comparisons — never the whole statement, so SQL keywords,
+    function names and literals are not mistaken for columns.
     """
     names = []
     m = _SQL_SELECT_LIST_RE.search(sql)
@@ -632,11 +639,18 @@ def _unqualified_columns(sql: str) -> list:
             ident = c.strip().strip('"`[]')
             if re.fullmatch(r'[A-Za-z_]\w*', ident) and ident.lower() not in _SQL_RESERVED:
                 names.append(ident)
+    # A predicate's left-hand side: `WHERE order_number = :x`, `AND status <> 'X'`.
+    # Requires a comparison operator so bare keywords cannot slip through, and
+    # skips anything qualified or followed by '(' (a function call).
+    for ident in _SQL_PREDICATE_LHS_RE.findall(sql):
+        ident = ident.strip('"`[]')
+        if re.fullmatch(r'[A-Za-z_]\w*', ident) and ident.lower() not in _SQL_RESERVED:
+            names.append(ident)
     return names
 
 
 def _check_sql_identifiers(op_id: str, code: str, col_index: Dict[str, set]) -> list:
-    """Report SQL columns that belong to a different table than the one used.
+    """Report SQL columns that the table they are used against does not have.
 
     Covers both `alias.column` references and unqualified columns — the latter
     only when the statement touches exactly one known table, which makes the
@@ -644,6 +658,12 @@ def _check_sql_identifiers(op_id: str, code: str, col_index: Dict[str, set]) -> 
     `product_name` straight out of `order_items` (it lives on `products`) and
     inserted `created_at` into `returns` (that column is `requested_at`); with
     no alias in the SQL, a qualified-only check saw neither.
+
+    Once the table is resolved, a column missing from that table's column list
+    is wrong whether or not it exists elsewhere: the scan returns the complete
+    column list for every table it read, so `shipments` having no `created_at`
+    is a fact, not a guess. Naming the table that does own the column is extra
+    help when there is one, not a precondition for reporting.
     """
     issues = []
     if not col_index:
@@ -656,18 +676,22 @@ def _check_sql_identifiers(op_id: str, code: str, col_index: Dict[str, set]) -> 
     def report(qualifier, column, table):
         if column in col_index.get(table, set()):
             return
-        real_owners = owner.get(column, set()) - {table}
-        if not real_owners:
-            return          # column not described anywhere — don't guess
         shown = f"{qualifier}.{column}" if qualifier else column
+        real_owners = sorted(owner.get(column, set()) - {table})
+        if real_owners:
+            where = (f"but `{column}` belongs to {real_owners} — not to `{table}`. "
+                     f"Join through to {real_owners[0]} or use the correct column "
+                     f"from `{table}`.")
+        else:
+            where = (f"but `{table}` has no column `{column}`, and no scanned table "
+                     f"does. Use one of the columns the scan reported for "
+                     f"`{table}`: {sorted(col_index.get(table, set()))}.")
         issues.append({
             "operation_id": op_id, "field": shown,
             "asset_type": "sql_schema_mismatch",
             "issue": f"Lambda '{op_id}' SQL references `{shown}` against `{table}`, "
-                     f"but `{column}` belongs to {sorted(real_owners)} — not to "
-                     f"`{table}`. This fails at runtime with 'column does not exist' "
-                     f"(SQLState 42703). Join through to {sorted(real_owners)[0]} or "
-                     f"use the correct column from `{table}`.",
+                     f"{where} This fails at runtime with 'column does not exist' "
+                     f"(SQLState 42703).",
         })
 
     for sql in _extract_sql_statements(code):


### PR DESCRIPTION
Three defects surfaced by scanning a deliberately complex schema — a 12-table
logistics model with a four-level foreign-key chain, a many-to-many junction,
composite primary keys, a self-referencing key, a generated column and a view —
across RDS and Aurora on PostgreSQL, MySQL and MariaDB.

### CHECK constraints were never read on MySQL

The MySQL query set had no `checks` entry, so a documented `quantity > 0` reached
the generator as nothing at all while the same constraint came through fine on
PostgreSQL. Affects MySQL, MariaDB and Aurora MySQL.

Reads them from `INFORMATION_SCHEMA.CHECK_CONSTRAINTS`, joined onto
`TABLE_CONSTRAINTS` for the table name (which the former does not carry). MySQL
exposes the view from 8.0.16 and MariaDB from 10.2, so the query runs outside the
main try block — an older server yields no constraints rather than failing the
whole scan.

### The SQL column gate stayed silent on columns that exist nowhere

It reported a column only when some *other* table owned it. `oi.product_name` was
caught because `product_name` lives on `products`; `s.created_at` passed silently
because `created_at` exists on no table — which is exactly the shape of a typo or
an invented name.

The abstention was meant to tolerate a partial scan, but the scan returns the
*complete* column list for every table it reads. So once the qualifier resolves
to a table, absence from that table's column list is a fact rather than a guess.
Naming the owning table is now supplementary detail instead of a precondition,
and the message falls back to listing the columns the table actually has.

### Predicates were not checked for unqualified columns

Only the SELECT list and the INSERT column list were read, so
`... FROM orders WHERE customer_name = :n` went through. Extraction now also
covers the left-hand side of `WHERE`/`AND`/`OR` comparisons, requiring a
comparison operator so bare keywords cannot slip in and excluding anything
followed by `(` so function calls are left alone. Join statements still abstain,
where an unqualified column is genuinely ambiguous.

### Verification

Structural accuracy was checked by connecting to each database independently and
diffing the scan against the catalog, rather than trusting the scanner's own
success flag.

| | engine | connection | mismatches | deep checks |
|---|---|---|---|---|
| Aurora PostgreSQL | postgresql | Data API | 0 | 18/18 |
| Aurora MySQL | mysql | Data API | 0 | 18/18 |
| RDS PostgreSQL | postgresql | driver | 0 | 18/18 |
| RDS MySQL | mysql | driver | 0 | 18/18 |
| RDS MariaDB | mysql | driver | 0 | 18/18 |

Mismatch checks covered tables, columns, SQL types, nullability, composite
primary keys (including column order), foreign keys and real row counts. The deep
checks covered the four-level chain, the many-to-many junction, the
self-referencing key, reverse relationships, the generated column, native enums,
observed values on a plain `VARCHAR` status column, check constraints, comments
carrying business rules, a zero-row table, a mixed-case table name, a composite
index, and views being distinguished from base tables.

Gate behaviour on join-heavy SQL: 12/12, counting both detection of injected
defects and absence of false positives on correct four-level, many-to-many,
self-referencing and aggregate queries. The predicate extension was verified
separately at 11/11, including `IS NULL`, `IN`, `BETWEEN`, `LIKE`, function calls
and `CURRENT_DATE` comparisons. The existing parameter type-binding matrix still
passes 13/13, and seven correct statements produce zero findings against all five
engine schemas.
