### PR TITLE
Carry the scanned DB access_method through to the generators + re-sync the CLI skill

### DIFF
--- a/backend/ecs/src/prompts/system_prompt.py
+++ b/backend/ecs/src/prompts/system_prompt.py
@@ -943,9 +943,16 @@ When collected_data includes `existing_table == true`:
      environment_variables{<ENTITY>_TABLE_NAME}
    - RDS:      tables[].primary_key / columns[] (exact names, sql_type,
      allowed_values, description) / indexes / foreign_keys / referenced_by,
-     relationships[], enum_types{}, connection{cluster_arn, secret_arn,
-     database_name}, environment_variables{DB_CLUSTER_ARN, DB_SECRET_ARN,
-     DB_NAME}, iam_requirements[]
+     relationships[], enum_types{}, plus `access_method` and the connection
+     contract that matches it:
+       · `rds-data-api`      → connection{cluster_arn, secret_arn, database_name},
+         environment_variables{DB_CLUSTER_ARN, DB_SECRET_ARN, DB_NAME},
+         iam_requirements[rds-data:*, secretsmanager:GetSecretValue]
+       · `<engine>-driver`   → connection{host, port, secret_arn, database_name},
+         environment_variables{DB_SECRET_ARN, DB_HOST, DB_PORT, DB_NAME},
+         iam_requirements[secretsmanager:GetSecretValue]
+     Pass `access_method` and the env vars through UNCHANGED — lambda_generator
+     picks the Data API vs driver code path from them.
    - both:     data_conventions{} with REAL sampled examples, access_notes[]
 
 4. ⚠️ The scanned schema is now the CONTRACT. Never rename, re-case, or invent

--- a/backend/ecs/src/tools/db_introspector.py
+++ b/backend/ecs/src/tools/db_introspector.py
@@ -1,13 +1,17 @@
 """
 Database Introspector Tool
 
-Connects to customer databases (DynamoDB, RDS/Aurora MySQL & PostgreSQL)
-and discovers schema information to help generate accurate Lambda functions.
+Connects to customer databases (DynamoDB, and every RDS/Aurora engine — see the
+engine registry below) and discovers schema information to help generate
+accurate Lambda functions.
 
-RDS introspection goes through the **RDS Data API**, which is only available on
-Aurora Serverless v2 / Aurora provisioned clusters with the HTTP endpoint
-enabled. Plain RDS instances are not reachable this way and produce an
-actionable error instead of a silent empty result.
+RDS introspection picks its connection method per target: the **RDS Data API**
+when the cluster is Aurora with the HTTP endpoint enabled, and a **direct engine
+driver** otherwise (plain RDS PostgreSQL/MySQL/MariaDB, SQL Server, Oracle, Db2,
+or Aurora with the endpoint off). Whichever was used is reported as
+`access_method` (`rds-data-api` or `<engine>-driver`) and carried into the
+converted infrastructure schema, because it decides which code path the
+generated Lambda must take.
 """
 
 import json
@@ -2123,6 +2127,19 @@ def _convert_dynamodb(r: dict) -> dict:
 def _convert_rds(r: dict) -> dict:
     engine = r.get("engine") or _DB_TYPE_FAMILY.get(r.get("db_type"), "postgresql")
     database_name = r.get("database_name")
+    # The scan already decided how it reached this database (data_api vs a real
+    # driver connection). Carry that decision through verbatim — hardcoding
+    # "rds-data-api" here made every driver-only engine (plain RDS PostgreSQL/MySQL,
+    # SQL Server, Oracle, Db2, or Aurora with the HTTP endpoint off) present
+    # downstream as Data API, so lambda_generator emitted rds-data calls against a
+    # cluster that has no Data API and the deployed handler failed on the first query.
+    access_method = r.get("access_method")
+    if not access_method:
+        # Hand-built payloads (document path, cached older scans) may omit it —
+        # infer from which connection coordinates are actually present.
+        access_method = ("rds-data-api" if (r.get("cluster_arn") and r.get("secret_arn"))
+                         else f"{engine}-driver")
+    uses_data_api = access_method == "rds-data-api"
 
     tables = []
     conventions = {}
@@ -2175,27 +2192,48 @@ def _convert_rds(r: dict) -> dict:
                     "example": example,
                 }
 
+    if uses_data_api:
+        connection = {
+            "cluster_arn": r.get("cluster_arn"),
+            "secret_arn": r.get("secret_arn"),
+            "database_name": database_name,
+        }
+        environment_variables = {
+            "DB_CLUSTER_ARN": r.get("cluster_arn"),
+            "DB_SECRET_ARN": r.get("secret_arn"),
+            "DB_NAME": database_name,
+        }
+        iam_requirements = [
+            "rds-data:ExecuteStatement",
+            "rds-data:BatchExecuteStatement",
+            "secretsmanager:GetSecretValue",
+        ]
+    else:
+        # Driver path: the Lambda opens a TCP connection, so it needs the endpoint
+        # instead of a cluster ARN, and only the secret read from IAM.
+        connection = {
+            "host": r.get("host"),
+            "port": r.get("port"),
+            "secret_arn": r.get("secret_arn"),
+            "database_name": database_name,
+        }
+        environment_variables = {
+            "DB_SECRET_ARN": r.get("secret_arn"),
+            "DB_HOST": r.get("host"),
+            "DB_PORT": str(r["port"]) if r.get("port") is not None else None,
+            "DB_NAME": database_name,
+        }
+        iam_requirements = ["secretsmanager:GetSecretValue"]
+
     return {
         "db_type": r["db_type"],
         "engine": engine,
         "region": r.get("region"),
         "database_name": database_name,
-        "access_method": "rds-data-api",
-        "connection": {
-            "cluster_arn": r.get("cluster_arn"),
-            "secret_arn": r.get("secret_arn"),
-            "database_name": database_name,
-        },
-        "environment_variables": {
-            "DB_CLUSTER_ARN": r.get("cluster_arn"),
-            "DB_SECRET_ARN": r.get("secret_arn"),
-            "DB_NAME": database_name,
-        },
-        "iam_requirements": [
-            "rds-data:ExecuteStatement",
-            "rds-data:BatchExecuteStatement",
-            "secretsmanager:GetSecretValue",
-        ],
+        "access_method": access_method,
+        "connection": connection,
+        "environment_variables": environment_variables,
+        "iam_requirements": iam_requirements,
         "tables": tables,
         "relationships": r.get("relationships", []),
         "enum_types": r.get("enum_types"),

--- a/backend/ecs/tests/test_db_access_method.py
+++ b/backend/ecs/tests/test_db_access_method.py
@@ -1,0 +1,188 @@
+"""Regression test: the scanned access_method must survive the conversion.
+
+`introspect_database()` picks its own connection method per target — the RDS Data
+API on Aurora with the HTTP endpoint enabled, a real engine driver everywhere
+else — and reports it as `access_method`. `convert_to_infrastructure_schema()`
+used to throw that away and hardcode `"rds-data-api"` (plus the Data-API-only
+`connection` / `environment_variables` / `iam_requirements`).
+
+Consequence: every driver-only database — plain RDS PostgreSQL/MySQL/MariaDB,
+SQL Server, Oracle, Db2, or Aurora with the endpoint off — presented downstream
+as Data API. `lambda_generator`'s driver branch keys on
+`access_method == "<engine>-driver"`, so it was unreachable: the generated
+handler called `rds-data:ExecuteStatement` against a cluster that has no Data
+API, was given a `DB_CLUSTER_ARN` that does not exist, and failed on its first
+query. The CloudFormation also asked for `rds-data:*` IAM the function cannot
+use and omitted the `VpcConfig` a driver connection needs.
+
+The two paths carry different contracts, so the test pins both:
+
+    rds-data-api     connection{cluster_arn, secret_arn, database_name}
+                     env{DB_CLUSTER_ARN, DB_SECRET_ARN, DB_NAME}
+                     iam[rds-data:*, secretsmanager:GetSecretValue]
+
+    <engine>-driver  connection{host, port, secret_arn, database_name}
+                     env{DB_SECRET_ARN, DB_HOST, DB_PORT, DB_NAME}
+                     iam[secretsmanager:GetSecretValue]
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC = os.path.abspath(os.path.join(_HERE, "..", "src"))
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+from tools.db_introspector import convert_to_infrastructure_schema  # noqa: E402
+
+SECRET_ARN = "arn:aws:secretsmanager:ap-northeast-2:111122223333:secret:orders-db-AbCdEf"
+CLUSTER_ARN = "arn:aws:rds:ap-northeast-2:111122223333:cluster:orders-aurora"
+
+# One table is enough — this is about the connection contract, not the columns.
+TABLES = [
+    {
+        "table_name": "orders",
+        "table_type": "BASE TABLE",
+        "primary_key": ["order_id"],
+        "columns": [
+            {"name": "order_id", "full_type": "bigint", "nullable": False},
+            {"name": "status", "full_type": "varchar(20)", "nullable": False},
+        ],
+    }
+]
+
+
+def _scan(**overrides) -> dict:
+    """A successful introspect_database() result, shaped like the real one."""
+    base = {
+        "success": True,
+        "db_type": "aurora_postgresql",
+        "engine": "postgresql",
+        "rds_engine": "aurora-postgresql",
+        "database_name": "ordersdb",
+        "region": "ap-northeast-2",
+        "cluster_arn": CLUSTER_ARN,
+        "secret_arn": SECRET_ARN,
+        "host": None,
+        "port": None,
+        "access_method": "rds-data-api",
+        "table_count": len(TABLES),
+        "tables": TABLES,
+        "relationships": [],
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Data API path — unchanged behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_data_api_scan_keeps_the_data_api_contract():
+    schema = convert_to_infrastructure_schema(_scan())
+
+    assert schema["access_method"] == "rds-data-api"
+    assert schema["connection"] == {
+        "cluster_arn": CLUSTER_ARN,
+        "secret_arn": SECRET_ARN,
+        "database_name": "ordersdb",
+    }
+    assert schema["environment_variables"] == {
+        "DB_CLUSTER_ARN": CLUSTER_ARN,
+        "DB_SECRET_ARN": SECRET_ARN,
+        "DB_NAME": "ordersdb",
+    }
+    assert "rds-data:ExecuteStatement" in schema["iam_requirements"]
+    assert "secretsmanager:GetSecretValue" in schema["iam_requirements"]
+
+
+# ---------------------------------------------------------------------------
+# Driver path — the regression
+# ---------------------------------------------------------------------------
+
+# (db_type, engine) pairs that can only ever be reached by a driver.
+DRIVER_ENGINES = [
+    ("rds_postgresql", "postgresql"),
+    ("rds_mysql", "mysql"),
+    ("rds_mariadb", "mysql"),
+    ("rds_sqlserver", "sqlserver"),
+    ("rds_oracle", "oracle"),
+    ("rds_db2", "db2"),
+]
+
+
+@pytest.mark.parametrize("db_type,engine", DRIVER_ENGINES)
+def test_driver_scan_keeps_the_driver_contract(db_type, engine):
+    host = f"orders.cluster-abc123.ap-northeast-2.rds.amazonaws.com"
+    schema = convert_to_infrastructure_schema(
+        _scan(
+            db_type=db_type,
+            engine=engine,
+            rds_engine=db_type.replace("rds_", ""),
+            access_method=f"{engine}-driver",
+            cluster_arn=None,  # a non-Aurora instance has none
+            host=host,
+            port=5432,
+        )
+    )
+
+    assert schema["access_method"] == f"{engine}-driver"
+    assert schema["connection"] == {
+        "host": host,
+        "port": 5432,
+        "secret_arn": SECRET_ARN,
+        "database_name": "ordersdb",
+    }
+    assert schema["environment_variables"] == {
+        "DB_SECRET_ARN": SECRET_ARN,
+        "DB_HOST": host,
+        "DB_PORT": "5432",  # env vars are strings; the handler int()s it
+        "DB_NAME": "ordersdb",
+    }
+    # No rds-data:* — the function cannot use it and asking for it is a finding
+    # for the IAM consistency check.
+    assert schema["iam_requirements"] == ["secretsmanager:GetSecretValue"]
+    assert not any(p.startswith("rds-data:") for p in schema["iam_requirements"])
+    assert "DB_CLUSTER_ARN" not in schema["environment_variables"]
+
+
+def test_aurora_with_the_http_endpoint_off_is_a_driver_target():
+    """Same engine as the Data API case — only the scan's verdict differs."""
+    schema = convert_to_infrastructure_schema(
+        _scan(access_method="postgresql-driver", host="aur.example.rds.amazonaws.com", port=5432)
+    )
+
+    assert schema["access_method"] == "postgresql-driver"
+    assert "DB_HOST" in schema["environment_variables"]
+    assert schema["iam_requirements"] == ["secretsmanager:GetSecretValue"]
+
+
+# ---------------------------------------------------------------------------
+# Payloads that predate `access_method`
+# ---------------------------------------------------------------------------
+
+
+def test_missing_access_method_is_inferred_from_the_coordinates():
+    """Hand-built / cached payloads omit it; infer, don't guess a fixed value."""
+    data_api = _scan()
+    data_api.pop("access_method")
+    assert convert_to_infrastructure_schema(data_api)["access_method"] == "rds-data-api"
+
+    driver = _scan(db_type="rds_mysql", engine="mysql", cluster_arn=None,
+                   host="db.example.rds.amazonaws.com", port=3306)
+    driver.pop("access_method")
+    assert convert_to_infrastructure_schema(driver)["access_method"] == "mysql-driver"
+
+
+def test_port_none_does_not_become_the_string_none():
+    """A schema-as-document payload may know the host but not the port."""
+    driver = _scan(db_type="rds_mysql", engine="mysql", access_method="mysql-driver",
+                   cluster_arn=None, host="db.example.rds.amazonaws.com", port=None)
+    env = convert_to_infrastructure_schema(driver)["environment_variables"]
+    assert env["DB_PORT"] is None

--- a/skills/aicc-builder-skill/README.md
+++ b/skills/aicc-builder-skill/README.md
@@ -24,7 +24,8 @@ skills/aicc-builder-skill/
     │   ├── document_analysis.md       # Raw-requirements-doc entry mode
     │   └── operation_spec_template.md # OperationSpec authoring template
     ├── sub-agents/
-    │   ├── _shared_rules.md        # 16 golden rules + Complete/Escalate tool-result contract
+    │   ├── _shared_rules.md        # 17 golden rules (incl. BUSINESS_OUTCOME_200_RULE)
+    │   │                          #   + Complete/Escalate tool-result contract
     │   ├── infrastructure_generator.md
     │   ├── lambda_generator.md
     │   ├── openapi_generator.md
@@ -41,7 +42,11 @@ skills/aicc-builder-skill/
     │   ├── InfrastructureSpec.schema.json
     │   └── ... (12 more JSON Schemas, incl. SessionFlowConfig / ContactFlowSpec / FlowBehavior)
     ├── scripts/
-    │   ├── validate_consistency.py  # 9-check cross-asset validator
+    │   ├── lint_assets.py           # AUTO-GENERATED from backend tools/asset_linters.py:
+    │   │                            #   Lambda syntax + BUSINESS_OUTCOME_200, cfn-lint,
+    │   │                            #   OpenAPI, Contact Flow, AI prompt (+ --fix)
+    │   ├── validate_consistency.py  # 18-check cross-asset validator (incl. IAM, RDS, SQL)
+    │   ├── shape_parity.py          # spec ↔ OpenAPI shape parity HARD GATE
     │   ├── check_spec_complete.py   # Interview-completion gate
     │   └── clues_format.py          # CLUES response helper
     ├── templates/
@@ -149,13 +154,22 @@ or any generated asset exists yet:
 2. **Generation** — Claude runs the in-scope phases one-per-turn
    (infrastructure → lambda *(one per tool)* → openapi → prompt → contact flow →
    faq), loading the matching `resources/sub-agents/*.md` persona each phase,
-   merging fragments, and gating on cfn-lint / OpenAPI validation before the
-   cross-asset consistency check.
+   merging fragments, and running the deterministic gates before moving on.
 
-After Phase 3 and Phase 6, Claude runs
-`resources/scripts/validate_consistency.py` which enforces the same 9
-cross-asset rules the ECS webapp enforces (field names, HTTP methods,
-path prefixes, GSI names, env vars, etc.).
+Three non-LLM gates carry the webapp's safety net, all of them ports of what the
+ECS backend runs:
+
+| Script | Gate | When |
+|---|---|---|
+| `lint_assets.py` | per-asset syntax + import-safety, with auto-fixes (`--fix`) | after every generation phase |
+| `validate_consistency.py` | 18 cross-asset checks | after Phase 3 and Phase 6 |
+| `shape_parity.py` | spec ↔ OpenAPI shape parity (reviewer HARD GATE) | after Phase 3, again at Phase 7 |
+
+`validate_consistency.py` covers the original spec↔asset checks (field names, HTTP
+methods, path prefixes, GSI names, env vars, response wrapper, counts) **plus** the
+IAM permission check (D2), the RDS Data API env/usage contract (D3) and the four SQL
+checks against the scanned schema (D4/D5). All three take `<output_dir>`, accept
+`--json`, and exit 1 on findings.
 
 See `claude/SKILL.md` for the full workflow.
 
@@ -171,11 +185,14 @@ See `claude/SKILL.md` for the full workflow.
 | `import_uploaded_asset_tool` / vision import | `SKILL.md` "Import an existing asset" + `resources/reference/vision_import.md` |
 | `web_search` / `fetch_webpage` (AgentCore Gateway) | Native `WebSearch` / `WebFetch` |
 | Contact-Flow RAG KB | `resources/reference/contact_flow_block_schemas.md` + WebSearch on docs.aws.amazon.com |
-| `merge_*_fragments` + cfn-lint / OpenAPI gates | String-merge at anchor + `cfn-lint` / OpenAPI validate in `SKILL.md` |
+| `merge_*_fragments` + cfn-lint / OpenAPI gates | String-merge at anchor + `resources/scripts/lint_assets.py` |
 | Fixed `update_q_session` Node.js Lambda | `resources/templates/update_q_session/index.js` (copied, not generated) |
 | `workspace_file_tools.py` | Claude's `Read` / `Write` / `Edit` |
 | `s3_asset_storage.py` | Local filesystem under `<output_dir>/assets/v1/` |
 | `validate_consistency.py` (Strands tool) | `resources/scripts/validate_consistency.py` (stdlib + PyYAML) |
+| `shape_parity.py` (reviewer HARD GATE) | `resources/scripts/shape_parity.py` |
+| `asset_linters.py` (`@tool` wrappers over S3) | `resources/scripts/lint_assets.py` (auto-generated, wrappers stripped) |
+| `introspect_database` / `convert_to_infrastructure_schema` | `SKILL.md` "PHASE 0 — existing database": AWS CLI scan or schema-as-document → `state/infrastructure_schema.json` |
 | `<generation_state>` injected block | `state/progress.json`, re-read each turn |
 | 4-phase / 12-step progress sidebar | Printed phase headers + ticking checklist |
 | WebSocket streaming UI | Your normal streamed responses |
@@ -187,25 +204,39 @@ The generated artifacts are equivalent — same paths, same contracts.
 ## Re-syncing from the webapp
 
 When you edit prompts in `backend/ecs/src/prompts/` or
-`backend/ecs/src/agents/*/system_prompt.py`, or change a Pydantic spec model,
-re-run:
+`backend/ecs/src/agents/*/system_prompt.py`, change a Pydantic spec model, or
+change a lint rule in `backend/ecs/src/tools/asset_linters.py`, re-run:
 
 ```bash
 ./scripts/extract_prompts.sh           # regenerate resources/
 ./scripts/extract_prompts.sh --check   # CI / pre-commit drift + coverage gate
 ```
 
-`extract_prompts.sh` regenerates `resources/orchestrator/*.md`,
-`resources/sub-agents/*.md`, and `resources/schemas/*.json` from the Python
-source. The `--check` gate diffs against the backend **and** fails if a NEW
-prompt section or spec model isn't covered by the extractor — so the skill
-can't silently fall out of sync. Review the diff, commit, done.
+**Auto-extracted — never hand-edit:**
 
-> The authored files under `resources/reference/` and
-> `resources/templates/update_q_session/` are **not** auto-extracted. Update
-> them by hand when their backend counterparts
-> (`agents/contact_flow_generator/vision_import.py`, `tools/asset_linters.py`,
-> `tools/asset_packager.py`) change.
+| Output | Source |
+|---|---|
+| `resources/orchestrator/*.md` | `prompts/system_prompt.py`, `prompts/interview_agent_prompt.py` |
+| `resources/sub-agents/*.md` | `agents/*/system_prompt.py` + `agents/_consistency_rules.py` |
+| `resources/schemas/*.json` | `tools/spec_manager.py` (Pydantic → JSON Schema) |
+| `resources/scripts/lint_assets.py` | `tools/asset_linters.py` — the `strands` import and every `@tool` wrapper (they need the S3/session runtime) are stripped, and `scripts/_lint_assets_cli.py` is appended as the CLI driver |
+
+Extracting the linters rather than hand-copying them is deliberate: that module
+carries ~1600 lines of API-verified Contact Flow block/error tables that change
+often, and a stale copy in the skill would reject flows the webapp accepts.
+
+The `--check` gate diffs against the backend **and** fails if a NEW prompt
+section or spec model isn't covered by the extractor — so the skill can't
+silently fall out of sync. Review the diff, commit, done.
+
+> **Authored / hand-maintained:** `resources/reference/*`, `resources/templates/*`
+> (incl. `update_q_session/index.js`, `deploy_workshop.sh`), `resources/examples/*`,
+> `resources/scripts/{validate_consistency,shape_parity,check_spec_complete,clues_format}.py`,
+> and both `SKILL.md` files. `validate_consistency.py` / `shape_parity.py` are hand
+> ports of `tools/validate_consistency.py` / `tools/shape_parity.py` — when a check
+> changes there, port it here and re-run the smoke tests. Also update by hand when
+> `agents/contact_flow_generator/vision_import.py` or `tools/asset_packager.py`
+> change.
 
 ## License
 

--- a/skills/aicc-builder-skill/README.md
+++ b/skills/aicc-builder-skill/README.md
@@ -125,8 +125,14 @@ rm -f  ~/.kiro/skills/aicc-builder/README.md
 - **Python 3.9+** for the bundled validator scripts
 - **PyYAML** (`pip install pyyaml`) — the consistency validator parses
   the generated OpenAPI YAML
-- That's it. No AWS credentials needed to run the skill itself — you only
-  need them to `aws cloudformation deploy` the generated template.
+- **Optional, but recommended for full parity with the webapp:**
+  `pip install cfn-lint openapi-spec-validator`. The ECS image has both, so the
+  webapp always validates the CloudFormation template and the OpenAPI document.
+  Without them `lint_assets.py` still applies its deterministic autofixes but
+  **skips those two validations** — it logs a warning saying so rather than
+  failing, which is easy to miss in a long run.
+- No AWS credentials needed to run the skill itself — you only need them to
+  `aws cloudformation deploy` the generated template.
 
 ## How it works
 

--- a/skills/aicc-builder-skill/claude/SKILL.md
+++ b/skills/aicc-builder-skill/claude/SKILL.md
@@ -80,7 +80,8 @@ Always write to a local directory (default `./aicc-output/` — ask if unsure):
     project.json                         # company, industry, language, mode, scope
     progress.json                        # phase + 12-step checklist (your <generation_state>)
     specs/<operation_id>.json            # one OperationSpec per operation
-    infrastructure_schema.json           # tables, Lambda wiring, env vars (the Schema Summary)
+    infrastructure_schema.json           # tables, Lambda wiring, env vars (the Schema Summary);
+                                         # on the existing-DB path this is the scanned SCHEMA CONTRACT
     session_flow_config.json             # call direction, greeting, persona
     requirements/<doc_type>.md           # raw customer input (large text / uploaded docs)
     research/<topic>.md                  # cited web-research notes (optional)
@@ -140,19 +141,112 @@ png/jpeg/gif/webp; documents pdf/txt/md/docx/csv/xlsx.
 When the user provides an existing **Contact Flow JSON**, **AI Prompt YAML**, or a
 **flow-diagram image**:
 
-1. **Flow / prompt file** — `Read` it, then run the lint/repair pass:
-   - Contact Flow → enforce the verified block schemas in
-     `resources/reference/contact_flow_block_schemas.md` (and `validate_consistency.py`
-     where applicable). The repaired JSON may be **shorter** than the original — the
-     linter strips invalid `DTMFConfiguration`, duplicate SSML, etc. That is correct.
-   - AI Prompt YAML → dedup any `{{variable}}` that appears more than once inside a
-     single `{{ }}` (qconnect rejects duplicates).
+1. **Flow / prompt file** — `Read` it, seed it to its stable path, then run the
+   deterministic repair pass rather than eyeballing it:
+   ```bash
+   python3 resources/scripts/lint_assets.py <output_dir> --fix
+   python3 resources/scripts/lint_assets.py <output_dir>          # must come back clean
+   ```
+   - Contact Flow → `lint_contact_flow` applies the API-verified block schemas
+     (explained in `resources/reference/contact_flow_block_schemas.md`). The repaired
+     JSON may be **shorter** than the original — the linter strips invalid
+     `DTMFConfiguration`, duplicate SSML, etc. That is correct.
+   - AI Prompt YAML → `lint_ai_prompt` strips the braces from any `{{variable}}` used
+     more than once (qconnect rejects duplicates).
 2. **Flow image** — follow `resources/reference/vision_import.md`: confirm intent,
    `Read` the image, transcribe to flow JSON with the vision contract, then lint as above.
 3. **Seed** the repaired asset to its stable path (`imported_flow` / `imported_agent`).
 4. **Print an import summary** line: `{errors, warnings, fixesApplied}`.
 5. **Switch to patch-only modification mode** (see below). Never regenerate an
    imported asset from scratch.
+
+## PHASE 0 — existing database (run BEFORE Phase 1 whenever the data already exists)
+
+If the interview establishes that the customer already has tables (`existing_table
+== true`), the schema — not your imagination — is the contract. The webapp calls
+`introspect_database` + `convert_to_infrastructure_schema`; in a CLI you do the same
+work with `Bash` + the AWS CLI, or read the schema as a document. The full
+orchestrator text for both paths is in
+`resources/orchestrator/system_prompt.md` → "GENERATION FLOW: EXISTING DATABASE PATH".
+
+**Path A — live scan.** Confirm the target account/region with the user first, use
+**read-only credentials**, and stick to `describe`/`SELECT` calls:
+
+```bash
+aws sts get-caller-identity                                     # confirm the account
+# DynamoDB
+aws dynamodb describe-table --table-name <T> --region <R>
+aws dynamodb scan --table-name <T> --max-items 5 --region <R>    # data conventions only
+# RDS / Aurora — resolve the identifier to a cluster/instance first
+aws rds describe-db-clusters   --region <R> --query 'DBClusters[].[DBClusterIdentifier,Engine,Endpoint]'
+aws rds describe-db-instances  --region <R> --query 'DBInstances[].[DBInstanceIdentifier,Engine,Endpoint.Address]'
+# Aurora with the Data API enabled — the only engine path reachable from a CLI
+aws rds-data execute-statement --resource-arn <clusterArn> --secret-arn <secretArn> \
+  --database <db> --include-result-metadata --sql "
+    SELECT c.table_name, c.column_name, c.data_type, c.udt_name, c.is_nullable,
+           c.column_default, c.is_generated, c.ordinal_position
+    FROM information_schema.columns c
+    WHERE c.table_schema = 'public'
+    ORDER BY c.table_name, c.ordinal_position"
+```
+Also pull primary keys, indexes, foreign keys and enum labels (`pg_constraint`,
+`pg_index`, `pg_enum` on PostgreSQL; `information_schema.key_column_usage` +
+`SHOW INDEX` on MySQL/MariaDB). A **driver-only** database (no Data API, private
+subnet) is generally *not* reachable from a laptop — say so and switch to Path B
+rather than guessing.
+
+**Path B — schema as a document.** DDL dump, ERD image, data dictionary, or sample
+JSON payloads. Extract exact table + column names, SQL types, PK (incl. composite),
+FKs, indexes, enum/allowed values, NOT NULL, defaults, generated columns, and any
+comments carrying business rules. Ask for anything the document doesn't state —
+especially the caller-lookup key and enum spellings — and use explicit
+`<REPLACE_ME>` placeholders for missing ARNs, never invented values.
+
+**Both paths, then:**
+
+1. Write the result to `state/infrastructure_schema.json` in the same shape the
+   webapp's converter produces, with `existing: true` on every table:
+   `tables[].{name, primary_key, sort_key, columns[{name, sql_type, nullable,
+   default, generated, allowed_values, description}], indexes, foreign_keys}`,
+   `relationships[]`, `enum_types{}`, `data_conventions{}` with REAL sampled
+   examples, plus `access_method` and **the connection contract that matches it**
+   — the two are not interchangeable, and `lambda_generator` picks its code path
+   from `access_method`:
+
+   | `access_method` | `connection` | `environment_variables` | `iam_requirements` |
+   |---|---|---|---|
+   | `rds-data-api` | `{cluster_arn, secret_arn, database_name}` | `{DB_CLUSTER_ARN, DB_SECRET_ARN, DB_NAME}` | `rds-data:ExecuteStatement`, `rds-data:BatchExecuteStatement`, `secretsmanager:GetSecretValue` |
+   | `<engine>-driver` | `{host, port, secret_arn, database_name}` | `{DB_SECRET_ARN, DB_HOST, DB_PORT, DB_NAME}` | `secretsmanager:GetSecretValue` only |
+
+   Writing the Data API shape for a driver target is the failure this table exists
+   to prevent: the handler then calls `rds-data` against a cluster that has no
+   Data API and reads a `DB_CLUSTER_ARN` that was never set. A driver target also
+   needs `VpcConfig` (subnets + an SG allowed on the DB port) **and** either a
+   Secrets Manager interface VPC endpoint or a NAT — without one,
+   `GetSecretValue` hangs until the function times out.
+2. **Persist the COMPLETE column list for every table, verbatim.** Do not hand-write
+   an abbreviated summary of "just the columns this operation needs" — the `sql_*`
+   checks in `validate_consistency.py` compare generated SQL against this file, so
+   any column you omit becomes invisible to the gate and a hallucinated reference
+   (`order_items.product_name` when it lives on `products`) ships and fails at
+   runtime with SQLState 42703. Completeness here is what makes the gate work.
+3. **Echo back what you parsed** (table → columns → PK → FKs) and get confirmation
+   BEFORE generating.
+4. Fill `data_source` on every OperationSpec — for RDS/Aurora that means `db_type`,
+   `table_name` (the primary table), `partition_key`, `database_name`,
+   `lookup_column` (the column identifying the caller, e.g. `customers.phone_number`)
+   and `related_tables` (every other table the operation joins, in query order).
+   An empty `data_source` renders "Table: ?" and blinds the reviewer.
+5. **Fidelity rule:** never rename, re-case, or invent an identifier; honour
+   `allowed_values` exactly; preserve `data_conventions` samples (a phone stored as
+   `821012345678` must not become `+8210…`). Column/table descriptions often carry
+   business rules ("auto-approve under 500,000 KRW") — feed those into the spec.
+
+Aurora Data API also has a **minimum engine version**; if the cluster is older,
+the driver path is the only option — flag it instead of emitting Data API code.
+Phase 1 then runs unchanged, passing `existing_tables[]` (with
+`table_arn: "existing table - managed outside CloudFormation"`) and
+`include_sample_data=False`.
 
 ## INTERVIEW MODE — gather requirements
 
@@ -205,7 +299,12 @@ in-scope phases below execute; mark the rest "skipped (not in scope)".
 | 4 | `prompt_generator` | all specs + flow config | `prompt/ai_agent_prompt.yaml` |
 | 5 | `contact_flow_generator` | flow config + prompt | `contact_flow/contact_flow.json` |
 | 6 | `faq_generator` (optional) | company profile / research | `faq/<category>/*.txt` |
-| 7 | **Review gate** (`reviewer_agent` + validator) | all of `assets/v1/` | `state/review_report.md` |
+| 7 | **Review gate** (`reviewer_agent` + 3 validators) | all of `assets/v1/` | `state/review_report.md` |
+
+Run `resources/scripts/lint_assets.py <output_dir>` at the end of **every** phase
+(Phase 0 excepted) before you report the result — it is cheap, deterministic, and
+catches the failures that otherwise surface only at CloudFormation deploy or flow
+import time. See **Validation** below for the full gate list.
 
 **Granularity & special Lambdas (Phase 1–2) — easy to get wrong:**
 - **One Lambda per TOOL, not per operation.** Enumerate every tool id across all
@@ -287,34 +386,84 @@ Example header:
 **Before each generation phase beyond #1**: confirm the previous phase's artifacts
 exist on disk.
 
-**After Phase 1 (infra)** — CloudFormation lint gate (mirrors the webapp's
-`merge_infrastructure_fragments` cfn-lint gate):
-```bash
-cfn-lint <output_dir>/assets/v1/infrastructure/template.yaml   # if cfn-lint is installed
-```
-Fix exactly the errors cfn-lint names (patch via `Edit`); don't paraphrase or
-over-fix. If cfn-lint isn't installed, say so and fall back to a YAML parse check.
+Three deterministic (non-LLM) gates carry the webapp's whole safety net. Run them —
+your reading of a file is not a substitute:
 
-**After Phase 3 (OpenAPI)** — OpenAPI 3.0 validation gate:
-```bash
-python -c "import yaml,sys; yaml.safe_load(open('<output_dir>/assets/v1/openapi/openapi.yaml'))"
-# or, if available: openapi-spec-validator <output_dir>/assets/v1/openapi/openapi.yaml
-```
+| Script | What it gates | When |
+|---|---|---|
+| `resources/scripts/lint_assets.py` | per-asset syntax + import-safety, with auto-fixes | after every generation phase |
+| `resources/scripts/validate_consistency.py` | 18 cross-asset consistency checks | after Phase 3 and Phase 6 |
+| `resources/scripts/shape_parity.py` | spec ↔ OpenAPI shape parity (reviewer HARD GATE) | after Phase 3, again at Phase 7 |
 
-**After Phase 3 and Phase 6** — the 9-check cross-asset consistency validator:
+All three take `<output_dir>`, accept `--json`, exit 0 on success and 1 on findings,
+and resolve assets from the newest `assets/vN/` (a flat `assets/` also works).
+
+**Asset linters — after EVERY generation phase.** `lint_assets.py` is generated from
+the webapp's `asset_linters.py`, so it enforces exactly what the webapp enforces:
 ```bash
-python resources/scripts/validate_consistency.py <output_dir>
+python3 resources/scripts/lint_assets.py <output_dir>          # report
+python3 resources/scripts/lint_assets.py <output_dir> --fix     # apply deterministic fixes
 ```
-It enforces the same 9 rules the webapp enforces:
-1. Lambda reads every `input_fields[].name`
-2. Lambda response contains every `output_fields[].name`
-3. OpenAPI `requestBody` matches spec inputs
-4. OpenAPI response schema matches spec outputs
-5. Infra table keys include `data_source.primary_key`
-6. Lambda `IndexName=` values exist as infra GSIs
-7. Lambda `os.environ["X_TABLE_NAME"]` matches infra env vars
-8. Lambda response wrapper (data vs flat) matches OpenAPI response shape
-9. Lambda & OpenAPI count each ≥ spec count
+It runs, per asset type:
+- **Lambda** — Python `compile()` syntax check, then **BUSINESS_OUTCOME_200**: rewrites
+  `create_response(4xx, …)` business outcomes to 200 (5xx is preserved) and warns when
+  the body has no outcome discriminator.
+- **CloudFormation** — cfn-lint plus deterministic autofixes (`pip install cfn-lint`;
+  without it you get autofixes but **no validation**, and it says so).
+- **OpenAPI** — openapi-spec-validator plus autofixes
+  (`pip install openapi-spec-validator`).
+- **Contact Flow** — the API-verified block tables: renames invalid `Type`s, adds
+  required error branches, strips `Transitions` from terminal blocks, normalizes the
+  `Complete`/`Escalate` tool-result values, checks JSONPath roots and redaction
+  languages.
+- **AI prompt** — the qconnect variable-once rule.
+
+`NEEDS FIX` lines mean the fix is *available but unapplied*; re-run with `--fix`, then
+re-lint. A repaired Contact Flow may be **shorter** than the draft — that is correct.
+
+**Cross-asset consistency — after Phase 3 and Phase 6:**
+```bash
+python3 resources/scripts/validate_consistency.py <output_dir>
+```
+18 checks, the same ones the webapp runs after every generation phase:
+
+*spec ↔ generated asset* — `lambda_input` (spec input never read by the handler),
+`lambda_output` (spec output absent from the response body), `lambda_tool` (ToolSpec
+input never read by its handler), `openapi_input` / `openapi_output`, `infra_pk`
+(spec primary key is not a key on the infra table), `lambda_gsi` (`IndexName=` that
+is not a GSI), `lambda_env` (`*_TABLE_NAME` the schema never defines),
+`response_structure` (`data` wrapper on one side only), `count_lambda` /
+`count_openapi` (fewer handlers/paths than specs — or than tools).
+
+*IAM (D2)* — `iam_permissions`: the handler calls an AWS API its CloudFormation role
+never grants (this is the `AccessDeniedException` you'd otherwise find at runtime).
+
+*RDS Data API contract (D3)* — `rds_env_contract`: the env-var names are exactly
+`DB_CLUSTER_ARN`, `DB_SECRET_ARN`, `DB_NAME` (not `RDS_CLUSTER_ARN`, `SECRET_ARN`, …)
+**and** the template actually defines each one, or the function `KeyError`s on cold
+start. `rds_data_api`: `includeResultMetadata=True` is passed, rows are read by column
+name rather than by position, and SQL is not built by string interpolation.
+
+*SQL vs the database schema (D4/D5)* — `sql_schema_mismatch` (a column the resolved
+table does not have → SQLState 42703), `sql_type_mismatch` (a `::cast` to a type the
+schema never defines), `sql_missing_required_column` (an INSERT that omits a NOT NULL
+column with no default), `sql_param_type_mismatch` (a `:param` bound with the wrong
+Data API value key — `longValue` for integer types, `booleanValue` for bool,
+`stringValue` for char/text; date/uuid/json/enum/numeric legitimately take
+`stringValue`). These only work if `state/infrastructure_schema.json` holds the
+complete column list (see Phase 0).
+
+**Shape parity — after Phase 3:**
+```bash
+python3 resources/scripts/shape_parity.py <output_dir>
+```
+This is the reviewer's **HARD GATE**: every spec `field_type` must map to the OpenAPI
+type, enums must match exactly, nested `items.properties` must survive, and neither
+side may declare a property the other doesn't. It enforces on the OpenAPI side what
+golden rules 13/15/16 ask the generators to do, and it covers **multi-tool** specs
+(each `tools[].input_fields` / `output_fields`), not just the operation-level fields.
+An exit code of 2 means the document uses a construct the validator refuses to guess
+at — `oneOf`/`anyOf`/`allOf` or an external `$ref` — so flatten it into a plain schema.
 
 On a mismatch: **field rename/typo** → `Edit` the offending file (don't regenerate);
 **structural mismatch** → re-run the specific sub-agent persona with a
@@ -322,18 +471,21 @@ On a mismatch: **field rename/typo** → `Edit` the offending file (don't regene
 
 ### Phase 7 — Final review gate (MANDATORY)
 
-After the last generation phase, complete all three before declaring done:
+After the last generation phase, complete all five before declaring done:
 
 1. **Artifact presence** — every in-scope output path exists and is non-empty.
-2. **Consistency validator** exits 0 (run it again).
-3. **Reviewer pass** — adopt `resources/sub-agents/reviewer_agent.md`, read all
+2. **`lint_assets.py`** exits 0 with no pending fixes.
+3. **`validate_consistency.py`** exits 0.
+4. **`shape_parity.py`** exits 0.
+5. **Reviewer pass** — adopt `resources/sub-agents/reviewer_agent.md`, read all
    `assets/v1/` artifacts, and `Write` `state/review_report.md` with sections:
    `## Summary` (one sentence per asset), `## Consistency findings`,
    `## Recommended edits` (empty = clean), `## Verdict` (`READY_TO_DEPLOY` |
    `NEEDS_EDITS`). Write the report in the user's language.
 
-If `NEEDS_EDITS`, apply edits via `Edit` (never whole-file regen) and re-run the
-validator. Surface `READY_TO_DEPLOY` only once all three pass.
+If `NEEDS_EDITS`, apply edits via `Edit` (never whole-file regen) and re-run the three
+scripts. Surface `READY_TO_DEPLOY` only once all five pass — and quote the three exit
+codes in the report so the user can see the gates actually ran.
 
 ## Patch-only modification protocol (post-generation)
 
@@ -382,20 +534,36 @@ when the user explicitly asks ("다시 검토 / review again") — otherwise rea
 ## Cross-generator golden rules (ALWAYS apply)
 
 Read the full `resources/sub-agents/_shared_rules.md` before Phase 1 — it carries all
-16 rules **and** the AI-bot↔flow tool-result contract. The essentials:
+**17** rules **and** the AI-bot↔flow tool-result contract. The essentials:
 
-1. **HTTP_METHOD_RULE** — spec verb == OpenAPI verb == CFN `HttpMethod`, exactly.
-2. **PATH_PREFIX_RULE** — OpenAPI `paths:` start with `/tools/`; the CFN `ApiEndpoint`
+1. **BUSINESS_OUTCOME_200_RULE** (rule 17, CRITICAL) — an Amazon Connect AI agent
+   treats **any non-2xx as a broken tool** and never reads the body, so it can't tell
+   "no reservation found" from "the API is down". Every *business* outcome — not found,
+   not eligible, already cancelled, validation rejected — returns **HTTP 200** with a
+   body discriminator (`success`/`found`/`eligible`/`errorCode`/…) **and** a
+   customer-readable `message`. Only genuine 5xx server faults stay non-2xx.
+   `lint_assets.py` rewrites 4xx business outcomes for you; the point is to not write
+   them in the first place.
+2. **HTTP_METHOD_RULE** — spec verb == OpenAPI verb == CFN `HttpMethod`, exactly.
+3. **PATH_PREFIX_RULE** — OpenAPI `paths:` start with `/tools/`; the CFN `ApiEndpoint`
    Output has no `/tools` suffix.
-3. **LAMBDA_ARCHITECTURES_RULE** — `Architectures:\n  - arm64` (plural block-list).
-4. **IAM_Q_IN_CONNECT_RULE** — use `wisdom:*` IAM actions, never `qconnect:*`
-   (the latter causes runtime AccessDenied).
-5. **FIELD_NAMING_RULE** — camelCase everywhere, identical spec → OpenAPI → Lambda → prompt.
-6. **FIELD_SHAPE_FIDELITY_RULE** — preserve `items.properties` nesting; never flatten.
-7. **ENUM_FIDELITY_RULE** — copy `enum_values` exactly (case + underscores).
-8. **TOOL_RESULT_CONTRACT** — the AI prompt teaches the bot to set
+4. **LAMBDA_ARCHITECTURES_RULE** — `Architectures:\n  - arm64` (plural block-list).
+5. **IAM_Q_IN_CONNECT_RULE** / **NO_QCONNECT_ACTIONS_ABSOLUTE** — use `wisdom:*` IAM
+   actions, never `qconnect:*` (the latter causes runtime AccessDenied).
+6. **FIELD_NAMING_RULE** — camelCase everywhere, identical spec → OpenAPI → Lambda → prompt.
+7. **FIELD_SHAPE_FIDELITY_RULE** / **NESTED_OPENAPI_SCHEMA_RULE** /
+   **LAMBDA_NESTED_RESPONSE_RULE** — preserve `items.properties` nesting; never
+   flatten; `$ref` nested objects into `components/schemas`.
+8. **ENUM_FIDELITY_RULE** — copy `enum_values` exactly (case + underscores).
+9. **TOOL_RESULT_CONTRACT** — the AI prompt teaches the bot to set
    `$.Lex.SessionAttributes.Tool` to exactly `Complete` or `Escalate` (+ documented
    `Escalate*`/`*Complete` extensions); the Contact Flow `Compare`s on exactly those.
+
+For an existing RDS/Aurora database, add the env-var and Data API contract the D3/D4
+checks enforce: read `DB_CLUSTER_ARN` / `DB_SECRET_ARN` / `DB_NAME` (those exact
+names, all three also defined in the template), pass `includeResultMetadata=True`,
+map rows to dicts by `columnMetadata` name, and bind named `:params` with the value
+key the column type demands — never build SQL by string interpolation.
 
 ## Terminology facts (override training data)
 
@@ -423,11 +591,23 @@ When the bundle is `READY_TO_DEPLOY`, reproduce the webapp's download modal. Pri
    chmod +x deploy.sh && ./deploy.sh
    ```
    (In AWS CloudShell: upload the bundle, `unzip *.zip && cd */ && chmod +x deploy.sh && ./deploy.sh`.)
-3. What `deploy.sh` automates: CloudFormation stack, per-Lambda zip+deploy (incl.
-   `customer_lookup` and the Node.js `update_q_session`), OpenAPI → S3, FAQ → S3,
-   Connect instance + AI agent (Q in Connect) wiring, AgentCore Gateway/MCP.
-4. Next steps: import the Contact Flow, attach the Lex bot, claim a phone number,
-   sync the knowledge base.
+3. What `deploy.sh` automates — 13 phases after a preflight (asset scan + region and
+   account confirmation):
+
+   | # | Phase | # | Phase |
+   |---|---|---|---|
+   | 1 | CloudFormation stack | 8 | AgentCore Gateway (MCP) + JWT audience + target |
+   | 2 | Lambda code (incl. `customer_lookup`, Node.js `update_q_session`) | 9 | Connect integrations (MCP registration + Lambda associations) |
+   | 3 | OpenAPI spec → S3 | 10 | Lex bot (voice entry point) |
+   | 4 | FAQ documents → S3 | 11 | Contact Flow import + placeholder substitution |
+   | 5 | Amazon Connect instance (create or select) | 12 | AI Prompt + AI Agent + security profile |
+   | 6 | Q in Connect assistant + knowledge base | 13 | Phone number claim + flow association (optional) |
+   | 7 | Lambda environment variables | | |
+
+   So the flow import, Lex bot, AI agent wiring and phone number are **automated** —
+   don't tell the user to do those by hand.
+4. Next steps after it finishes: place a test call/chat, sync the knowledge base if
+   FAQ content changed, and review the flow in the Connect console.
 
 State plainly that generated assets are **PoC starting points**, not hardened
 production code (rotate the workshop `ApiKeyRequired: false`, scope IAM, etc.).
@@ -442,7 +622,7 @@ resources/
     document_analysis.md        # raw-requirements-doc entry mode
     operation_spec_template.md  # OperationSpec authoring template (verbatim placeholders)
   sub-agents/
-    _shared_rules.md            # 16 golden rules + Complete/Escalate contract + nested-field rendering
+    _shared_rules.md            # 17 golden rules (incl. BUSINESS_OUTCOME_200_RULE) + Complete/Escalate contract + nested-field rendering
     infrastructure_generator.md  lambda_generator.md  openapi_generator.md
     prompt_generator.md          contact_flow_generator.md  faq_generator.md
     research_agent.md            reviewer_agent.md
@@ -455,7 +635,10 @@ resources/
     SessionFlowConfig / ContactFlowSpec / FlowBehavior / CustomerInfoVariable /
     NoResponsePolicy .schema.json
   scripts/
-    validate_consistency.py     # 9-check cross-asset validator (stdlib + PyYAML)
+    lint_assets.py              # per-asset linters + autofixes — AUTO-GENERATED from
+                                # backend tools/asset_linters.py; do not hand-edit
+    validate_consistency.py     # 18-check cross-asset validator (stdlib + PyYAML)
+    shape_parity.py             # spec ↔ OpenAPI shape parity HARD GATE
     check_spec_complete.py       clues_format.py
   templates/
     pre_questionnaire_template.md
@@ -473,7 +656,19 @@ After editing any prompt in `backend/ecs/src/` or a Pydantic spec model, re-run:
 skills/aicc-builder-skill/scripts/extract_prompts.sh          # regenerate resources/
 skills/aicc-builder-skill/scripts/extract_prompts.sh --check  # CI/pre-commit drift + coverage gate
 ```
-`--check` now also fails if a NEW backend prompt section or spec model isn't covered
-by the extractor — so the skill can't silently fall behind. The authored files under
-`resources/reference/` and `resources/templates/update_q_session/` are NOT extracted;
-update them by hand when the corresponding backend source changes.
+`--check` also fails if a NEW backend prompt section or spec model isn't covered by
+the extractor — so the skill can't silently fall behind.
+
+**Auto-extracted (never hand-edit):** `resources/orchestrator/*.md`,
+`resources/sub-agents/*.md`, `resources/schemas/*.json`, and
+`resources/scripts/lint_assets.py` (generated from `tools/asset_linters.py` with the
+`@tool` S3 wrappers stripped — that is how the API-verified Contact Flow tables stay
+in sync).
+
+**Authored / hand-maintained:** `resources/reference/*`, `resources/templates/*`
+(incl. `update_q_session/index.js` and `deploy_workshop.sh`), `resources/examples/*`,
+`resources/scripts/validate_consistency.py`, `resources/scripts/shape_parity.py`,
+`resources/scripts/check_spec_complete.py`, `resources/scripts/clues_format.py`, and
+these SKILL.md files. `validate_consistency.py` and `shape_parity.py` are ports of
+`backend/ecs/src/tools/{validate_consistency,shape_parity}.py` — when a check changes
+there, port it here by hand and re-run the smoke tests.

--- a/skills/aicc-builder-skill/claude/SKILL.md
+++ b/skills/aicc-builder-skill/claude/SKILL.md
@@ -170,7 +170,9 @@ orchestrator text for both paths is in
 `resources/orchestrator/system_prompt.md` → "GENERATION FLOW: EXISTING DATABASE PATH".
 
 **Path A — live scan.** Confirm the target account/region with the user first, use
-**read-only credentials**, and stick to `describe`/`SELECT` calls:
+**read-only credentials**, and stick to `describe`/`SELECT` calls. Which sub-path
+applies depends on how the database is reachable — **A1** (Data API, IAM only) or
+**A2** (a real driver connection, which needs a network path):
 
 ```bash
 aws sts get-caller-identity                                     # confirm the account
@@ -180,7 +182,7 @@ aws dynamodb scan --table-name <T> --max-items 5 --region <R>    # data conventi
 # RDS / Aurora — resolve the identifier to a cluster/instance first
 aws rds describe-db-clusters   --region <R> --query 'DBClusters[].[DBClusterIdentifier,Engine,Endpoint]'
 aws rds describe-db-instances  --region <R> --query 'DBInstances[].[DBInstanceIdentifier,Engine,Endpoint.Address]'
-# Aurora with the Data API enabled — the only engine path reachable from a CLI
+# A1 — Aurora with the Data API enabled: pure IAM, no network path needed
 aws rds-data execute-statement --resource-arn <clusterArn> --secret-arn <secretArn> \
   --database <db> --include-result-metadata --sql "
     SELECT c.table_name, c.column_name, c.data_type, c.udt_name, c.is_nullable,
@@ -191,9 +193,56 @@ aws rds-data execute-statement --resource-arn <clusterArn> --secret-arn <secretA
 ```
 Also pull primary keys, indexes, foreign keys and enum labels (`pg_constraint`,
 `pg_index`, `pg_enum` on PostgreSQL; `information_schema.key_column_usage` +
-`SHOW INDEX` on MySQL/MariaDB). A **driver-only** database (no Data API, private
-subnet) is generally *not* reachable from a laptop — say so and switch to Path B
-rather than guessing.
+`SHOW INDEX` on MySQL/MariaDB).
+
+**Path A2 — driver connection (every non-Data-API engine).** Do NOT assume this is
+impossible from a CLI. Reachability here is a **network** question, not an IAM one:
+credentials get you *authenticated*, but the packets still have to arrive. Work out
+which case you are in before falling back to Path B:
+
+```bash
+aws rds describe-db-instances --region <R> --db-instance-identifier <ID> \
+  --query 'DBInstances[0].{public:PubliclyAccessible,ep:Endpoint.Address,port:Endpoint.Port,sg:VpcSecurityGroups[].VpcSecurityGroupId,subnets:DBSubnetGroup.Subnets[].SubnetIdentifier}'
+aws ec2 describe-security-groups --group-ids <sg> \
+  --query 'SecurityGroups[0].IpPermissions'          # is your IP/CIDR allowed on the port?
+nc -zv <endpoint> <port>                              # 5s answer: reachable or not
+```
+
+| Situation | What to do |
+|---|---|
+| `PubliclyAccessible: true` and the SG allows your egress IP | Connect directly — nothing else needed |
+| You are on the customer's VPN / Direct Connect / a peered network, SG allows your CIDR | Connect directly |
+| Private-only, but you have `ssm:StartSession` and there is an SSM-managed instance in the VPC | **Port-forward** (below). No bastion key, no inbound SSH, no public DB |
+| Private-only, no tunnel available, or the customer won't grant DB access | Path B |
+
+```bash
+# Private RDS via any SSM-managed EC2 instance in its VPC (needs the Session Manager plugin).
+# The DB security group must allow the INSTANCE's security group on the port — not your laptop.
+aws ssm start-session --target <instanceId> --region <R> \
+  --document-name AWS-StartPortForwardingSessionToRemoteHost \
+  --parameters '{"host":["<db-endpoint>"],"portNumber":["5432"],"localPortNumber":["15432"]}'
+# then treat the database as localhost:15432
+```
+A CloudShell **VPC environment** placed in the DB's VPC/subnets/SG works the same way.
+
+Credentials: read the secret (`aws secretsmanager get-secret-value --secret-id <arn>
+--query SecretString`), or — PostgreSQL/MySQL/MariaDB with IAM database
+authentication enabled and the DB user mapped — mint a token instead of a password
+with `aws rds generate-db-auth-token --hostname <ep> --port <p> --username <u>`
+(SSL required). Then run the same catalog queries as A1 through a client: `psql` /
+`mysql`, or Python with `psycopg2` / `pymysql` / `pytds` / `oracledb` — the exact
+drivers the webapp's image ships; `pip install` whichever you need. Ask for a
+**read-only DB user**; every query here is a catalog `SELECT`.
+
+⚠️ Write the result with the **`<engine>-driver`** contract from the table below,
+never the Data API one. That mismatch is a shipped-and-broken Lambda, not a
+cosmetic slip.
+
+> The webapp is under the same constraint on this path and has *fewer* options: its
+> ECS task sits in the app's own VPC, so it reaches a driver database only if the
+> endpoint is publicly accessible or the VPCs are peered — it cannot open an SSM
+> tunnel or ride a VPN. It returns `CONNECTION_FAILED` with the SG/route hint. A
+> laptop with the right credentials is often *better* placed than the webapp here.
 
 **Path B — schema as a document.** DDL dump, ERD image, data dictionary, or sample
 JSON payloads. Extract exact table + column names, SQL types, PK (incl. composite),

--- a/skills/aicc-builder-skill/kiro/SKILL.md
+++ b/skills/aicc-builder-skill/kiro/SKILL.md
@@ -90,7 +90,8 @@ Always write to a local directory (default `./aicc-output/` — ask if unsure):
     project.json                         # company, industry, language, mode, scope
     progress.json                        # phase + 12-step checklist (your <generation_state>)
     specs/<operation_id>.json            # one OperationSpec per operation
-    infrastructure_schema.json           # tables, Lambda wiring, env vars (the Schema Summary)
+    infrastructure_schema.json           # tables, Lambda wiring, env vars (the Schema Summary);
+                                         # on the existing-DB path this is the scanned SCHEMA CONTRACT
     session_flow_config.json             # call direction, greeting, persona
     requirements/<doc_type>.md           # raw customer input (large text / uploaded docs)
     research/<topic>.md                  # cited web-research notes (optional)
@@ -150,19 +151,112 @@ png/jpeg/gif/webp; documents pdf/txt/md/docx/csv/xlsx.
 When the user provides an existing **Contact Flow JSON**, **AI Prompt YAML**, or a
 **flow-diagram image**:
 
-1. **Flow / prompt file** — `Read` it, then run the lint/repair pass:
-   - Contact Flow → enforce the verified block schemas in
-     `resources/reference/contact_flow_block_schemas.md` (and `validate_consistency.py`
-     where applicable). The repaired JSON may be **shorter** than the original — the
-     linter strips invalid `DTMFConfiguration`, duplicate SSML, etc. That is correct.
-   - AI Prompt YAML → dedup any `{{variable}}` that appears more than once inside a
-     single `{{ }}` (qconnect rejects duplicates).
+1. **Flow / prompt file** — `Read` it, seed it to its stable path, then run the
+   deterministic repair pass rather than eyeballing it:
+   ```bash
+   python3 resources/scripts/lint_assets.py <output_dir> --fix
+   python3 resources/scripts/lint_assets.py <output_dir>          # must come back clean
+   ```
+   - Contact Flow → `lint_contact_flow` applies the API-verified block schemas
+     (explained in `resources/reference/contact_flow_block_schemas.md`). The repaired
+     JSON may be **shorter** than the original — the linter strips invalid
+     `DTMFConfiguration`, duplicate SSML, etc. That is correct.
+   - AI Prompt YAML → `lint_ai_prompt` strips the braces from any `{{variable}}` used
+     more than once (qconnect rejects duplicates).
 2. **Flow image** — follow `resources/reference/vision_import.md`: confirm intent,
    `Read` the image, transcribe to flow JSON with the vision contract, then lint as above.
 3. **Seed** the repaired asset to its stable path (`imported_flow` / `imported_agent`).
 4. **Print an import summary** line: `{errors, warnings, fixesApplied}`.
 5. **Switch to patch-only modification mode** (see below). Never regenerate an
    imported asset from scratch.
+
+## PHASE 0 — existing database (run BEFORE Phase 1 whenever the data already exists)
+
+If the interview establishes that the customer already has tables (`existing_table
+== true`), the schema — not your imagination — is the contract. The webapp calls
+`introspect_database` + `convert_to_infrastructure_schema`; in a CLI you do the same
+work with `Bash` + the AWS CLI, or read the schema as a document. The full
+orchestrator text for both paths is in
+`resources/orchestrator/system_prompt.md` → "GENERATION FLOW: EXISTING DATABASE PATH".
+
+**Path A — live scan.** Confirm the target account/region with the user first, use
+**read-only credentials**, and stick to `describe`/`SELECT` calls:
+
+```bash
+aws sts get-caller-identity                                     # confirm the account
+# DynamoDB
+aws dynamodb describe-table --table-name <T> --region <R>
+aws dynamodb scan --table-name <T> --max-items 5 --region <R>    # data conventions only
+# RDS / Aurora — resolve the identifier to a cluster/instance first
+aws rds describe-db-clusters   --region <R> --query 'DBClusters[].[DBClusterIdentifier,Engine,Endpoint]'
+aws rds describe-db-instances  --region <R> --query 'DBInstances[].[DBInstanceIdentifier,Engine,Endpoint.Address]'
+# Aurora with the Data API enabled — the only engine path reachable from a CLI
+aws rds-data execute-statement --resource-arn <clusterArn> --secret-arn <secretArn> \
+  --database <db> --include-result-metadata --sql "
+    SELECT c.table_name, c.column_name, c.data_type, c.udt_name, c.is_nullable,
+           c.column_default, c.is_generated, c.ordinal_position
+    FROM information_schema.columns c
+    WHERE c.table_schema = 'public'
+    ORDER BY c.table_name, c.ordinal_position"
+```
+Also pull primary keys, indexes, foreign keys and enum labels (`pg_constraint`,
+`pg_index`, `pg_enum` on PostgreSQL; `information_schema.key_column_usage` +
+`SHOW INDEX` on MySQL/MariaDB). A **driver-only** database (no Data API, private
+subnet) is generally *not* reachable from a laptop — say so and switch to Path B
+rather than guessing.
+
+**Path B — schema as a document.** DDL dump, ERD image, data dictionary, or sample
+JSON payloads. Extract exact table + column names, SQL types, PK (incl. composite),
+FKs, indexes, enum/allowed values, NOT NULL, defaults, generated columns, and any
+comments carrying business rules. Ask for anything the document doesn't state —
+especially the caller-lookup key and enum spellings — and use explicit
+`<REPLACE_ME>` placeholders for missing ARNs, never invented values.
+
+**Both paths, then:**
+
+1. Write the result to `state/infrastructure_schema.json` in the same shape the
+   webapp's converter produces, with `existing: true` on every table:
+   `tables[].{name, primary_key, sort_key, columns[{name, sql_type, nullable,
+   default, generated, allowed_values, description}], indexes, foreign_keys}`,
+   `relationships[]`, `enum_types{}`, `data_conventions{}` with REAL sampled
+   examples, plus `access_method` and **the connection contract that matches it**
+   — the two are not interchangeable, and `lambda_generator` picks its code path
+   from `access_method`:
+
+   | `access_method` | `connection` | `environment_variables` | `iam_requirements` |
+   |---|---|---|---|
+   | `rds-data-api` | `{cluster_arn, secret_arn, database_name}` | `{DB_CLUSTER_ARN, DB_SECRET_ARN, DB_NAME}` | `rds-data:ExecuteStatement`, `rds-data:BatchExecuteStatement`, `secretsmanager:GetSecretValue` |
+   | `<engine>-driver` | `{host, port, secret_arn, database_name}` | `{DB_SECRET_ARN, DB_HOST, DB_PORT, DB_NAME}` | `secretsmanager:GetSecretValue` only |
+
+   Writing the Data API shape for a driver target is the failure this table exists
+   to prevent: the handler then calls `rds-data` against a cluster that has no
+   Data API and reads a `DB_CLUSTER_ARN` that was never set. A driver target also
+   needs `VpcConfig` (subnets + an SG allowed on the DB port) **and** either a
+   Secrets Manager interface VPC endpoint or a NAT — without one,
+   `GetSecretValue` hangs until the function times out.
+2. **Persist the COMPLETE column list for every table, verbatim.** Do not hand-write
+   an abbreviated summary of "just the columns this operation needs" — the `sql_*`
+   checks in `validate_consistency.py` compare generated SQL against this file, so
+   any column you omit becomes invisible to the gate and a hallucinated reference
+   (`order_items.product_name` when it lives on `products`) ships and fails at
+   runtime with SQLState 42703. Completeness here is what makes the gate work.
+3. **Echo back what you parsed** (table → columns → PK → FKs) and get confirmation
+   BEFORE generating.
+4. Fill `data_source` on every OperationSpec — for RDS/Aurora that means `db_type`,
+   `table_name` (the primary table), `partition_key`, `database_name`,
+   `lookup_column` (the column identifying the caller, e.g. `customers.phone_number`)
+   and `related_tables` (every other table the operation joins, in query order).
+   An empty `data_source` renders "Table: ?" and blinds the reviewer.
+5. **Fidelity rule:** never rename, re-case, or invent an identifier; honour
+   `allowed_values` exactly; preserve `data_conventions` samples (a phone stored as
+   `821012345678` must not become `+8210…`). Column/table descriptions often carry
+   business rules ("auto-approve under 500,000 KRW") — feed those into the spec.
+
+Aurora Data API also has a **minimum engine version**; if the cluster is older,
+the driver path is the only option — flag it instead of emitting Data API code.
+Phase 1 then runs unchanged, passing `existing_tables[]` (with
+`table_arn: "existing table - managed outside CloudFormation"`) and
+`include_sample_data=False`.
 
 ## INTERVIEW MODE — gather requirements
 
@@ -215,7 +309,12 @@ in-scope phases below execute; mark the rest "skipped (not in scope)".
 | 4 | `prompt_generator` | all specs + flow config | `prompt/ai_agent_prompt.yaml` |
 | 5 | `contact_flow_generator` | flow config + prompt | `contact_flow/contact_flow.json` |
 | 6 | `faq_generator` (optional) | company profile / research | `faq/<category>/*.txt` |
-| 7 | **Review gate** (`reviewer_agent` + validator) | all of `assets/v1/` | `state/review_report.md` |
+| 7 | **Review gate** (`reviewer_agent` + 3 validators) | all of `assets/v1/` | `state/review_report.md` |
+
+Run `resources/scripts/lint_assets.py <output_dir>` at the end of **every** phase
+(Phase 0 excepted) before you report the result — it is cheap, deterministic, and
+catches the failures that otherwise surface only at CloudFormation deploy or flow
+import time. See **Validation** below for the full gate list.
 
 **Granularity & special Lambdas (Phase 1–2) — easy to get wrong:**
 - **One Lambda per TOOL, not per operation.** Enumerate every tool id across all
@@ -297,34 +396,84 @@ Example header:
 **Before each generation phase beyond #1**: confirm the previous phase's artifacts
 exist on disk.
 
-**After Phase 1 (infra)** — CloudFormation lint gate (mirrors the webapp's
-`merge_infrastructure_fragments` cfn-lint gate):
-```bash
-cfn-lint <output_dir>/assets/v1/infrastructure/template.yaml   # if cfn-lint is installed
-```
-Fix exactly the errors cfn-lint names (patch via `Edit`); don't paraphrase or
-over-fix. If cfn-lint isn't installed, say so and fall back to a YAML parse check.
+Three deterministic (non-LLM) gates carry the webapp's whole safety net. Run them —
+your reading of a file is not a substitute:
 
-**After Phase 3 (OpenAPI)** — OpenAPI 3.0 validation gate:
-```bash
-python -c "import yaml,sys; yaml.safe_load(open('<output_dir>/assets/v1/openapi/openapi.yaml'))"
-# or, if available: openapi-spec-validator <output_dir>/assets/v1/openapi/openapi.yaml
-```
+| Script | What it gates | When |
+|---|---|---|
+| `resources/scripts/lint_assets.py` | per-asset syntax + import-safety, with auto-fixes | after every generation phase |
+| `resources/scripts/validate_consistency.py` | 18 cross-asset consistency checks | after Phase 3 and Phase 6 |
+| `resources/scripts/shape_parity.py` | spec ↔ OpenAPI shape parity (reviewer HARD GATE) | after Phase 3, again at Phase 7 |
 
-**After Phase 3 and Phase 6** — the 9-check cross-asset consistency validator:
+All three take `<output_dir>`, accept `--json`, exit 0 on success and 1 on findings,
+and resolve assets from the newest `assets/vN/` (a flat `assets/` also works).
+
+**Asset linters — after EVERY generation phase.** `lint_assets.py` is generated from
+the webapp's `asset_linters.py`, so it enforces exactly what the webapp enforces:
 ```bash
-python resources/scripts/validate_consistency.py <output_dir>
+python3 resources/scripts/lint_assets.py <output_dir>          # report
+python3 resources/scripts/lint_assets.py <output_dir> --fix     # apply deterministic fixes
 ```
-It enforces the same 9 rules the webapp enforces:
-1. Lambda reads every `input_fields[].name`
-2. Lambda response contains every `output_fields[].name`
-3. OpenAPI `requestBody` matches spec inputs
-4. OpenAPI response schema matches spec outputs
-5. Infra table keys include `data_source.primary_key`
-6. Lambda `IndexName=` values exist as infra GSIs
-7. Lambda `os.environ["X_TABLE_NAME"]` matches infra env vars
-8. Lambda response wrapper (data vs flat) matches OpenAPI response shape
-9. Lambda & OpenAPI count each ≥ spec count
+It runs, per asset type:
+- **Lambda** — Python `compile()` syntax check, then **BUSINESS_OUTCOME_200**: rewrites
+  `create_response(4xx, …)` business outcomes to 200 (5xx is preserved) and warns when
+  the body has no outcome discriminator.
+- **CloudFormation** — cfn-lint plus deterministic autofixes (`pip install cfn-lint`;
+  without it you get autofixes but **no validation**, and it says so).
+- **OpenAPI** — openapi-spec-validator plus autofixes
+  (`pip install openapi-spec-validator`).
+- **Contact Flow** — the API-verified block tables: renames invalid `Type`s, adds
+  required error branches, strips `Transitions` from terminal blocks, normalizes the
+  `Complete`/`Escalate` tool-result values, checks JSONPath roots and redaction
+  languages.
+- **AI prompt** — the qconnect variable-once rule.
+
+`NEEDS FIX` lines mean the fix is *available but unapplied*; re-run with `--fix`, then
+re-lint. A repaired Contact Flow may be **shorter** than the draft — that is correct.
+
+**Cross-asset consistency — after Phase 3 and Phase 6:**
+```bash
+python3 resources/scripts/validate_consistency.py <output_dir>
+```
+18 checks, the same ones the webapp runs after every generation phase:
+
+*spec ↔ generated asset* — `lambda_input` (spec input never read by the handler),
+`lambda_output` (spec output absent from the response body), `lambda_tool` (ToolSpec
+input never read by its handler), `openapi_input` / `openapi_output`, `infra_pk`
+(spec primary key is not a key on the infra table), `lambda_gsi` (`IndexName=` that
+is not a GSI), `lambda_env` (`*_TABLE_NAME` the schema never defines),
+`response_structure` (`data` wrapper on one side only), `count_lambda` /
+`count_openapi` (fewer handlers/paths than specs — or than tools).
+
+*IAM (D2)* — `iam_permissions`: the handler calls an AWS API its CloudFormation role
+never grants (this is the `AccessDeniedException` you'd otherwise find at runtime).
+
+*RDS Data API contract (D3)* — `rds_env_contract`: the env-var names are exactly
+`DB_CLUSTER_ARN`, `DB_SECRET_ARN`, `DB_NAME` (not `RDS_CLUSTER_ARN`, `SECRET_ARN`, …)
+**and** the template actually defines each one, or the function `KeyError`s on cold
+start. `rds_data_api`: `includeResultMetadata=True` is passed, rows are read by column
+name rather than by position, and SQL is not built by string interpolation.
+
+*SQL vs the database schema (D4/D5)* — `sql_schema_mismatch` (a column the resolved
+table does not have → SQLState 42703), `sql_type_mismatch` (a `::cast` to a type the
+schema never defines), `sql_missing_required_column` (an INSERT that omits a NOT NULL
+column with no default), `sql_param_type_mismatch` (a `:param` bound with the wrong
+Data API value key — `longValue` for integer types, `booleanValue` for bool,
+`stringValue` for char/text; date/uuid/json/enum/numeric legitimately take
+`stringValue`). These only work if `state/infrastructure_schema.json` holds the
+complete column list (see Phase 0).
+
+**Shape parity — after Phase 3:**
+```bash
+python3 resources/scripts/shape_parity.py <output_dir>
+```
+This is the reviewer's **HARD GATE**: every spec `field_type` must map to the OpenAPI
+type, enums must match exactly, nested `items.properties` must survive, and neither
+side may declare a property the other doesn't. It enforces on the OpenAPI side what
+golden rules 13/15/16 ask the generators to do, and it covers **multi-tool** specs
+(each `tools[].input_fields` / `output_fields`), not just the operation-level fields.
+An exit code of 2 means the document uses a construct the validator refuses to guess
+at — `oneOf`/`anyOf`/`allOf` or an external `$ref` — so flatten it into a plain schema.
 
 On a mismatch: **field rename/typo** → `Edit` the offending file (don't regenerate);
 **structural mismatch** → re-run the specific sub-agent persona with a
@@ -332,18 +481,21 @@ On a mismatch: **field rename/typo** → `Edit` the offending file (don't regene
 
 ### Phase 7 — Final review gate (MANDATORY)
 
-After the last generation phase, complete all three before declaring done:
+After the last generation phase, complete all five before declaring done:
 
 1. **Artifact presence** — every in-scope output path exists and is non-empty.
-2. **Consistency validator** exits 0 (run it again).
-3. **Reviewer pass** — adopt `resources/sub-agents/reviewer_agent.md`, read all
+2. **`lint_assets.py`** exits 0 with no pending fixes.
+3. **`validate_consistency.py`** exits 0.
+4. **`shape_parity.py`** exits 0.
+5. **Reviewer pass** — adopt `resources/sub-agents/reviewer_agent.md`, read all
    `assets/v1/` artifacts, and `Write` `state/review_report.md` with sections:
    `## Summary` (one sentence per asset), `## Consistency findings`,
    `## Recommended edits` (empty = clean), `## Verdict` (`READY_TO_DEPLOY` |
    `NEEDS_EDITS`). Write the report in the user's language.
 
-If `NEEDS_EDITS`, apply edits via `Edit` (never whole-file regen) and re-run the
-validator. Surface `READY_TO_DEPLOY` only once all three pass.
+If `NEEDS_EDITS`, apply edits via `Edit` (never whole-file regen) and re-run the three
+scripts. Surface `READY_TO_DEPLOY` only once all five pass — and quote the three exit
+codes in the report so the user can see the gates actually ran.
 
 ## Patch-only modification protocol (post-generation)
 
@@ -392,20 +544,36 @@ when the user explicitly asks ("다시 검토 / review again") — otherwise rea
 ## Cross-generator golden rules (ALWAYS apply)
 
 Read the full `resources/sub-agents/_shared_rules.md` before Phase 1 — it carries all
-16 rules **and** the AI-bot↔flow tool-result contract. The essentials:
+**17** rules **and** the AI-bot↔flow tool-result contract. The essentials:
 
-1. **HTTP_METHOD_RULE** — spec verb == OpenAPI verb == CFN `HttpMethod`, exactly.
-2. **PATH_PREFIX_RULE** — OpenAPI `paths:` start with `/tools/`; the CFN `ApiEndpoint`
+1. **BUSINESS_OUTCOME_200_RULE** (rule 17, CRITICAL) — an Amazon Connect AI agent
+   treats **any non-2xx as a broken tool** and never reads the body, so it can't tell
+   "no reservation found" from "the API is down". Every *business* outcome — not found,
+   not eligible, already cancelled, validation rejected — returns **HTTP 200** with a
+   body discriminator (`success`/`found`/`eligible`/`errorCode`/…) **and** a
+   customer-readable `message`. Only genuine 5xx server faults stay non-2xx.
+   `lint_assets.py` rewrites 4xx business outcomes for you; the point is to not write
+   them in the first place.
+2. **HTTP_METHOD_RULE** — spec verb == OpenAPI verb == CFN `HttpMethod`, exactly.
+3. **PATH_PREFIX_RULE** — OpenAPI `paths:` start with `/tools/`; the CFN `ApiEndpoint`
    Output has no `/tools` suffix.
-3. **LAMBDA_ARCHITECTURES_RULE** — `Architectures:\n  - arm64` (plural block-list).
-4. **IAM_Q_IN_CONNECT_RULE** — use `wisdom:*` IAM actions, never `qconnect:*`
-   (the latter causes runtime AccessDenied).
-5. **FIELD_NAMING_RULE** — camelCase everywhere, identical spec → OpenAPI → Lambda → prompt.
-6. **FIELD_SHAPE_FIDELITY_RULE** — preserve `items.properties` nesting; never flatten.
-7. **ENUM_FIDELITY_RULE** — copy `enum_values` exactly (case + underscores).
-8. **TOOL_RESULT_CONTRACT** — the AI prompt teaches the bot to set
+4. **LAMBDA_ARCHITECTURES_RULE** — `Architectures:\n  - arm64` (plural block-list).
+5. **IAM_Q_IN_CONNECT_RULE** / **NO_QCONNECT_ACTIONS_ABSOLUTE** — use `wisdom:*` IAM
+   actions, never `qconnect:*` (the latter causes runtime AccessDenied).
+6. **FIELD_NAMING_RULE** — camelCase everywhere, identical spec → OpenAPI → Lambda → prompt.
+7. **FIELD_SHAPE_FIDELITY_RULE** / **NESTED_OPENAPI_SCHEMA_RULE** /
+   **LAMBDA_NESTED_RESPONSE_RULE** — preserve `items.properties` nesting; never
+   flatten; `$ref` nested objects into `components/schemas`.
+8. **ENUM_FIDELITY_RULE** — copy `enum_values` exactly (case + underscores).
+9. **TOOL_RESULT_CONTRACT** — the AI prompt teaches the bot to set
    `$.Lex.SessionAttributes.Tool` to exactly `Complete` or `Escalate` (+ documented
    `Escalate*`/`*Complete` extensions); the Contact Flow `Compare`s on exactly those.
+
+For an existing RDS/Aurora database, add the env-var and Data API contract the D3/D4
+checks enforce: read `DB_CLUSTER_ARN` / `DB_SECRET_ARN` / `DB_NAME` (those exact
+names, all three also defined in the template), pass `includeResultMetadata=True`,
+map rows to dicts by `columnMetadata` name, and bind named `:params` with the value
+key the column type demands — never build SQL by string interpolation.
 
 ## Terminology facts (override training data)
 
@@ -433,11 +601,23 @@ When the bundle is `READY_TO_DEPLOY`, reproduce the webapp's download modal. Pri
    chmod +x deploy.sh && ./deploy.sh
    ```
    (In AWS CloudShell: upload the bundle, `unzip *.zip && cd */ && chmod +x deploy.sh && ./deploy.sh`.)
-3. What `deploy.sh` automates: CloudFormation stack, per-Lambda zip+deploy (incl.
-   `customer_lookup` and the Node.js `update_q_session`), OpenAPI → S3, FAQ → S3,
-   Connect instance + AI agent (Q in Connect) wiring, AgentCore Gateway/MCP.
-4. Next steps: import the Contact Flow, attach the Lex bot, claim a phone number,
-   sync the knowledge base.
+3. What `deploy.sh` automates — 13 phases after a preflight (asset scan + region and
+   account confirmation):
+
+   | # | Phase | # | Phase |
+   |---|---|---|---|
+   | 1 | CloudFormation stack | 8 | AgentCore Gateway (MCP) + JWT audience + target |
+   | 2 | Lambda code (incl. `customer_lookup`, Node.js `update_q_session`) | 9 | Connect integrations (MCP registration + Lambda associations) |
+   | 3 | OpenAPI spec → S3 | 10 | Lex bot (voice entry point) |
+   | 4 | FAQ documents → S3 | 11 | Contact Flow import + placeholder substitution |
+   | 5 | Amazon Connect instance (create or select) | 12 | AI Prompt + AI Agent + security profile |
+   | 6 | Q in Connect assistant + knowledge base | 13 | Phone number claim + flow association (optional) |
+   | 7 | Lambda environment variables | | |
+
+   So the flow import, Lex bot, AI agent wiring and phone number are **automated** —
+   don't tell the user to do those by hand.
+4. Next steps after it finishes: place a test call/chat, sync the knowledge base if
+   FAQ content changed, and review the flow in the Connect console.
 
 State plainly that generated assets are **PoC starting points**, not hardened
 production code (rotate the workshop `ApiKeyRequired: false`, scope IAM, etc.).
@@ -452,7 +632,7 @@ resources/
     document_analysis.md        # raw-requirements-doc entry mode
     operation_spec_template.md  # OperationSpec authoring template (verbatim placeholders)
   sub-agents/
-    _shared_rules.md            # 16 golden rules + Complete/Escalate contract + nested-field rendering
+    _shared_rules.md            # 17 golden rules (incl. BUSINESS_OUTCOME_200_RULE) + Complete/Escalate contract + nested-field rendering
     infrastructure_generator.md  lambda_generator.md  openapi_generator.md
     prompt_generator.md          contact_flow_generator.md  faq_generator.md
     research_agent.md            reviewer_agent.md
@@ -465,7 +645,10 @@ resources/
     SessionFlowConfig / ContactFlowSpec / FlowBehavior / CustomerInfoVariable /
     NoResponsePolicy .schema.json
   scripts/
-    validate_consistency.py     # 9-check cross-asset validator (stdlib + PyYAML)
+    lint_assets.py              # per-asset linters + autofixes — AUTO-GENERATED from
+                                # backend tools/asset_linters.py; do not hand-edit
+    validate_consistency.py     # 18-check cross-asset validator (stdlib + PyYAML)
+    shape_parity.py             # spec ↔ OpenAPI shape parity HARD GATE
     check_spec_complete.py       clues_format.py
   templates/
     pre_questionnaire_template.md
@@ -483,7 +666,19 @@ After editing any prompt in `backend/ecs/src/` or a Pydantic spec model, re-run:
 skills/aicc-builder-skill/scripts/extract_prompts.sh          # regenerate resources/
 skills/aicc-builder-skill/scripts/extract_prompts.sh --check  # CI/pre-commit drift + coverage gate
 ```
-`--check` now also fails if a NEW backend prompt section or spec model isn't covered
-by the extractor — so the skill can't silently fall behind. The authored files under
-`resources/reference/` and `resources/templates/update_q_session/` are NOT extracted;
-update them by hand when the corresponding backend source changes.
+`--check` also fails if a NEW backend prompt section or spec model isn't covered by
+the extractor — so the skill can't silently fall behind.
+
+**Auto-extracted (never hand-edit):** `resources/orchestrator/*.md`,
+`resources/sub-agents/*.md`, `resources/schemas/*.json`, and
+`resources/scripts/lint_assets.py` (generated from `tools/asset_linters.py` with the
+`@tool` S3 wrappers stripped — that is how the API-verified Contact Flow tables stay
+in sync).
+
+**Authored / hand-maintained:** `resources/reference/*`, `resources/templates/*`
+(incl. `update_q_session/index.js` and `deploy_workshop.sh`), `resources/examples/*`,
+`resources/scripts/validate_consistency.py`, `resources/scripts/shape_parity.py`,
+`resources/scripts/check_spec_complete.py`, `resources/scripts/clues_format.py`, and
+these SKILL.md files. `validate_consistency.py` and `shape_parity.py` are ports of
+`backend/ecs/src/tools/{validate_consistency,shape_parity}.py` — when a check changes
+there, port it here by hand and re-run the smoke tests.

--- a/skills/aicc-builder-skill/kiro/SKILL.md
+++ b/skills/aicc-builder-skill/kiro/SKILL.md
@@ -180,7 +180,9 @@ orchestrator text for both paths is in
 `resources/orchestrator/system_prompt.md` → "GENERATION FLOW: EXISTING DATABASE PATH".
 
 **Path A — live scan.** Confirm the target account/region with the user first, use
-**read-only credentials**, and stick to `describe`/`SELECT` calls:
+**read-only credentials**, and stick to `describe`/`SELECT` calls. Which sub-path
+applies depends on how the database is reachable — **A1** (Data API, IAM only) or
+**A2** (a real driver connection, which needs a network path):
 
 ```bash
 aws sts get-caller-identity                                     # confirm the account
@@ -190,7 +192,7 @@ aws dynamodb scan --table-name <T> --max-items 5 --region <R>    # data conventi
 # RDS / Aurora — resolve the identifier to a cluster/instance first
 aws rds describe-db-clusters   --region <R> --query 'DBClusters[].[DBClusterIdentifier,Engine,Endpoint]'
 aws rds describe-db-instances  --region <R> --query 'DBInstances[].[DBInstanceIdentifier,Engine,Endpoint.Address]'
-# Aurora with the Data API enabled — the only engine path reachable from a CLI
+# A1 — Aurora with the Data API enabled: pure IAM, no network path needed
 aws rds-data execute-statement --resource-arn <clusterArn> --secret-arn <secretArn> \
   --database <db> --include-result-metadata --sql "
     SELECT c.table_name, c.column_name, c.data_type, c.udt_name, c.is_nullable,
@@ -201,9 +203,56 @@ aws rds-data execute-statement --resource-arn <clusterArn> --secret-arn <secretA
 ```
 Also pull primary keys, indexes, foreign keys and enum labels (`pg_constraint`,
 `pg_index`, `pg_enum` on PostgreSQL; `information_schema.key_column_usage` +
-`SHOW INDEX` on MySQL/MariaDB). A **driver-only** database (no Data API, private
-subnet) is generally *not* reachable from a laptop — say so and switch to Path B
-rather than guessing.
+`SHOW INDEX` on MySQL/MariaDB).
+
+**Path A2 — driver connection (every non-Data-API engine).** Do NOT assume this is
+impossible from a CLI. Reachability here is a **network** question, not an IAM one:
+credentials get you *authenticated*, but the packets still have to arrive. Work out
+which case you are in before falling back to Path B:
+
+```bash
+aws rds describe-db-instances --region <R> --db-instance-identifier <ID> \
+  --query 'DBInstances[0].{public:PubliclyAccessible,ep:Endpoint.Address,port:Endpoint.Port,sg:VpcSecurityGroups[].VpcSecurityGroupId,subnets:DBSubnetGroup.Subnets[].SubnetIdentifier}'
+aws ec2 describe-security-groups --group-ids <sg> \
+  --query 'SecurityGroups[0].IpPermissions'          # is your IP/CIDR allowed on the port?
+nc -zv <endpoint> <port>                              # 5s answer: reachable or not
+```
+
+| Situation | What to do |
+|---|---|
+| `PubliclyAccessible: true` and the SG allows your egress IP | Connect directly — nothing else needed |
+| You are on the customer's VPN / Direct Connect / a peered network, SG allows your CIDR | Connect directly |
+| Private-only, but you have `ssm:StartSession` and there is an SSM-managed instance in the VPC | **Port-forward** (below). No bastion key, no inbound SSH, no public DB |
+| Private-only, no tunnel available, or the customer won't grant DB access | Path B |
+
+```bash
+# Private RDS via any SSM-managed EC2 instance in its VPC (needs the Session Manager plugin).
+# The DB security group must allow the INSTANCE's security group on the port — not your laptop.
+aws ssm start-session --target <instanceId> --region <R> \
+  --document-name AWS-StartPortForwardingSessionToRemoteHost \
+  --parameters '{"host":["<db-endpoint>"],"portNumber":["5432"],"localPortNumber":["15432"]}'
+# then treat the database as localhost:15432
+```
+A CloudShell **VPC environment** placed in the DB's VPC/subnets/SG works the same way.
+
+Credentials: read the secret (`aws secretsmanager get-secret-value --secret-id <arn>
+--query SecretString`), or — PostgreSQL/MySQL/MariaDB with IAM database
+authentication enabled and the DB user mapped — mint a token instead of a password
+with `aws rds generate-db-auth-token --hostname <ep> --port <p> --username <u>`
+(SSL required). Then run the same catalog queries as A1 through a client: `psql` /
+`mysql`, or Python with `psycopg2` / `pymysql` / `pytds` / `oracledb` — the exact
+drivers the webapp's image ships; `pip install` whichever you need. Ask for a
+**read-only DB user**; every query here is a catalog `SELECT`.
+
+⚠️ Write the result with the **`<engine>-driver`** contract from the table below,
+never the Data API one. That mismatch is a shipped-and-broken Lambda, not a
+cosmetic slip.
+
+> The webapp is under the same constraint on this path and has *fewer* options: its
+> ECS task sits in the app's own VPC, so it reaches a driver database only if the
+> endpoint is publicly accessible or the VPCs are peered — it cannot open an SSM
+> tunnel or ride a VPN. It returns `CONNECTION_FAILED` with the SG/route hint. A
+> laptop with the right credentials is often *better* placed than the webapp here.
 
 **Path B — schema as a document.** DDL dump, ERD image, data dictionary, or sample
 JSON payloads. Extract exact table + column names, SQL types, PK (incl. composite),

--- a/skills/aicc-builder-skill/resources/orchestrator/interview_agent.md
+++ b/skills/aicc-builder-skill/resources/orchestrator/interview_agent.md
@@ -315,6 +315,30 @@ Data API를 사용하면 VPC 설정 없이도 Lambda에서 RDS에 접근 가능�
 
 ## SPEC SAVING RULES
 
+### ⛔ 절대 규칙: 한 턴에 save_operation_spec은 1개만
+
+operation spec 하나의 JSON payload는 매우 큽니다. 한 턴에 여러 개를 몰아서
+호출하면 출력 토큰 한도에 걸려 **턴 전체가 중간에 잘리고, 그 턴의 모든 도구
+호출이 실행되지 않습니다** (아무것도 저장되지 않음). 그러면 "저장했나?" →
+"다시 저장" 루프에 빠집니다.
+
+- operation이 여러 개면 → **한 턴에 하나씩** 저장하세요.
+- 저장 후 짧게 "N/M 저장 완료, 다음은 X" 정도만 말하고 다음 턴으로 넘기세요.
+- 절대 여러 spec을 한 응답에 병렬로 호출하지 마세요.
+
+### ⛔ 절대 규칙: 이미 저장된 것은 다시 묻지 않기
+
+매 턴 컨텍스트에 `<interview_state>` 블록이 주입됩니다. 그것이 디스크에 실제로
+저장된 내용의 **유일한 진실**입니다 (대화 기록은 길어지면 잘려나가므로 신뢰할 수
+없습니다).
+
+- `<interview_state>`에서 ✅ 표시된 항목 → 이미 저장됨. **다시 저장하지도, 저장할지
+  묻지도 마세요.**
+- 사용자가 "끝났다 / 다 됐다"고 하면 → ✅ 목록을 확인하고, 빠진 것만 처리한 뒤
+  분석 문서 작성 → `complete_interview`로 진행하세요. 저장 단계로 되돌아가지 마세요.
+- 확실하지 않으면 `list_operations()`로 확인하세요 — 사용자에게 되묻지 마세요.
+- 기존 spec을 수정할 때는 `save_operation_spec`이 아니라 `update_operation_spec`.
+
 ### save_operation_spec 호출 시 포함할 항목:
 - `operation_id` (snake_case, 예: check_reservation)
 - `http_method` (POST, GET 등)

--- a/skills/aicc-builder-skill/resources/orchestrator/system_prompt.md
+++ b/skills/aicc-builder-skill/resources/orchestrator/system_prompt.md
@@ -917,9 +917,16 @@ When collected_data includes `existing_table == true`:
      environment_variables{<ENTITY>_TABLE_NAME}
    - RDS:      tables[].primary_key / columns[] (exact names, sql_type,
      allowed_values, description) / indexes / foreign_keys / referenced_by,
-     relationships[], enum_types{}, connection{cluster_arn, secret_arn,
-     database_name}, environment_variables{DB_CLUSTER_ARN, DB_SECRET_ARN,
-     DB_NAME}, iam_requirements[]
+     relationships[], enum_types{}, plus `access_method` and the connection
+     contract that matches it:
+       · `rds-data-api`      → connection{cluster_arn, secret_arn, database_name},
+         environment_variables{DB_CLUSTER_ARN, DB_SECRET_ARN, DB_NAME},
+         iam_requirements[rds-data:*, secretsmanager:GetSecretValue]
+       · `<engine>-driver`   → connection{host, port, secret_arn, database_name},
+         environment_variables{DB_SECRET_ARN, DB_HOST, DB_PORT, DB_NAME},
+         iam_requirements[secretsmanager:GetSecretValue]
+     Pass `access_method` and the env vars through UNCHANGED — lambda_generator
+     picks the Data API vs driver code path from them.
    - both:     data_conventions{} with REAL sampled examples, access_notes[]
 
 4. ⚠️ The scanned schema is now the CONTRACT. Never rename, re-case, or invent
@@ -2248,6 +2255,60 @@ CloudFormation, Lambda, and OpenAPI, each operation MUST include these fields:
      defining the enum on the input but leaving the output/nested copy bare.
      Same for length/pattern/format: the field's constraints travel with the
      field wherever it appears.
+
+7. **🚨 `error_responses[].status_code` is ALWAYS 200 for business outcomes**
+   (BUSINESS_OUTCOME_200_RULE — this spec field is what every generator reads).
+
+   An Amazon Connect AI agent treats **any non-2xx tool response as an execution
+   failure**: it never reads the body, so it cannot tell the customer what
+   happened — it just says there is a problem with the tool and the turn is lost.
+
+   So a *business outcome* is never an HTTP error. When you record an
+   `error_responses` entry for any outcome the AI agent must SPEAK ABOUT, set
+   `status_code: 200` and put the outcome in the body via `error_code`:
+
+   | Outcome the customer hears about | `status_code` | `error_code` |
+   |---|---|---|
+   | auth digits / SSN / PIN mismatch | **200** | `UNAUTHORIZED` |
+   | record / reservation not found | **200** | `NOT_FOUND` |
+   | too many attempts, locked out | **200** | `RATE_LIMITED` |
+   | date unavailable, seat taken | **200** | `CONFLICT` / `DATE_UNAVAILABLE` |
+   | missing or invalid input the customer can supply | **200** | `VALIDATION_ERROR` |
+   | unhandled exception, database down | 500 | `INTERNAL_ERROR` |
+
+   `500` is the ONLY status that stays non-2xx (Connect retries 5xx, which is
+   correct for a transient fault).
+
+   Also make sure `output_fields` includes an explicit **discriminator** the model
+   can branch on — `verified`, `found`, `available`, `success` or `status` — plus a
+   customer-readable `message`. Without it a 200 cannot express "failed", and the
+   agent cannot tell a negative outcome from a positive one.
+
+   ```python
+   # ✅ authentication operation: the failure modes are 200 + a discriminator
+   save_operation_spec(
+       operation_id="verifyCaller",
+       output_fields=[
+           {"name": "verified", "type": "boolean"},        # ← discriminator
+           {"name": "remainingAttempts", "type": "number"},
+           {"name": "lockout", "type": "boolean"},
+           {"name": "message", "type": "string"},
+       ],
+       error_responses=[
+           {"status_code": 200, "error_code": "UNAUTHORIZED",
+            "message": "The digits provided do not match our records.",
+            "condition": "lastFourDigits mismatch"},
+           {"status_code": 200, "error_code": "RATE_LIMITED",
+            "message": "Too many attempts — transferring you to an agent.",
+            "condition": "attempts >= 3"},
+           {"status_code": 500, "error_code": "INTERNAL_ERROR",
+            "message": "Internal error", "condition": "unhandled exception"},
+       ],
+   )
+   ```
+
+   ❌ Never write `{"status_code": 403, "error_code": "UNAUTHORIZED"}` — that is
+   the exact drift that makes a working Lambda look like a broken tool.
 
 ### Example: Calling Infrastructure Generator (Recommended)
 ```python

--- a/skills/aicc-builder-skill/resources/reference/contact_flow_block_schemas.md
+++ b/skills/aicc-builder-skill/resources/reference/contact_flow_block_schemas.md
@@ -9,83 +9,177 @@
 > `docs.aws.amazon.com/connect`** — NOT the research agent (that is for company/API
 > research, not flow-block syntax).
 
-Validated against the real `aws connect create-contact-flow` API. The API is the
-ground truth — official docs and the console block-name list are **not** enough to
-know the JSON `Type` string or the required params.
+Validated against the real `aws connect create-contact-flow` API (all-blocks console
+export, verified 2026-06-08; re-validated 2026-07-03 across ~700 API calls). The API is
+the ground truth — official docs and the console block-name list are **not** enough to
+know the JSON `Type` string or the required params. Guessed names such as
+`TransferToAgent` or `CheckStaffing` fail import with
+`InvalidContactFlowException: Invalid Action type`.
+
+**Run the linter, don't trust your memory.** Everything below is enforced
+executably by [`../scripts/lint_assets.py`](../scripts/lint_assets.py) (generated
+from the webapp's `asset_linters.py`, so it can't drift from the webapp):
+
+```bash
+python3 resources/scripts/lint_assets.py <output_dir>          # report
+python3 resources/scripts/lint_assets.py <output_dir> --fix     # apply deterministic fixes
+```
+
+It auto-renames every invalid `Type` in the table below, adds missing required error
+branches, strips `Transitions` from terminal blocks, and normalizes the tool-result
+values. Treat this doc as the explanation and the linter as the gate.
 
 ## Console name → JSON `Type` (API-verified)
 
 | Console block | JSON `Type` |
 |---|---|
-| Get customer input | `GetParticipantInput` |
-| Store customer input | `GetParticipantInput` (`StoreInput=True`) |
+| Get customer input / Store customer input | `GetParticipantInput` |
 | Play prompt / Send message | `MessageParticipant` |
-| Connect assistant | `CreateWisdomSession` |
+| Message iteratively | `MessageParticipantIteratively` |
+| Render message template (Q in Connect) | `RenderMessageTemplate` |
+| Connect assistant (Q in Connect) | `CreateWisdomSession` |
+| Q in Connect AI bot | `ConnectParticipantWithLexBot` |
 | Set callback number | `UpdateContactCallbackNumber` |
 | Set contact attributes | `UpdateContactAttributes` |
+| Set flow attributes | `UpdateFlowAttributes` |
 | Set working queue | `UpdateContactTargetQueue` |
 | Set voice | `UpdateContactTextToSpeechVoice` |
 | Set logging behavior | `UpdateFlowLoggingBehavior` |
-| Set recording/analytics | `UpdateContactRecordingBehavior` |
+| Set recording / analytics | `UpdateContactRecordingAndAnalyticsBehavior` (legacy `UpdateContactRecordingBehavior` also imports) |
+| Set event flow / hooks | `UpdateContactEventHooks` |
+| Set routing criteria | `UpdateContactRoutingCriteria` |
+| Change routing priority / age | `UpdateContactRoutingBehavior` |
+| Media streaming (start / stop) | `UpdateContactMediaStreamingBehavior` |
+| Update previous participant state | `UpdatePreviousContactParticipantState` |
 | Check hours of operation | `CheckHoursOfOperation` |
 | Check contact attributes | `Compare` |
-| Check staffing / Get metrics | `CheckMetricData` |
+| Check staffing / Get metrics | `CheckMetricData`, `GetMetricData` |
+| Check call progress (outbound) | `CheckOutboundCallStatus` |
+| Loop | `Loop` |
+| Wait | `Wait` |
+| Distribute by percentage | `DistributeByPercentage` |
 | AWS Lambda function | `InvokeLambdaFunction` |
 | Invoke module | `InvokeFlowModule` |
+| Create task | `CreateTask` |
+| Cases (create) | `CreateCase` |
+| Create contact | `CreateContact` |
+| Outbound email | `StartOutboundEmailContact` |
+| Customer profiles | `GetCustomerProfile`, `GetCustomerProfileObject`, `AssociateContactToCustomerProfile` |
+| Data table | `EvaluateDataTableValues` |
+| Get stored content | `LoadContactContent` |
+| Authenticate customer | `AuthenticateParticipant` |
+| Show view | `ShowView` |
+| Resume contact | `ResumeContact` |
+| Contact tags (tag / untag) | `TagContact`, `UntagContact` |
+| Persistent contact association | `CreatePersistentContactAssociation` |
 | Transfer to queue | `TransferContactToQueue` |
+| Dequeue + transfer to queue | `DequeueContactAndTransferToQueue` |
+| Transfer to phone number / third party | `TransferParticipantToThirdParty` |
+| Transfer to flow | `TransferToFlow` |
 | Disconnect | `DisconnectParticipant` |
-| Loop | `Loop` · Wait → `Wait` · Resume contact → `ResumeContact` |
+| End flow / resume | `EndFlowExecution` |
+| Update contact data | `UpdateContactData` |
+
+That is the complete verified set (51 `Type`s). Anything not in it should be
+confirmed against a real console export before you emit it — the linter rejects
+unknown `Type`s outright rather than guessing.
 
 ## INVALID `Type`s the model/KB tends to hallucinate (NEVER emit)
 
-| Wrong | Correct |
+| Wrong (guessed) | Use instead |
 |---|---|
-| `CheckStaffing` | `CheckMetricData` |
-| `SetLoggingBehavior` | `UpdateFlowLoggingBehavior` |
 | `PlayPrompt` | `MessageParticipant` |
-| `StoreUserInput` | `GetParticipantInput` (`StoreInput=True`) |
-| `Trigger` / `EntryPoint` | none — flow starts at `StartAction`'s target |
-| `InvokeAgentAction` | `ConnectParticipantWithLexBot` |
-| `CheckCondition` | `Compare` |
+| `Disconnect` / `EndFlow` | `DisconnectParticipant` |
+| `GetUserInput` / `StoreUserInput` | `GetParticipantInput` (`StoreInput=True` for store mode) |
+| `TransferToAgent` / `TransferToQueue` | `TransferContactToQueue` |
+| `TransferToPhoneNumber` / `TransferToThirdParty` | `TransferParticipantToThirdParty` |
+| `CheckStaffing` / `CheckQueueStatus` | `CheckMetricData` |
+| `CheckCondition` / `CheckValue` / `CheckAttribute` / `Condition` | `Compare` |
+| `Distribute` | `DistributeByPercentage` |
+| `StartMediaStreaming` / `StopMediaStreaming` | `UpdateContactMediaStreamingBehavior` |
+| `ReturnFromFlowModule` | `EndFlowExecution` |
+| `InvokeAPI` | `InvokeLambdaFunction` |
+| `InvokeAgentAction` / `InvokeBedrockAgent` / `InvokeQConnect` / `InvokeAmazonQConnect` / `GetParticipantWithLexV2Bot` | `ConnectParticipantWithLexBot` |
+| `SetContactAttributes` | `UpdateContactAttributes` |
+| `SetCallbackNumber` | `UpdateContactCallbackNumber` |
+| `SetWorkingQueue` | `UpdateContactTargetQueue` |
+| `SetVoice` | `UpdateContactTextToSpeechVoice` |
+| `SetLoggingBehavior` | `UpdateFlowLoggingBehavior` |
+| `SetRecordingBehavior` | `UpdateContactRecordingBehavior` |
+| `SetRecordingAndAnalyticsBehavior` | `UpdateContactRecordingAndAnalyticsBehavior` |
+| `UpdateContactRoutingData` | `UpdateContactRoutingCriteria` |
+| `UpdateContactTextToSpeechManner` | `UpdateContactTextToSpeechVoice` |
+| `PutCustomerProfile` / `UpdateCustomerProfileObject` | Customer Profiles integration / `UpdateContactData` |
+| `CreateCallbackContact` | remove — use `UpdateContactCallbackNumber` + `TransferContactToQueue` |
+| `Trigger` / `EntryPoint` | remove — flows start at `StartAction`'s target, there is no entry block |
 
 ## Per-block required params / errors (the ones most often gotten wrong)
 
-- **GetParticipantInput — MENU mode** (DTMF branching via `Conditions`):
-  `StoreInput=False`, **NO** `DTMFConfiguration`; errors =
-  `NoMatchingCondition` + `InputTimeLimitExceeded` + `NoMatchingError`.
-- **GetParticipantInput — STORE mode**: `StoreInput=True`, requires
-  `InputValidation.CustomValidation.MaximumLength`; optional
-  `DTMFConfiguration.DisableCancelKey` (**never** `InputTerminationSequence`);
-  errors = `NoMatchingError` only.
-- **Loop**: `LoopCount` param; `Conditions` operands are `DoneLooping` /
-  `ContinueLooping` (NOT `Looping`/`Complete`).
-- **TransferContactToQueue**: **NO** `QueueId` param (queue is set by a prior
+- **GetParticipantInput** has TWO modes, and **both** require `InputTimeLimitSeconds`
+  (omitting it fails with `Action is missing required property … Parameters.InputTimeLimitSeconds`):
+  - **MENU mode** (DTMF branching via `Conditions`): `StoreInput: "False"`, **NO**
+    `DTMFConfiguration`; errors = `NoMatchingCondition` + `InputTimeLimitExceeded` +
+    `NoMatchingError`.
+  - **STORE mode** (captures to an attribute): `StoreInput: "True"`, requires
+    `InputValidation.CustomValidation.MaximumLength`; optional
+    `DTMFConfiguration.DisableCancelKey` (**never** `InputTerminationSequence`);
+    errors = `NoMatchingError` only.
+- **Loop**: `LoopCount` param; `Conditions` operands are `ContinueLooping` /
+  `DoneLooping` (NOT `Looping`/`Complete`), **and** the block still needs a
+  `Transitions.NextAction` in addition to those two conditions.
+- **TransferContactToQueue**: **NO** `QueueId` param (the queue is set by a prior
   `UpdateContactTargetQueue`); errors = `QueueAtCapacity` + `NoMatchingError`.
 - **UpdateContactAttributes**: requires `NoMatchingError`.
-- **UpdateContactCallbackNumber**: only `NoMatchingError` (`InvalidNumber` /
-  `NotDialable` are NOT valid here).
-- **DisconnectParticipant**: terminal — **NO** `Transitions`/`Conditions`/`Errors`.
-- **Compare**: only `NoMatchingCondition` error (never `NoMatchingError`);
-  `ComparisonValue` must use a real JSONPath root.
+- **UpdateContactCallbackNumber**: errors are `InvalidCallbackNumber` +
+  `CallbackNumberNotDialable`; `NoMatchingError` / `InvalidNumber` / `NotDialable`
+  are **NOT** valid here. `CallbackNumber` must be a valid E.164 number **or** a
+  JSONPath (e.g. `$.CustomerEndpoint.Address`) — a bare literal was rejected on the
+  verified instance.
+- **DisconnectParticipant** / **EndFlowExecution**: terminal — **NO**
+  `Transitions`/`Conditions`/`Errors`.
+- **TransferContactToQueue** / **TransferToFlow**: terminal for the *contact*, but
+  they DO carry error branches (unlike the two above).
+- **Compare**: only `NoMatchingCondition` (never `NoMatchingError`).
+  Operators are `Equals`, `TextContains`, `TextStartsWith`, `TextEndsWith`,
+  `NumberGreaterThan`, `NumberLessThan`, `NumberGreaterOrEqualTo`,
+  `NumberLessOrEqualTo`. Note the asymmetry: `>=`/`<=` drop the "Than"
+  (`NumberGreaterOrEqualTo`, not `NumberGreaterThanOrEqualTo`), and there is **no**
+  `NumberEquals` — use plain `Equals` for numeric equality.
+  `ComparisonValue` must use a real JSONPath root: `$.Attributes.`, `$.Channel`,
+  `$.CustomerEndpoint`, `$.SystemEndpoint`, `$.Lex.`, `$.Customer.`, `$.External.`,
+  `$.StoredCustomerInput`, `$.Media.`, `$.ContactId`, `$.InitialContactId`,
+  `$.Queue.`, `$.Metadata.`, `$.FlowAttributes.`.
+- **CheckHoursOfOperation**: `NoMatchingError` only — `NoMatchingCondition` is invalid.
+- **ConnectParticipantWithLexBot**: errors = `NoMatchingError` +
+  `NoMatchingCondition`; `AgentError` is invalid.
 - **CreateWisdomSession**: `WisdomAssistantArn` must be a real existing assistant
-  ARN (use a `{{PLACEHOLDER}}` token until deploy time).
+  ARN (use a `{{PLACEHOLDER}}` token until deploy time); requires `NoMatchingError`.
+- **RenderMessageTemplate**: the Q-in-Connect message-template render block, **not**
+  a generic templated message. Requires `WisdomKnowledgeBaseArn` +
+  `WisdomMessageTemplateArn` (generic `Template` / `AttributeMap` params are rejected
+  as invalid property names); errors = `TemplateRenderingError` + `NoMatchingError`.
+- **UpdateContactRecordingAndAnalyticsBehavior**: real-time redaction is only
+  supported for `de-DE`, `en-AU`, `en-GB`, `en-IN`, `en-US`, `es-US`, `fr-CA`,
+  `fr-FR`, `it-IT`, `pt-BR`. Korean (`ko-KR`) flows must NOT request redaction —
+  set the analytics language explicitly and leave redaction off.
+- **AuthenticateParticipant**: errors = `NoMatchingError` + `TimeLimitExceeded`.
+- **GetCustomerProfileObject**: errors = `NoMatchingError` + `NoneFoundError`.
 
 ## AI bot ↔ Contact Flow tool-result contract
 
 The `Compare` block that branches on the AI agent's outcome must compare on
 `$.Lex.SessionAttributes.Tool`, and the AI prompt must teach the bot to set
 **exactly** `Complete` or `Escalate` (plus the documented `Escalate*` / `*Complete`
-extensions). See the canonical contract in
+extensions). Near-miss values the linter normalizes — `Done`, `Finish(ed)`,
+`EndCall`, `EndConversation`, `Hangup`, `Disconnect` → `Complete`; `Escalation`,
+`Transfer`, `TransferToAgent`, `Handoff`, `Human`, `Agent` → `Escalate` — mean the
+bot and the flow silently disagreed at runtime, so fix the source, not just the flow.
+See the canonical contract in
 [`../sub-agents/_shared_rules.md`](../sub-agents/_shared_rules.md) →
-"AI-BOT ↔ CONTACT-FLOW TOOL-RESULT CONTRACT". The bot and the flow MUST agree on
-these exact values or they silently disagree at runtime.
+"AI-BOT ↔ CONTACT-FLOW TOOL-RESULT CONTRACT".
 
-## Still unknown — need a console export to confirm `Type`
+## AI prompt variable rule (qconnect `CreateAIPrompt`)
 
-Authenticate Customer, Get stored content, Contact tags, Hold customer or agent,
-Change routing priority/age, Check call progress, Check queue status, Transfer to
-flow, Transfer to phone number, Cases, Data Table, Show View, Set customer queue
-flow, Set disconnect/hold/whisper/event flow, Set routing criteria, Set touchtone
-buffer, Create task, Start/Stop media streaming. For these, confirm the `Type`
-against a real console export or the verified list in
-[`vision_import.md`](vision_import.md) before emitting.
+Each variable may appear inside `{{ }}` **only once** in the whole prompt; a second
+`{{$.Custom.foo}}` fails validation. Reference it without braces after the first
+use. `lint_assets.py` strips the braces from duplicates automatically.

--- a/skills/aicc-builder-skill/resources/reference/vision_import.md
+++ b/skills/aicc-builder-skill/resources/reference/vision_import.md
@@ -23,12 +23,17 @@ chart — and wants it turned into an importable Amazon Connect Contact Flow.
 4. **Lint + repair** the draft with the deterministic linter before trusting it —
    the draft is best-effort and MUST pass import-safety:
    ```bash
-   python resources/scripts/validate_consistency.py <output_dir>   # cross-asset
+   python3 resources/scripts/lint_assets.py <output_dir>          # report
+   python3 resources/scripts/lint_assets.py <output_dir> --fix     # apply fixes
    ```
-   plus the Contact-Flow block rules in
-   [`resources/reference/contact_flow_block_schemas.md`](contact_flow_block_schemas.md).
-   The repaired JSON may be **shorter** than the draft (the linter strips invalid
-   `DTMFConfiguration`, duplicate SSML, etc.) — that is expected and correct.
+   `lint_assets.py` carries the same `lint_contact_flow` the webapp runs (it is
+   generated from `backend/ecs/src/tools/asset_linters.py`), so it renames invalid
+   `Type`s, adds required error branches, and strips `Transitions` from terminal
+   blocks. See
+   [`resources/reference/contact_flow_block_schemas.md`](contact_flow_block_schemas.md)
+   for what each rule means. The repaired JSON may be **shorter** than the draft
+   (the linter strips invalid `DTMFConfiguration`, duplicate SSML, etc.) — that is
+   expected and correct.
 5. **Seed it as an imported asset** under a stable id and enter patch-only mode:
    `assets/v1/contact_flow/imported_flow/contact_flow.json`. Subsequent edits use
    `Edit` (or re-call `contact_flow_generator` with `flow_name="imported_flow"` +
@@ -50,15 +55,16 @@ chart — and wants it turned into an importable Amazon Connect Contact Flow.
 >   `AssociateContactToCustomerProfile, AuthenticateParticipant, CheckHoursOfOperation,
 >   CheckMetricData, CheckOutboundCallStatus, Compare, ConnectParticipantWithLexBot,
 >   CreateCase, CreateContact, CreatePersistentContactAssociation, CreateTask,
->   CreateWisdomSession, DisconnectParticipant, DistributeByPercentage,
->   EndFlowExecution, EvaluateDataTableValues, GetCustomerProfile,
->   GetCustomerProfileObject, GetMetricData, GetParticipantInput, InvokeFlowModule,
->   InvokeLambdaFunction, LoadContactContent, Loop, MessageParticipant,
->   MessageParticipantIteratively, RenderMessageTemplate, ResumeContact, ShowView,
->   StartOutboundEmailContact, TagContact, TransferContactToQueue,
->   TransferParticipantToThirdParty, TransferToFlow, UntagContact,
->   UpdateContactAttributes, UpdateContactCallbackNumber, UpdateContactData,
->   UpdateContactEventHooks, UpdateContactMediaStreamingBehavior,
+>   CreateWisdomSession, DequeueContactAndTransferToQueue, DisconnectParticipant,
+>   DistributeByPercentage, EndFlowExecution, EvaluateDataTableValues,
+>   GetCustomerProfile, GetCustomerProfileObject, GetMetricData, GetParticipantInput,
+>   InvokeFlowModule, InvokeLambdaFunction, LoadContactContent, Loop,
+>   MessageParticipant, MessageParticipantIteratively, RenderMessageTemplate,
+>   ResumeContact, ShowView, StartOutboundEmailContact, TagContact,
+>   TransferContactToQueue, TransferParticipantToThirdParty, TransferToFlow,
+>   UntagContact, UpdateContactAttributes, UpdateContactCallbackNumber,
+>   UpdateContactData, UpdateContactEventHooks,
+>   UpdateContactMediaStreamingBehavior,
 >   UpdateContactRecordingAndAnalyticsBehavior, UpdateContactRecordingBehavior,
 >   UpdateContactRoutingBehavior, UpdateContactRoutingCriteria,
 >   UpdateContactTargetQueue, UpdateContactTextToSpeechVoice,
@@ -75,6 +81,19 @@ chart — and wants it turned into an importable Amazon Connect Contact Flow.
 >   user refines it afterward.
 > - Use `{{PLACEHOLDER}}` tokens (e.g. `{{FRONT_DESK_QUEUE_ARN}}`, `{{LAMBDA_ARN}}`)
 >   for any ARN/id the diagram references but doesn't provide.
+
+The webapp builds that `Type` list at import time from
+`VALID_CONTACT_FLOW_ACTION_TYPES`, so the copy above can go stale. Print the
+authoritative list instead of trusting it:
+
+```bash
+python3 -c "import importlib.util as u; s=u.spec_from_file_location('la','resources/scripts/lint_assets.py'); m=u.module_from_spec(s); s.loader.exec_module(m); print(', '.join(sorted(m.VALID_CONTACT_FLOW_ACTION_TYPES)))"
+```
+
+If the user supplied a company name or a note about the diagram, pass both as
+context alongside the image — the webapp prefixes the transcription request with
+`Company: <name>.` and `User note: <hint>.`, and they measurably improve queue/prompt
+naming.
 
 See [`contact_flow_block_schemas.md`](contact_flow_block_schemas.md) for the
 per-block required parameters and error lists the linter enforces.

--- a/skills/aicc-builder-skill/resources/schemas/DataSourceSpec.schema.json
+++ b/skills/aicc-builder-skill/resources/schemas/DataSourceSpec.schema.json
@@ -87,6 +87,59 @@
       ],
       "default": null,
       "title": "Region"
+    },
+    "database_name": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "RDS/Aurora database (schema) name the operation queries",
+      "title": "Database Name"
+    },
+    "cluster_arn": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Aurora cluster ARN used via the RDS Data API",
+      "title": "Cluster Arn"
+    },
+    "lookup_column": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "SQL column used to identify the caller/record (e.g. customers.phone_number)",
+      "title": "Lookup Column"
+    },
+    "related_tables": {
+      "anyOf": [
+        {
+          "items": {},
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Other tables this operation joins/reads, in query order (e.g. ['customers', 'orders', 'order_items'])",
+      "title": "Related Tables"
     }
   },
   "title": "DataSourceSpec",

--- a/skills/aicc-builder-skill/resources/schemas/ErrorResponse.schema.json
+++ b/skills/aicc-builder-skill/resources/schemas/ErrorResponse.schema.json
@@ -1,6 +1,6 @@
 {
   "additionalProperties": true,
-  "description": "Specification for an error response.",
+  "description": "Specification for an error response.\n\nNOTE on ``status_code``: an Amazon Connect AI agent treats any non-2xx tool\nresponse as an execution failure \u2014 it never reads the body, so it cannot relay\nthe outcome and simply reports that the tool is broken. Business outcomes are\ntherefore coerced to 200 here (BUSINESS_OUTCOME_200_RULE); only 5xx, a genuine\nfault Connect should retry, is preserved.",
   "properties": {
     "status_code": {
       "anyOf": [
@@ -12,7 +12,7 @@
         }
       ],
       "default": null,
-      "description": "HTTP status code",
+      "description": "HTTP status code (business outcomes are always 200; only 5xx faults differ)",
       "title": "Status Code"
     },
     "error_code": {

--- a/skills/aicc-builder-skill/resources/schemas/OperationSpec.schema.json
+++ b/skills/aicc-builder-skill/resources/schemas/OperationSpec.schema.json
@@ -240,6 +240,59 @@
           ],
           "default": null,
           "title": "Region"
+        },
+        "database_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "RDS/Aurora database (schema) name the operation queries",
+          "title": "Database Name"
+        },
+        "cluster_arn": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Aurora cluster ARN used via the RDS Data API",
+          "title": "Cluster Arn"
+        },
+        "lookup_column": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "SQL column used to identify the caller/record (e.g. customers.phone_number)",
+          "title": "Lookup Column"
+        },
+        "related_tables": {
+          "anyOf": [
+            {
+              "items": {},
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Other tables this operation joins/reads, in query order (e.g. ['customers', 'orders', 'order_items'])",
+          "title": "Related Tables"
         }
       },
       "title": "DataSourceSpec",
@@ -247,7 +300,7 @@
     },
     "ErrorResponse": {
       "additionalProperties": true,
-      "description": "Specification for an error response.",
+      "description": "Specification for an error response.\n\nNOTE on ``status_code``: an Amazon Connect AI agent treats any non-2xx tool\nresponse as an execution failure \u2014 it never reads the body, so it cannot relay\nthe outcome and simply reports that the tool is broken. Business outcomes are\ntherefore coerced to 200 here (BUSINESS_OUTCOME_200_RULE); only 5xx, a genuine\nfault Connect should retry, is preserved.",
       "properties": {
         "status_code": {
           "anyOf": [
@@ -259,7 +312,7 @@
             }
           ],
           "default": null,
-          "description": "HTTP status code",
+          "description": "HTTP status code (business outcomes are always 200; only 5xx faults differ)",
           "title": "Status Code"
         },
         "error_code": {

--- a/skills/aicc-builder-skill/resources/schemas/SessionFlowConfig.schema.json
+++ b/skills/aicc-builder-skill/resources/schemas/SessionFlowConfig.schema.json
@@ -115,6 +115,59 @@
           ],
           "default": null,
           "title": "Region"
+        },
+        "database_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "RDS/Aurora database (schema) name the operation queries",
+          "title": "Database Name"
+        },
+        "cluster_arn": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Aurora cluster ARN used via the RDS Data API",
+          "title": "Cluster Arn"
+        },
+        "lookup_column": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "SQL column used to identify the caller/record (e.g. customers.phone_number)",
+          "title": "Lookup Column"
+        },
+        "related_tables": {
+          "anyOf": [
+            {
+              "items": {},
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Other tables this operation joins/reads, in query order (e.g. ['customers', 'orders', 'order_items'])",
+          "title": "Related Tables"
         }
       },
       "title": "DataSourceSpec",

--- a/skills/aicc-builder-skill/resources/schemas/ToolSpec.schema.json
+++ b/skills/aicc-builder-skill/resources/schemas/ToolSpec.schema.json
@@ -89,6 +89,59 @@
           ],
           "default": null,
           "title": "Region"
+        },
+        "database_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "RDS/Aurora database (schema) name the operation queries",
+          "title": "Database Name"
+        },
+        "cluster_arn": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Aurora cluster ARN used via the RDS Data API",
+          "title": "Cluster Arn"
+        },
+        "lookup_column": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "SQL column used to identify the caller/record (e.g. customers.phone_number)",
+          "title": "Lookup Column"
+        },
+        "related_tables": {
+          "anyOf": [
+            {
+              "items": {},
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Other tables this operation joins/reads, in query order (e.g. ['customers', 'orders', 'order_items'])",
+          "title": "Related Tables"
         }
       },
       "title": "DataSourceSpec",

--- a/skills/aicc-builder-skill/resources/scripts/lint_assets.py
+++ b/skills/aicc-builder-skill/resources/scripts/lint_assets.py
@@ -1,0 +1,1607 @@
+#!/usr/bin/env python3
+# AUTO-GENERATED — DO NOT EDIT.
+#
+# Mechanically extracted from backend/ecs/src/tools/asset_linters.py by
+# skills/aicc-builder-skill/scripts/_extract_prompts.py: the `strands` import and
+# every @tool-decorated wrapper (they need the S3/session runtime) are stripped,
+# and scripts/_lint_assets_cli.py is appended as the CLI driver.
+#
+# To change a lint rule, edit the backend module and re-run
+# skills/aicc-builder-skill/scripts/extract_prompts.sh.
+
+"""
+Deterministic asset linters: CloudFormation + OpenAPI 3.0.
+
+Run automatically after the deterministic merge steps (merge_infrastructure /
+merge_openapi) and also exposed as standalone @tool functions so the
+orchestrator can re-lint after a manual patch.
+
+Design principles
+------------------
+1. **Fault-tolerant.** Linting must NEVER crash the generation pipeline. If a
+   lint library is missing, or the parser throws on malformed input, we log and
+   return a benign result (``available=False`` / ``ok=True``) instead of raising.
+2. **Deterministic auto-fix first.** A small set of unambiguous, well-understood
+   issues (e.g. ``!Sub`` used where CloudFormation only accepts a literal string,
+   ``!Sub`` with no variables) are fixed in-place by regex. These are the issues
+   that recur every workshop and are safe to fix without an LLM.
+3. **Surface the rest.** Remaining errors are returned as a structured list so
+   the caller (orchestrator / sub-agent) can patch them — we do NOT silently
+   swallow them.
+
+The two public tools are :func:`lint_cloudformation` and :func:`lint_openapi`.
+The two library helpers used by the merge functions are
+:func:`lint_and_autofix_cfn` and :func:`lint_and_autofix_openapi`.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# CloudFormation
+# ---------------------------------------------------------------------------
+
+# Top-level (column-0) ``Description:`` only accepts a literal string — cfn-lint
+# E1004. The infra agent occasionally emits ``Description: !Sub "..."`` here.
+_TOP_LEVEL_DESC_SUB_RE = re.compile(
+    r'^(Description:[ \t]+)!Sub[ \t]+(.+)$', re.MULTILINE
+)
+
+# ``!Sub`` with no ``${...}`` variables is redundant (cfn-lint W1020) and, in a
+# handful of string-only fields, an outright error. Converting a single-line
+# ``!Sub "literal"`` (no variables) back to a plain quoted string is always safe.
+_SUB_NO_VAR_RE = re.compile(
+    r'!Sub[ \t]+(?P<q>[\'"])(?P<body>(?:(?!(?P=q)).)*)(?P=q)'
+)
+
+
+def _autofix_cfn(yaml_str: str) -> tuple[str, list[str]]:
+    """Apply deterministic, always-safe CloudFormation fixes.
+
+    Returns (fixed_yaml, list_of_human_readable_fix_descriptions).
+    """
+    fixes: list[str] = []
+
+    # 1. Strip !Sub from the template-level Description (E1004). The Description
+    #    field is literal-only and cannot interpolate, so we also collapse any
+    #    embedded ${...} placeholders to their bare token text to avoid the
+    #    follow-on E1029 ("embedded parameter outside Fn::Sub").
+    def _strip_top_desc(m: re.Match) -> str:
+        literal = m.group(2)
+        # Collapse ${Foo::Bar} or ${Foo} -> Foo::Bar / Foo (plain text).
+        literal = re.sub(r'\$\{([^}]*)\}', r'\1', literal)
+        return m.group(1) + literal
+
+    new_yaml, n = _TOP_LEVEL_DESC_SUB_RE.subn(_strip_top_desc, yaml_str)
+    if n:
+        fixes.append(f"Removed !Sub from {n} top-level Description field(s) (E1004/E1029)")
+        yaml_str = new_yaml
+
+    # 2. Convert `!Sub "literal"` (no ${} variables) to a plain quoted string.
+    def _strip_useless_sub(m: re.Match) -> str:
+        body = m.group("body")
+        if "${" in body:  # has a real variable — leave the !Sub intact
+            return m.group(0)
+        q = m.group("q")
+        return f"{q}{body}{q}"
+
+    new_yaml, n2 = _SUB_NO_VAR_RE.subn(_strip_useless_sub, yaml_str)
+    # subn counts all matches incl. ones we left untouched; recount real changes
+    if new_yaml != yaml_str:
+        changed = sum(
+            1 for m in _SUB_NO_VAR_RE.finditer(yaml_str) if "${" not in m.group("body")
+        )
+        fixes.append(f"Converted {changed} variable-free !Sub to literal string (W1020)")
+        yaml_str = new_yaml
+
+    return yaml_str, fixes
+
+
+def _run_cfn_lint(yaml_str: str) -> tuple[bool, list[dict]]:
+    """Run cfn-lint. Returns (available, issues).
+
+    issues: list of {id, level, message, line} where level is 'error'|'warning'.
+    Fault-tolerant: any failure -> (False, []).
+    """
+    try:
+        import cfnlint.api as cfn_api
+    except Exception as e:  # library missing
+        logger.warning(f"[LINT_CFN] cfn-lint unavailable, skipping: {e}")
+        return False, []
+
+    try:
+        matches = cfn_api.lint(yaml_str)
+    except Exception as e:
+        logger.warning(f"[LINT_CFN] cfn-lint raised on input, skipping: {e}")
+        return True, []
+
+    issues: list[dict] = []
+    for m in matches:
+        try:
+            rid = getattr(getattr(m, "rule", None), "id", "?") or "?"
+            # cfn-lint severity: error ids start with E, warnings W, info I
+            level = "error" if str(rid).startswith("E") else (
+                "warning" if str(rid).startswith("W") else "info"
+            )
+            issues.append({
+                "id": str(rid),
+                "level": level,
+                "message": str(getattr(m, "message", m)),
+                "line": getattr(m, "linenumber", None),
+            })
+        except Exception:
+            continue
+    return True, issues
+
+
+def lint_and_autofix_cfn(yaml_str: str) -> dict:
+    """Library entry point used by merge_infrastructure_fragments.
+
+    Returns dict: {available, fixed_yaml, fixes_applied, errors, warnings}.
+    Never raises.
+    """
+    try:
+        fixed_yaml, fixes = _autofix_cfn(yaml_str)
+        available, issues = _run_cfn_lint(fixed_yaml)
+        errors = [i for i in issues if i["level"] == "error"]
+        warnings = [i for i in issues if i["level"] == "warning"]
+        if fixes:
+            logger.info(f"[LINT_CFN] Auto-fixes applied: {fixes}")
+        if errors:
+            logger.warning(
+                f"[LINT_CFN] {len(errors)} error(s) remain after autofix: "
+                + "; ".join(f"{e['id']}@L{e['line']}: {e['message']}" for e in errors[:8])
+            )
+        return {
+            "available": available,
+            "fixed_yaml": fixed_yaml,
+            "fixes_applied": fixes,
+            "errors": errors,
+            "warnings": warnings,
+        }
+    except Exception as e:
+        logger.error(f"[LINT_CFN] Unexpected failure, passing through: {e}")
+        return {"available": False, "fixed_yaml": yaml_str, "fixes_applied": [],
+                "errors": [], "warnings": []}
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI 3.0
+# ---------------------------------------------------------------------------
+
+
+def _autofix_openapi(doc: dict) -> tuple[dict, list[str]]:
+    """Apply deterministic, always-safe OpenAPI fixes to a parsed doc.
+
+    Targets the recurring workshop issues:
+      - ``null`` where a string/object is required (drop the key)
+      - missing ``responses`` on an operation (add a minimal 200)
+      - ``type: "null"`` (invalid in OpenAPI 3.0) — drop the offending schema key
+    Returns (fixed_doc, fix_descriptions).
+    """
+    fixes: list[str] = []
+
+    def _scrub_nulls(node, path="$"):
+        """Recursively drop dict keys whose value is literally None."""
+        if isinstance(node, dict):
+            null_keys = [k for k, v in node.items() if v is None]
+            for k in null_keys:
+                del node[k]
+                fixes.append(f"Dropped null field '{k}' at {path}")
+            for k, v in list(node.items()):
+                _scrub_nulls(v, f"{path}.{k}")
+        elif isinstance(node, list):
+            for idx, item in enumerate(node):
+                _scrub_nulls(item, f"{path}[{idx}]")
+
+    _scrub_nulls(doc)
+
+    # Ensure every operation has a responses object (OpenAPI requires it).
+    paths = doc.get("paths")
+    if isinstance(paths, dict):
+        for p, methods in paths.items():
+            if not isinstance(methods, dict):
+                continue
+            for verb, op in methods.items():
+                if verb.lower() not in {
+                    "get", "post", "put", "delete", "patch", "head", "options", "trace"
+                }:
+                    continue
+                if isinstance(op, dict) and not op.get("responses"):
+                    op["responses"] = {
+                        "200": {"description": "Successful response"}
+                    }
+                    fixes.append(f"Added minimal 200 response to {verb.upper()} {p}")
+
+    # pattern ↔ minLength/maxLength contradiction fix.
+    # The LLM recurrently writes e.g. pattern '^FF-\d{8}$' (11 chars) with
+    # maxLength: 8 (it counts only the digits). The MCP gateway enforces
+    # length bounds BEFORE the pattern, so every valid-looking value is
+    # rejected with "maxLength validation failed" at runtime (hit live).
+    # When a fixed-length pattern's implied length falls outside the declared
+    # bounds, widen the bounds to match the pattern (the pattern is the
+    # stronger, more intentional constraint).
+    def _pattern_fixed_length(pattern: str):
+        """Return exact length implied by an anchored fixed-width regex, else None."""
+        if not (pattern.startswith("^") and pattern.endswith("$")):
+            return None
+        body = pattern[1:-1]
+        length, i = 0, 0
+        while i < len(body):
+            ch = body[i]
+            if ch == "\\" and i + 1 < len(body):
+                nxt = body[i + 1]
+                if i + 2 < len(body) and body[i + 2] == "{":
+                    end = body.find("}", i + 2)
+                    if end == -1:
+                        return None
+                    rep = body[i + 3:end]
+                    if not rep.isdigit():
+                        return None  # {m,n} → not fixed width
+                    length += int(rep)
+                    i = end + 1
+                else:
+                    length += 1
+                    i += 2
+                continue
+            if ch == "[":
+                end = body.find("]", i)
+                if end == -1:
+                    return None
+                if end + 1 < len(body) and body[end + 1] == "{":
+                    e2 = body.find("}", end + 1)
+                    rep = body[end + 2:e2]
+                    if not rep.isdigit():
+                        return None
+                    length += int(rep)
+                    i = e2 + 1
+                else:
+                    length += 1
+                    i = end + 1
+                continue
+            if ch in "*+?|(){":
+                return None  # variable width / groups — bail out
+            length += 1
+            i += 1
+        return length
+
+    def _fix_length_bounds(node, path="$"):
+        if isinstance(node, dict):
+            pat = node.get("pattern")
+            if isinstance(pat, str) and node.get("type") == "string":
+                implied = _pattern_fixed_length(pat)
+                if implied is not None:
+                    if isinstance(node.get("maxLength"), int) and node["maxLength"] < implied:
+                        fixes.append(
+                            f"maxLength {node['maxLength']} contradicts pattern "
+                            f"'{pat}' (implies {implied}) at {path} — raised to {implied}"
+                        )
+                        node["maxLength"] = implied
+                    if isinstance(node.get("minLength"), int) and node["minLength"] > implied:
+                        fixes.append(
+                            f"minLength {node['minLength']} contradicts pattern "
+                            f"'{pat}' (implies {implied}) at {path} — lowered to {implied}"
+                        )
+                        node["minLength"] = implied
+            for k, v in node.items():
+                _fix_length_bounds(v, f"{path}.{k}")
+        elif isinstance(node, list):
+            for idx, item in enumerate(node):
+                _fix_length_bounds(item, f"{path}[{idx}]")
+
+    _fix_length_bounds(doc)
+
+    return doc, fixes
+
+
+def _run_openapi_validate(doc: dict) -> tuple[bool, list[str]]:
+    """Validate an OpenAPI 3.0 doc. Returns (available, error_messages)."""
+    try:
+        from openapi_spec_validator import OpenAPIV30SpecValidator
+    except Exception as e:
+        logger.warning(f"[LINT_OAS] openapi-spec-validator unavailable, skipping: {e}")
+        return False, []
+
+    try:
+        errors = [
+            f"{'/'.join(str(p) for p in err.absolute_path)}: {err.message}"
+            for err in OpenAPIV30SpecValidator(doc).iter_errors()
+        ]
+        return True, errors
+    except Exception as e:
+        logger.warning(f"[LINT_OAS] validator raised, skipping: {e}")
+        return True, []
+
+
+def lint_and_autofix_openapi(yaml_str: str) -> dict:
+    """Library entry point used by merge_openapi_fragments.
+
+    Parses YAML, scrubs nulls / adds missing responses, validates against the
+    OpenAPI 3.0 schema, and re-serialises. Never raises.
+    Returns {available, fixed_yaml, fixes_applied, errors}.
+    """
+    try:
+        import yaml as _yaml
+    except Exception as e:
+        logger.error(f"[LINT_OAS] PyYAML unavailable: {e}")
+        return {"available": False, "fixed_yaml": yaml_str, "fixes_applied": [], "errors": []}
+
+    try:
+        doc = _yaml.safe_load(yaml_str)
+    except Exception as e:
+        logger.warning(f"[LINT_OAS] YAML parse failed, cannot lint: {e}")
+        return {"available": True, "fixed_yaml": yaml_str, "fixes_applied": [],
+                "errors": [f"YAML parse error: {e}"]}
+
+    if not isinstance(doc, dict):
+        return {"available": True, "fixed_yaml": yaml_str, "fixes_applied": [], "errors": []}
+
+    try:
+        doc, fixes = _autofix_openapi(doc)
+        available, errors = _run_openapi_validate(doc)
+
+        if fixes:
+            # Re-serialise only if we actually changed something.
+            fixed_yaml = _yaml.safe_dump(doc, sort_keys=False, allow_unicode=True, width=4096)
+            logger.info(f"[LINT_OAS] Auto-fixes applied: {fixes}")
+        else:
+            fixed_yaml = yaml_str
+
+        if errors:
+            logger.warning(
+                f"[LINT_OAS] {len(errors)} validation error(s) remain: "
+                + "; ".join(errors[:8])
+            )
+        return {
+            "available": available,
+            "fixed_yaml": fixed_yaml,
+            "fixes_applied": fixes,
+            "errors": errors,
+        }
+    except Exception as e:
+        logger.error(f"[LINT_OAS] Unexpected failure, passing through: {e}")
+        return {"available": False, "fixed_yaml": yaml_str, "fixes_applied": [], "errors": []}
+
+
+# ---------------------------------------------------------------------------
+# Standalone tools (orchestrator can re-lint after a manual patch)
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Lambda (Python) — syntax check via the compiler (no execution)
+# ---------------------------------------------------------------------------
+
+
+def lint_python_source(code: str) -> dict:
+    """Compile-check Python Lambda source WITHOUT running it.
+
+    Catches syntax errors a generator might emit (unterminated strings, bad
+    indentation, stray markdown fences) before they reach a 500 at runtime.
+    Never raises. Returns {ok, errors:[{line, message}]}.
+    """
+    try:
+        # Strip stray markdown fences if a generator left them in.
+        src = code
+        m = re.search(r'```(?:python|py)?\s*\n(.*?)```', src, re.DOTALL)
+        if m:
+            src = m.group(1)
+        compile(src, "<lambda>", "exec")
+        return {"ok": True, "errors": []}
+    except SyntaxError as e:
+        return {"ok": False, "errors": [{"line": e.lineno, "message": f"{e.msg}: {(e.text or '').strip()[:80]}"}]}
+    except Exception as e:
+        # Non-syntax failure (e.g. null bytes) — report but don't crash.
+        return {"ok": False, "errors": [{"line": None, "message": str(e)[:120]}]}
+
+
+# An Amazon Connect AI agent treats any non-2xx tool response as an execution
+# failure: it never reads the body, so it cannot relay the outcome and just says
+# the tool is broken. Business outcomes ("digits didn't match", "not found",
+# "locked out", "date unavailable") MUST therefore be 200 with a discriminator in
+# the body. 5xx is left alone — a genuine fault, and Connect's retry is correct.
+# See BUSINESS_OUTCOME_200_RULE in agents/_consistency_rules.py.
+_BUSINESS_OUTCOME_4XX = range(400, 500)
+
+# A 200 body has to let the model tell outcomes apart without the status code.
+_DISCRIMINATOR_KEYS = frozenset({
+    "verified", "found", "success", "available", "status", "outcome", "lockout",
+    "eligible", "valid", "matched", "exists", "authenticated", "allowed",
+    "isvalid", "iseligible", "errorcode", "resultcode",
+})
+
+
+def _status_code_nodes(tree) -> list:
+    """Collect AST Constant nodes that are an HTTP status code in a response.
+
+    Two shapes, which are the only two the generators emit:
+      * ``create_response(4xx, {...})`` / ``..., status_code=4xx)`` — any callee
+        whose name ends in ``response`` (create_response, _response, make_response)
+      * a dict literal carrying ``"statusCode": 4xx`` (returned to API Gateway)
+
+    Returns a list of (const_node, body_node_or_None) so the caller can also
+    inspect the body that ships with the code.
+    """
+    import ast
+
+    found: list = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            fname = ""
+            if isinstance(node.func, ast.Name):
+                fname = node.func.id
+            elif isinstance(node.func, ast.Attribute):
+                fname = node.func.attr
+            if not fname.lower().endswith("response"):
+                continue
+            body = node.args[1] if len(node.args) > 1 else None
+            if node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, int):
+                found.append((node.args[0], body))
+            for kw in node.keywords:
+                if kw.arg in ("status_code", "statusCode", "code") and \
+                        isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, int):
+                    found.append((kw.value, body))
+        elif isinstance(node, ast.Dict):
+            for key, value in zip(node.keys, node.values):
+                if not (isinstance(key, ast.Constant) and key.value == "statusCode"):
+                    continue
+                if isinstance(value, ast.Constant) and isinstance(value.value, int):
+                    found.append((value, node))
+    return found
+
+
+def _body_has_discriminator(body_node) -> bool:
+    """True if the response body carries a field the model can branch on.
+
+    Only inspects literal dict keys — a body built by a helper call is given the
+    benefit of the doubt (we cannot see into it, and a false warning is worse
+    than a missing one).
+    """
+    import ast
+
+    if body_node is None:
+        return True
+    if not isinstance(body_node, ast.Dict):
+        return True
+    keys = {
+        k.value.lower()
+        for k in body_node.keys
+        if isinstance(k, ast.Constant) and isinstance(k.value, str)
+    }
+    if not keys:
+        return True
+    return bool(keys & _DISCRIMINATOR_KEYS)
+
+
+def lint_lambda_status_codes(code: str) -> dict:
+    """Rewrite 4xx business-outcome responses to 200 (BUSINESS_OUTCOME_200_RULE).
+
+    This is the deterministic safety net for the failure the prompts also warn
+    about: a Lambda that answers "authentication failed" with 403 makes the
+    Connect AI agent report a broken tool instead of telling the customer what
+    happened. Observed on a real build where an SSN/accountId verification tool
+    returned 400/403/409 and every negative path had to be corrected by hand.
+
+    Rewrites are position-exact (AST offsets), so only the integer literal
+    changes — comments, strings and formatting are untouched. 5xx is preserved.
+    Never raises; returns the input unchanged if anything goes wrong.
+
+    Returns {ok, fixed_code, fixes_applied, warnings}.
+    """
+    out = {"ok": True, "fixed_code": code, "fixes_applied": [], "warnings": []}
+    try:
+        import ast
+
+        tree = ast.parse(code)
+    except SyntaxError:
+        # Syntax is reported by lint_python_source; nothing safe to do here.
+        return out
+    except Exception as e:
+        logger.warning(f"[LINT_LAMBDA] status-code scan skipped: {e}")
+        return out
+
+    try:
+        edits = []
+        for const, body in _status_code_nodes(tree):
+            if const.value not in _BUSINESS_OUTCOME_4XX:
+                continue
+            if const.end_lineno is None or const.end_col_offset is None:
+                continue
+            edits.append((const.lineno, const.col_offset, const.end_col_offset, const.value, body))
+
+        if not edits:
+            return out
+
+        lines = code.splitlines(keepends=True)
+        # Apply bottom-up / right-to-left so earlier offsets stay valid.
+        for lineno, col, end_col, old_value, body in sorted(edits, reverse=True):
+            idx = lineno - 1
+            if idx >= len(lines):
+                continue
+            line = lines[idx]
+            if line[col:end_col] != str(old_value):
+                # Offsets didn't line up (unexpected encoding/continuation) —
+                # skip rather than corrupt the file.
+                continue
+            lines[idx] = line[:col] + "200" + line[end_col:]
+            out["fixes_applied"].append(
+                f"line {lineno}: HTTP {old_value} → 200 "
+                "(business outcome must be 200 or the Connect AI agent reads it as a tool failure)"
+            )
+            if not _body_has_discriminator(body):
+                out["warnings"].append(
+                    f"line {lineno}: response body has no outcome discriminator "
+                    f"(one of {', '.join(sorted(list(_DISCRIMINATOR_KEYS)[:6]))}...) — "
+                    "the AI agent cannot tell this apart from success; add e.g. "
+                    '"success": false with a customer-readable "message"'
+                )
+
+        candidate = "".join(lines)
+        # Re-parse: a rewrite that breaks the file must never be shipped.
+        ast.parse(candidate)
+        out["fixed_code"] = candidate
+        out["fixes_applied"].reverse()
+        return out
+    except Exception as e:
+        logger.warning(f"[LINT_LAMBDA] status-code autofix aborted, passing through: {e}")
+        return {"ok": True, "fixed_code": code, "fixes_applied": [], "warnings": []}
+
+
+# ---------------------------------------------------------------------------
+# Contact Flow (Amazon Connect flow JSON) — structural integrity
+# ---------------------------------------------------------------------------
+
+# Official Amazon Connect flow-language Action Types (the `Type` field of an
+# Action). VERIFIED against a real Amazon Connect console export (all 43 block
+# types) PLUS individual CreateContactFlow API probes (2026-06-08). A flow whose
+# `Type` is NOT in this set FAILS to import with InvalidContactFlowException.
+# Source of truth: knowledge-base-docs/contact-flow/_reference-console-export-all-blocks.json
+# Do NOT add a Type here without confirming it imports via the API — guessed
+# names (TransferToAgent, TransferToPhoneNumber, CheckQueueStatus, ...) were the
+# cause of import failures and are listed as invalid below.
+VALID_CONTACT_FLOW_ACTION_TYPES = frozenset({
+    # Interact
+    "MessageParticipant", "MessageParticipantIteratively", "GetParticipantInput",
+    "ConnectParticipantWithLexBot", "RenderMessageTemplate",
+    # Set / update
+    "UpdateContactAttributes", "UpdateContactData", "UpdateContactRecordingBehavior",
+    "UpdateContactRecordingAndAnalyticsBehavior",
+    "UpdateContactRecordingAndAnalyticsBehavior", "UpdateContactTextToSpeechVoice",
+    "UpdateContactTargetQueue", "UpdateContactCallbackNumber", "UpdateContactEventHooks",
+    "UpdateContactRoutingBehavior", "UpdateContactRoutingCriteria",
+    "UpdateFlowLoggingBehavior", "UpdateFlowAttributes",
+    "UpdateContactMediaStreamingBehavior", "UpdatePreviousContactParticipantState",
+    "TagContact", "UntagContact",
+    # Branch / control
+    "Compare", "Loop", "Wait", "DistributeByPercentage",
+    "CheckHoursOfOperation", "CheckMetricData", "GetMetricData", "CheckOutboundCallStatus",
+    "EvaluateDataTableValues",
+    # Integrate
+    "InvokeLambdaFunction", "InvokeFlowModule", "CreateWisdomSession",
+    "CreateTask", "CreateCase", "CreateContact", "StartOutboundEmailContact",
+    "AssociateContactToCustomerProfile", "GetCustomerProfile", "GetCustomerProfileObject",
+    "CreatePersistentContactAssociation", "LoadContactContent",
+    "AuthenticateParticipant", "ShowView", "ResumeContact",
+    # Transfer / terminate
+    "TransferContactToQueue", "TransferParticipantToThirdParty", "TransferToFlow",
+    "DequeueContactAndTransferToQueue",
+    "DisconnectParticipant", "EndFlowExecution",
+})
+
+# Known LLM hallucinations / wrong names → the correct official Type (or None
+# when there is no 1:1 replacement and the block must be removed/redesigned).
+# These are blocks the model has actually emitted that break import.
+INVALID_CONTACT_FLOW_TYPE_HINTS = {
+    # There is no "Trigger" / entry-point block — a flow starts at the action
+    # that StartAction points to. Drop the wrapper and start at its NextAction.
+    "Trigger": "(remove — flows start at StartAction, no Trigger block exists)",
+    "EntryPoint": "(remove — flows start at StartAction, no EntryPoint block exists)",
+    # Branch-on-value is `Compare`, not CheckCondition / CheckValue / Condition.
+    "CheckCondition": "Compare",
+    "CheckValue": "Compare",
+    "Condition": "Compare",
+    "CheckAttribute": "Compare",
+    # No "InvokeAgentAction" / Bedrock-agent block exists in the flow language.
+    # AI self-service runs through a Q-in-Connect-enabled Lex V2 bot.
+    "InvokeAgentAction": "ConnectParticipantWithLexBot",
+    "InvokeBedrockAgent": "ConnectParticipantWithLexBot",
+    "InvokeAmazonQConnect": "ConnectParticipantWithLexBot",
+    "InvokeQConnect": "ConnectParticipantWithLexBot",
+    # Common other hallucinations.
+    "PlayPrompt": "MessageParticipant",
+    "GetUserInput": "GetParticipantInput",
+    "SetWorkingQueue": "UpdateContactTargetQueue",
+    "SetCallbackNumber": "UpdateContactCallbackNumber",
+    "SetContactAttributes": "UpdateContactAttributes",
+    "SetRecordingBehavior": "UpdateContactRecordingBehavior",
+    "SetLoggingBehavior": "UpdateFlowLoggingBehavior",
+    "SetVoice": "UpdateContactTextToSpeechVoice",
+    "CreateCallbackContact": "(remove — use UpdateContactCallbackNumber + TransferContactToQueue)",
+    "TransferToQueue": "TransferContactToQueue",
+    "EndFlow": "DisconnectParticipant",
+    "Disconnect": "DisconnectParticipant",
+    # API-confirmed INVALID Types (2026-06-08) — these returned "Invalid Action
+    # type" from CreateContactFlow. Map to the real Type the console export uses.
+    "TransferToAgent": "TransferContactToQueue",
+    "TransferToPhoneNumber": "TransferParticipantToThirdParty",
+    "TransferToThirdParty": "TransferParticipantToThirdParty",
+    "CheckQueueStatus": "CheckMetricData",
+    "CheckStaffing": "CheckMetricData",
+    "Distribute": "DistributeByPercentage",
+    "StartMediaStreaming": "UpdateContactMediaStreamingBehavior",
+    "StopMediaStreaming": "UpdateContactMediaStreamingBehavior",
+    "ReturnFromFlowModule": "EndFlowExecution",
+    "InvokeAPI": "InvokeLambdaFunction",
+    "GetParticipantWithLexV2Bot": "ConnectParticipantWithLexBot",
+    "PutCustomerProfile": "(use Customer Profiles integration / UpdateContactData)",
+    "UpdateCustomerProfileObject": "(use Customer Profiles integration)",
+    "UpdateContactRoutingData": "UpdateContactRoutingCriteria",
+    "UpdateContactTextToSpeechManner": "UpdateContactTextToSpeechVoice",
+    "SetRecordingAndAnalyticsBehavior": "UpdateContactRecordingAndAnalyticsBehavior",
+}
+
+
+# Action Types that are TERMINAL — they end flow execution and MUST NOT carry
+# Transitions. Connect rejects "Action does not support transitions" otherwise.
+TERMINAL_ACTION_TYPES = frozenset({
+    "DisconnectParticipant", "EndFlowExecution", "ReturnFromFlowModule",
+    "TransferToFlow", "TransferContactToQueue", "TransferToAgent",
+})
+# TransferContactToQueue/TransferToAgent DO support transitions (queue-full etc.)
+# so keep only the truly terminal ones for the no-transitions rule.
+NO_TRANSITION_ACTION_TYPES = frozenset({
+    "DisconnectParticipant", "EndFlowExecution", "ReturnFromFlowModule",
+})
+
+# Required Error handlers per Action Type (Connect import enforces these).
+# Required Error handlers per Action Type — all verified against the real
+# CreateContactFlow API (create → inspect problems → delete, ap-northeast-2).
+# NOTE: GetParticipantInput is intentionally absent — its required errors depend
+# on mode (menu vs store) and are handled in the dedicated normalizer above.
+# NOTE: MessageParticipant is intentionally absent — API-verified (2026-07-04)
+# that it imports with NO Errors, so NoMatchingError is recommended (see prompt)
+# but NOT import-required; force-injecting it would over-normalize a valid flow.
+REQUIRED_ERRORS_BY_TYPE = {
+    "Compare": ["NoMatchingCondition"],
+    "ConnectParticipantWithLexBot": ["NoMatchingError", "NoMatchingCondition"],
+    "InvokeLambdaFunction": ["NoMatchingError"],
+    "CreateWisdomSession": ["NoMatchingError"],
+    "UpdateContactData": ["NoMatchingError"],
+    "TransferContactToQueue": ["QueueAtCapacity", "NoMatchingError"],
+    "DequeueContactAndTransferToQueue": ["QueueAtCapacity", "NoMatchingError"],
+    "UpdateContactTargetQueue": ["NoMatchingError"],
+    "UpdateContactAttributes": ["NoMatchingError"],   # API-verified: required
+    "CheckHoursOfOperation": ["NoMatchingError"],     # branches via True/False Conditions; needs NoMatchingError
+    # API-verified (2026-06-18): UpdateContactCallbackNumber requires BOTH of these
+    # and rejects NoMatchingError / InvalidNumber / NotDialable.
+    "UpdateContactCallbackNumber": ["InvalidCallbackNumber", "CallbackNumberNotDialable"],
+    # API-verified (2026-07-03) exhaustive per-parameter probe of the 10 blocks that
+    # the RAG sweep never exercised. Each block imports only with these error branches.
+    "AuthenticateParticipant": ["NoMatchingError", "TimeLimitExceeded"],
+    "CheckOutboundCallStatus": ["NoMatchingError"],
+    "CreatePersistentContactAssociation": ["NoMatchingError"],
+    "DistributeByPercentage": ["NoMatchingCondition"],
+    "EvaluateDataTableValues": ["NoMatchingError"],
+    "GetCustomerProfileObject": ["NoMatchingError", "NoneFoundError"],
+    "LoadContactContent": ["NoMatchingError"],
+    "UpdateContactRoutingCriteria": ["NoMatchingError"],
+    # NOTE: UpdateContactRoutingBehavior has CONDITIONAL errors — NoMatchingError is
+    # required ONLY for the RoutingProficiencies variant and MUST be absent for the
+    # QueuePriority / QueueTimeAdjustmentSeconds variants. Left out of this static map
+    # on purpose; enforcing a fixed set here would break the priority variant.
+}
+
+# Error types that are NOT valid for a given block — strip them on import.
+INVALID_ERRORS_BY_TYPE = {
+    "ConnectParticipantWithLexBot": {"AgentError"},
+    "CheckHoursOfOperation": {"NoMatchingCondition"},
+    # Compare branches via Conditions; its only valid Error is NoMatchingCondition.
+    "Compare": {"NoMatchingError"},
+    # API-verified (CreateContactFlow problems, 2026-06-18): UpdateContactCallbackNumber
+    # accepts ONLY InvalidCallbackNumber + CallbackNumberNotDialable (both required).
+    # It rejects NoMatchingError AND the outbound-dial types (InvalidNumber/NotDialable)
+    # the LLM tends to hallucinate here — all of which trip InvalidContactFlowException.
+    "UpdateContactCallbackNumber": {"InvalidNumber", "NotDialable", "NoMatchingError"},
+}
+
+# Canonical AI-bot tool-result vocabulary (see SUBAGENT_TERMINOLOGY_AND_ESCALATION).
+# The bot returns exactly `Complete` (end call) or `Escalate` (human transfer);
+# the flow's Compare branches on these. Map common LLM synonyms back to canonical.
+# Keys are upper-cased for case-insensitive matching. Spec-driven extensions like
+# `OutOfHoursComplete` / `EscalateBilling` are intentionally NOT remapped.
+_CANONICAL_TOOL_RESULT = {
+    "COMPLETE": "Complete",
+    "END_CALL": "Complete",
+    "ENDCALL": "Complete",
+    "END_CONVERSATION": "Complete",
+    "ENDCONVERSATION": "Complete",
+    "DONE": "Complete",
+    "FINISH": "Complete",
+    "FINISHED": "Complete",
+    "HANGUP": "Complete",
+    "DISCONNECT": "Complete",
+    "ESCALATE": "Escalate",
+    "ESCALATION": "Escalate",
+    "TRANSFER": "Escalate",
+    "TRANSFER_TO_AGENT": "Escalate",
+    "AGENT": "Escalate",
+    "HUMAN": "Escalate",
+    "HANDOFF": "Escalate",
+}
+
+# Valid JSONPath root namespaces for Compare.ComparisonValue / attribute refs.
+# The model sometimes invents roots like `$.Agent.ReturnControlEvent.Type`.
+_VALID_JSONPATH_ROOTS = (
+    "$.Attributes.", "$.Channel", "$.CustomerEndpoint", "$.SystemEndpoint",
+    "$.Lex.", "$.Customer.", "$.External.", "$.StoredCustomerInput",
+    "$.Media.", "$.ContactId", "$.InitialContactId", "$.Queue.",
+    "$.Metadata.", "$.FlowAttributes.",
+)
+
+
+# Languages for which Contact Lens real-time redaction can be requested inside
+# UpdateContactRecordingAndAnalyticsBehavior. Asking for redaction with any other
+# AnalyticsLanguage makes CreateContactFlow reject the flow, and the error names
+# AnalyticsLanguage rather than the redaction block — see the fix-up below.
+# Verified against CreateContactFlow (ap-northeast-2, 2026-08-06): en-US passes
+# with redaction enabled, ko-KR does not.
+REDACTION_SUPPORTED_LANGUAGES = {
+    "en-US", "en-GB", "en-AU", "en-IN", "es-US", "fr-CA", "fr-FR",
+    "de-DE", "it-IT", "pt-BR",
+}
+
+# Fallback when analytics is enabled but AnalyticsLanguage is missing (the API
+# requires it). Matches the default the rest of the pipeline assumes.
+_DEFAULT_ANALYTICS_LANGUAGE = "ko-KR"
+
+
+def _flow_analytics_language(actions: list) -> str:
+    """Best-guess AnalyticsLanguage for a flow, from its own voice settings."""
+    for a in actions:
+        if not isinstance(a, dict):
+            continue
+        p = a.get("Parameters") or a.get("parameters") or {}
+        if not isinstance(p, dict):
+            continue
+        for key in ("LanguageCode", "AnalyticsLanguage"):
+            val = p.get(key)
+            if isinstance(val, str) and "-" in val:
+                return val
+        tts = p.get("TextToSpeechVoice")
+        if isinstance(tts, dict) and isinstance(tts.get("languageCode"), str):
+            return tts["languageCode"]
+    return _DEFAULT_ANALYTICS_LANGUAGE
+
+
+def _normalize_contact_flow_params(actions: list, ids_to_first: dict, fixes: list) -> None:
+    """Rewrite block Parameters/Transitions to the shapes Amazon Connect's
+    CreateContactFlow API actually accepts. Mutates `actions` in place and
+    appends human-readable notes to `fixes`.
+
+    Every rule here was derived from real InvalidContactFlowException `problems`
+    returned by the Connect API (the strict validator the console import uses):
+      - UpdateContactRecordingBehavior: {Agent,Customer} → {RecordingBehavior,…}
+      - UpdateContactTextToSpeechVoice: {VoiceId,Engine,LanguageCode} → {TextToSpeechVoice,TextToSpeechEngine}
+      - UpdateFlowLoggingBehavior:      {LoggingBehavior} → {FlowLoggingBehavior}
+      - UpdateContactTargetQueue:       {Queue} → {QueueId}
+      - ConnectParticipantWithLexBot:   {BotAliasArn,LexBot{AliasArn},Participant…} → {LexV2Bot{AliasArn},Text}
+      - terminal blocks:                strip Transitions
+      - MessageParticipant:             only ONE of Text/SSML/Media
+      - missing required Error handlers: injected, routed to a safe fallback
+    """
+    # A safe fallback target for injected error transitions: prefer an existing
+    # disconnect/terminal block, else the first action.
+    fallback = None
+    for a in actions:
+        if isinstance(a, dict) and (a.get("Type") or a.get("type")) == "DisconnectParticipant":
+            fallback = a.get("Identifier") or a.get("identifier")
+            break
+    if not fallback and actions:
+        fallback = actions[0].get("Identifier") or actions[0].get("identifier")
+
+    for a in actions:
+        if not isinstance(a, dict):
+            continue
+        t = a.get("Type") or a.get("type")
+        p = a.get("Parameters")
+        if p is None:
+            p = a.get("parameters")
+        if p is None:
+            p = {}
+        pkey = "Parameters" if "Parameters" in a or "parameters" not in a else "parameters"
+        aid = a.get("Identifier") or a.get("identifier")
+
+        # --- UpdateContactRecordingAndAnalyticsBehavior (current console block):
+        #     API requires NoMatchingError + ChannelMismatch error branches
+        #     (+ InFlightRedactionConfigurationFailed when ChatBehavior present)
+        if t == "UpdateContactRecordingAndAnalyticsBehavior":
+            tr = a.setdefault("Transitions", {})
+            nxt = tr.get("NextAction") or fallback
+            errs = tr.setdefault("Errors", [])
+            have = {e.get("ErrorType") for e in errs if isinstance(e, dict)}
+            required = ["NoMatchingError", "ChannelMismatch"]
+            if isinstance(p, dict) and "ChatBehavior" in p:
+                required.append("InFlightRedactionConfigurationFailed")
+            for et in required:
+                if et not in have and nxt:
+                    errs.append({"ErrorType": et, "NextAction": nxt})
+                    fixes.append(f"[{aid}] UpdateContactRecordingAndAnalyticsBehavior: added required {et} error branch")
+
+            # Contact Lens real-time redaction is only supported for a subset of
+            # languages. Asking for it with an unsupported AnalyticsLanguage is
+            # rejected as "Invalid Action property value ... AnalyticsLanguage",
+            # which is misleading — the language is fine, the REDACTION is not.
+            # CreateContactFlow-verified (2026-08-06, ap-northeast-2):
+            #   ko-KR + redaction Enabled=True  -> Invalid ... AnalyticsLanguage
+            #   en-US + redaction Enabled=True  -> OK
+            #   ko-KR + redaction absent/False  -> OK
+            #   AnalyticsLanguage omitted       -> "missing required property"
+            # So: keep AnalyticsLanguage (it is REQUIRED) and drop the redaction
+            # request instead. Recording/analytics still work; only redaction is
+            # unavailable for that language.
+            vb = p.get("VoiceBehavior") if isinstance(p, dict) else None
+            vab = vb.get("VoiceAnalyticsBehavior") if isinstance(vb, dict) else None
+            if isinstance(vab, dict):
+                lang = str(vab.get("AnalyticsLanguage") or "")
+                red = vab.get("ConversationalAnalyticsRedactionConfiguration")
+                red_on = isinstance(red, dict) and str(red.get("Enabled", "")).lower() == "true"
+                if red_on and lang not in REDACTION_SUPPORTED_LANGUAGES:
+                    vab["ConversationalAnalyticsRedactionConfiguration"] = {"Enabled": "False"}
+                    fixes.append(
+                        f"[{aid}] UpdateContactRecordingAndAnalyticsBehavior: disabled "
+                        f"ConversationalAnalyticsRedactionConfiguration — redaction is not "
+                        f"supported for AnalyticsLanguage={lang or '(unset)'} and the API "
+                        f"rejects the flow with a misleading AnalyticsLanguage error"
+                    )
+                # AnalyticsLanguage is REQUIRED whenever analytics is enabled.
+                elif not lang and str(vab.get("Enabled", "")).lower() == "true":
+                    vab["AnalyticsLanguage"] = _flow_analytics_language(actions)
+                    fixes.append(
+                        f"[{aid}] UpdateContactRecordingAndAnalyticsBehavior: added required "
+                        f"AnalyticsLanguage={vab['AnalyticsLanguage']}"
+                    )
+
+        # --- UpdateContactRecordingBehavior: {Agent, Customer} → RecordingBehavior
+        if t == "UpdateContactRecordingBehavior":
+            if "RecordingBehavior" not in p:
+                p.pop("Agent", None)
+                p.pop("Customer", None)
+                p["RecordingBehavior"] = {
+                    "RecordedParticipants": ["Agent", "Customer"],
+                    "IVRRecordingBehavior": "Enabled",
+                }
+                p.setdefault("AnalyticsBehavior", {
+                    "Enabled": "True",
+                    "AnalyticsLanguage": "ko-KR",
+                    "ChannelConfiguration": {
+                        "Chat": {"AnalyticsModes": ["ContactLens"]},
+                        "Voice": {"AnalyticsModes": ["PostContact"]},
+                    },
+                })
+                fixes.append(f"[{aid}] UpdateContactRecordingBehavior: rebuilt RecordingBehavior (removed Agent/Customer)")
+
+        # --- UpdateContactTextToSpeechVoice: {VoiceId,Engine,LanguageCode} → {TextToSpeechVoice,Engine}
+        elif t == "UpdateContactTextToSpeechVoice":
+            if "TextToSpeechVoice" not in p:
+                voice = p.pop("VoiceId", None) or "Seoyeon"
+                eng = p.pop("Engine", None) or "Generative"
+                p.pop("LanguageCode", None)
+                p["TextToSpeechVoice"] = voice
+                p["TextToSpeechEngine"] = eng
+                p.setdefault("TextToSpeechStyle", "None")
+                fixes.append(f"[{aid}] UpdateContactTextToSpeechVoice: VoiceId/Engine/LanguageCode → TextToSpeechVoice/TextToSpeechEngine")
+
+        # --- UpdateFlowLoggingBehavior: {LoggingBehavior} → {FlowLoggingBehavior}
+        elif t == "UpdateFlowLoggingBehavior":
+            if "FlowLoggingBehavior" not in p and "LoggingBehavior" in p:
+                p["FlowLoggingBehavior"] = p.pop("LoggingBehavior")
+                fixes.append(f"[{aid}] UpdateFlowLoggingBehavior: LoggingBehavior → FlowLoggingBehavior")
+
+        # --- UpdateContactTargetQueue: {Queue} → {QueueId}; flatten nested QueueId
+        elif t == "UpdateContactTargetQueue":
+            if "QueueId" not in p and "Queue" in p:
+                p["QueueId"] = p.pop("Queue")
+                fixes.append(f"[{aid}] UpdateContactTargetQueue: Queue → QueueId")
+            # QueueId must be a string ARN/id, not a nested object {"QueueId": "..."}
+            if isinstance(p.get("QueueId"), dict):
+                inner = p["QueueId"].get("QueueId") or p["QueueId"].get("Id") or next(iter(p["QueueId"].values()), None)
+                p["QueueId"] = inner or "{{QUEUE_ARN}}"
+                fixes.append(f"[{aid}] UpdateContactTargetQueue: flattened nested QueueId → string")
+
+        # --- TransferContactToQueue: takes NO queue parameter (API-verified
+        # 2026-06-18). The target queue is set by a preceding UpdateContactTargetQueue;
+        # any QueueId/QueueArn/Queue here is rejected as "Invalid Action property name".
+        # The LLM frequently re-specifies the queue on the transfer block — strip it.
+        elif t == "TransferContactToQueue":
+            removed_q = [k for k in ("QueueId", "QueueArn", "Queue") if k in p]
+            for k in removed_q:
+                p.pop(k, None)
+            if removed_q:
+                fixes.append(f"[{aid}] TransferContactToQueue: removed invalid queue param(s) {removed_q} (queue is set via UpdateContactTargetQueue)")
+
+        # --- InvokeLambdaFunction: RequestAttributes → LambdaInvocationAttributes
+        elif t == "InvokeLambdaFunction":
+            if "RequestAttributes" in p:
+                p.setdefault("LambdaInvocationAttributes", p.pop("RequestAttributes"))
+                fixes.append(f"[{aid}] InvokeLambdaFunction: RequestAttributes → LambdaInvocationAttributes")
+            # ResponseValidation.ResponseType must be STRING_MAP or JSON (API-verified
+            # 2026-07-03: both import; JSON_OBJECT is REJECTED with "Invalid Action
+            # property value"). ResponseValidation itself is optional.
+            rv = p.get("ResponseValidation")
+            if isinstance(rv, dict) and rv.get("ResponseType") not in ("STRING_MAP", "JSON"):
+                rv["ResponseType"] = "STRING_MAP"
+                fixes.append(f"[{aid}] InvokeLambdaFunction: ResponseValidation.ResponseType → STRING_MAP")
+
+        # --- CheckHoursOfOperation: null/missing HoursOfOperationId → placeholder
+        elif t == "CheckHoursOfOperation":
+            if not p.get("HoursOfOperationId"):
+                p["HoursOfOperationId"] = "{{HOURS_OF_OPERATION_ID}}"
+                fixes.append(f"[{aid}] CheckHoursOfOperation: filled missing HoursOfOperationId placeholder")
+            # Must branch on BOTH True and False conditions.
+            tr = a.get("Transitions") or a.get("transitions") or {}
+            conds = tr.get("Conditions") or tr.get("conditions") or []
+            operands = {str(c.get("Condition", {}).get("Operands", [None])[0])
+                        for c in conds if isinstance(c, dict)}
+            nxt = tr.get("NextAction") or tr.get("nextAction") or fallback
+            true_target = next((c.get("NextAction") for c in conds
+                                if isinstance(c, dict) and str(c.get("Condition", {}).get("Operands", [None])[0]) == "True"), None)
+            if "False" not in operands:
+                conds.append({"Condition": {"Operator": "Equals", "Operands": ["False"]},
+                              "NextAction": nxt})
+                fixes.append(f"[{aid}] CheckHoursOfOperation: added missing 'False' branch")
+            if "True" not in operands:
+                conds.insert(0, {"Condition": {"Operator": "Equals", "Operands": ["True"]},
+                                 "NextAction": true_target or nxt})
+                fixes.append(f"[{aid}] CheckHoursOfOperation: added missing 'True' branch")
+            tr["Conditions"] = conds
+            a["Transitions" if "Transitions" in a or "transitions" not in a else "transitions"] = tr
+
+        # --- Compare: ComparisonValue must use a valid JSONPath root
+        elif t == "Compare":
+            cv = p.get("ComparisonValue")
+            if isinstance(cv, str) and cv.startswith("$.") and not cv.startswith(_VALID_JSONPATH_ROOTS):
+                # Re-home an invented root (e.g. $.Agent.ReturnControlEvent.Type)
+                # to a contact attribute, which is where flow logic should read.
+                leaf = cv.rstrip(".").split(".")[-1]
+                p["ComparisonValue"] = f"$.Attributes.{leaf}"
+                fixes.append(f"[{aid}] Compare: ComparisonValue '{cv}' → '$.Attributes.{leaf}' (invalid JSONPath root)")
+            # Canonical AI-bot tool-result vocabulary: when this Compare branches on
+            # the bot's Tool result, the operands MUST be `Complete`/`Escalate`
+            # (see SUBAGENT_TERMINOLOGY_AND_ESCALATION). Normalize known wrong
+            # synonyms so the flow's branch matches what the bot actually returns.
+            cv2 = p.get("ComparisonValue") or ""
+            if isinstance(cv2, str) and (".Tool" in cv2 or "actionType" in cv2 or ".toolResult" in cv2 or ".Tool." in cv2):
+                tr = a.get("Transitions") or a.get("transitions") or {}
+                for cond in (tr.get("Conditions") or tr.get("conditions") or []):
+                    if not isinstance(cond, dict):
+                        continue
+                    ops = cond.get("Condition", {}).get("Operands")
+                    if not isinstance(ops, list):
+                        continue
+                    for i_op, val in enumerate(ops):
+                        canon = _CANONICAL_TOOL_RESULT.get(str(val).strip().upper())
+                        if canon and val != canon:
+                            ops[i_op] = canon
+                            fixes.append(f"[{aid}] Compare: tool-result operand '{val}' → '{canon}' (canonical Complete/Escalate vocabulary)")
+
+        # --- ConnectParticipantWithLexBot: normalize to LexV2Bot.AliasArn + one message
+        elif t == "ConnectParticipantWithLexBot":
+            # Collect any ARN the model produced under various wrong keys.
+            arn = (p.pop("BotAliasArn", None)
+                   or p.pop("AgentAliasArn", None)
+                   or (isinstance(p.get("LexBot"), dict) and p["LexBot"].get("AliasArn"))
+                   or (isinstance(p.get("LexV2Bot"), dict) and p["LexV2Bot"].get("AliasArn")))
+            # Drop non-existent params.
+            for bad in ("ParticipantRole", "SessionAttributes", "RequestAttributes",
+                        "IdleSessionTimeout", "EndConversationPhrase"):
+                if bad in p and bad != "SessionAttributes":
+                    p.pop(bad, None)
+            # Migrate LexSessionAttributes-style key if present under SessionAttributes.
+            if "SessionAttributes" in p:
+                p.setdefault("LexSessionAttributes", p.pop("SessionAttributes"))
+            # Remove a malformed LexBot (V1 requires Name+Region+Alias; we use V2).
+            lexbot = p.get("LexBot")
+            if isinstance(lexbot, dict) and not all(k in lexbot for k in ("Name", "Region", "Alias")):
+                p.pop("LexBot", None)
+            if "LexV2Bot" not in p and "LexBot" not in p:
+                p["LexV2Bot"] = {"AliasArn": arn or "{{LEX_BOT_ALIAS_ARN}}"}
+                fixes.append(f"[{aid}] ConnectParticipantWithLexBot: normalized to LexV2Bot.AliasArn")
+            # Must have exactly one message property.
+            msg_keys = [k for k in ("Text", "SSML", "PromptId", "Media", "LexInitializationData") if k in p]
+            if not msg_keys:
+                p["Text"] = "{{WELCOME_MESSAGE}}"
+                fixes.append(f"[{aid}] ConnectParticipantWithLexBot: added required Text")
+
+        # --- GetParticipantInput: two distinct API-verified modes.
+        #   MENU mode  (branches via Conditions): StoreInput=False, NO
+        #     DTMFConfiguration, errors must be NoMatchingCondition +
+        #     InputTimeLimitExceeded + NoMatchingError.
+        #   STORE mode (captures input to an attribute): StoreInput=True,
+        #     requires InputValidation.CustomValidation.MaximumLength, optional
+        #     DTMFConfiguration{DisableCancelKey, InputTerminationSequence},
+        #     errors = NoMatchingError only.
+        # Both modes REQUIRE InputTimeLimitSeconds (string) at the Parameters root.
+        # DisableCancelKey MUST be a string "True"/"False" — a JSON boolean makes the
+        # whole block fail import with a MISLEADING "Invalid Action type" error.
+        # (Both verified against CreateContactFlow; the empty/guessed forms the
+        #  model emits otherwise fail import with misleading "Invalid Action type".)
+        if t == "GetParticipantInput":
+            tr_gp = a.get("Transitions") or a.get("transitions") or {}
+            conds_gp = tr_gp.get("Conditions") or tr_gp.get("conditions") or []
+            is_menu = bool(conds_gp)
+            # DisableCancelKey must be a string, never a JSON boolean (bool → misleading
+            # "Invalid Action type" on import).
+            _dtmf = p.get("DTMFConfiguration")
+            if isinstance(_dtmf, dict) and isinstance(_dtmf.get("DisableCancelKey"), bool):
+                _dtmf["DisableCancelKey"] = "True" if _dtmf["DisableCancelKey"] else "False"
+                fixes.append(f"[{aid}] GetParticipantInput: DisableCancelKey boolean → string")
+            # Both modes require InputTimeLimitSeconds (string) at the Parameters root.
+            # A value mistakenly nested in DTMFConfiguration is re-homed by the store-mode
+            # normalizer below; only inject a default when it exists in neither place.
+            _nested_itl = isinstance(_dtmf, dict) and "InputTimeLimitSeconds" in _dtmf
+            if "InputTimeLimitSeconds" not in p and not _nested_itl:
+                p["InputTimeLimitSeconds"] = "5"
+                fixes.append(f"[{aid}] GetParticipantInput: added required InputTimeLimitSeconds")
+            if is_menu:
+                if str(p.get("StoreInput")) != "False":
+                    p["StoreInput"] = "False"
+                    fixes.append(f"[{aid}] GetParticipantInput(menu): StoreInput=False")
+                if "DTMFConfiguration" in p:
+                    p.pop("DTMFConfiguration", None)
+                    fixes.append(f"[{aid}] GetParticipantInput(menu): removed DTMFConfiguration")
+                p.pop("InputValidation", None)
+            else:
+                if str(p.get("StoreInput")) != "True":
+                    p["StoreInput"] = "True"
+                    fixes.append(f"[{aid}] GetParticipantInput(store): StoreInput=True")
+                # DTMFConfiguration in store mode accepts DisableCancelKey and
+                # InputTerminationSequence (API-verified 2026-07-03 — the terminator
+                # key imports fine). InputTimeLimitSeconds belongs at the Parameters
+                # root, not inside DTMFConfiguration; any other key is rejected.
+                dtmf = p.get("DTMFConfiguration")
+                if isinstance(dtmf, dict):
+                    allowed = {"DisableCancelKey", "InputTerminationSequence"}
+                    bad = [k for k in list(dtmf.keys()) if k not in allowed]
+                    if bad:
+                        # InputTimeLimitSeconds is a real top-level param — re-home it.
+                        if "InputTimeLimitSeconds" in dtmf and "InputTimeLimitSeconds" not in p:
+                            p["InputTimeLimitSeconds"] = dtmf["InputTimeLimitSeconds"]
+                        for k in bad:
+                            dtmf.pop(k, None)
+                        dtmf.setdefault("DisableCancelKey", "False")
+                        fixes.append(f"[{aid}] GetParticipantInput(store): stripped invalid DTMFConfiguration keys {bad}")
+                if "InputValidation" not in p:
+                    p["InputValidation"] = {"CustomValidation": {"MaximumLength": "6"}}
+                    fixes.append(f"[{aid}] GetParticipantInput(store): added required InputValidation")
+                # Store mode: ONLY NoMatchingError is valid (no Conditions → no
+                # NoMatchingCondition; InputTimeLimitExceeded is rejected here).
+                tr_st = a.get("Transitions") or a.get("transitions")
+                if isinstance(tr_st, dict):
+                    errs = tr_st.get("Errors") or tr_st.get("errors") or []
+                    nxt = tr_st.get("NextAction") or tr_st.get("nextAction")
+                    bad_err = [e for e in errs if (e.get("ErrorType") or e.get("errorType")) != "NoMatchingError"]
+                    if bad_err:
+                        kept = [e for e in errs if (e.get("ErrorType") or e.get("errorType")) == "NoMatchingError"]
+                        if not kept:
+                            kept = [{"ErrorType": "NoMatchingError", "NextAction": nxt}]
+                        tr_st["Errors" if "Errors" in tr_st else "errors"] = kept
+                        fixes.append(f"[{aid}] GetParticipantInput(store): kept only NoMatchingError (removed {[e.get('ErrorType') for e in bad_err]})")
+
+        # --- Loop: condition operands are DoneLooping/ContinueLooping (NOT Looping/Complete)
+        if t == "Loop":
+            tr_lp = a.get("Transitions") or a.get("transitions") or {}
+            for c in (tr_lp.get("Conditions") or tr_lp.get("conditions") or []):
+                if not isinstance(c, dict):
+                    continue
+                ops = c.get("Condition", {}).get("Operands")
+                if isinstance(ops, list):
+                    for i_o, v in enumerate(ops):
+                        lv = str(v).strip().lower()
+                        if lv in ("looping", "continue", "continuelooping"):
+                            if ops[i_o] != "ContinueLooping":
+                                ops[i_o] = "ContinueLooping"
+                                fixes.append(f"[{aid}] Loop: operand → ContinueLooping")
+                        elif lv in ("complete", "done", "donelooping"):
+                            if ops[i_o] != "DoneLooping":
+                                ops[i_o] = "DoneLooping"
+                                fixes.append(f"[{aid}] Loop: operand → DoneLooping")
+
+        # --- MessageParticipant / GetParticipantInput: only ONE of Text/SSML/Media
+        if t in ("MessageParticipant", "GetParticipantInput", "MessageParticipantIteratively"):
+            present = [k for k in ("Text", "SSML", "PromptId", "Media") if k in p]
+            if len(present) > 1:
+                # Keep Text if present, else the first; drop the rest.
+                keep = "Text" if "Text" in present else present[0]
+                for k in present:
+                    if k != keep:
+                        p.pop(k, None)
+                fixes.append(f"[{aid}] {t}: kept only '{keep}' (removed {[k for k in present if k!=keep]})")
+
+        # write params back
+        if pkey in a or p:
+            a[pkey] = p
+
+        # --- Terminal blocks must not carry Transitions / Conditions / Errors
+        if t in NO_TRANSITION_ACTION_TYPES:
+            removed = []
+            for k in ("Transitions", "transitions", "Conditions", "Errors"):
+                if a.get(k):
+                    a.pop(k, None)
+                    removed.append(k)
+                elif k in a:
+                    a.pop(k, None)
+            if removed:
+                fixes.append(f"[{aid}] {t}: removed {removed} (terminal block carries none)")
+
+        # --- Strip Error types that are invalid for this block
+        bad_errs = INVALID_ERRORS_BY_TYPE.get(t)
+        if bad_errs:
+            tr = a.get("Transitions") or a.get("transitions")
+            if isinstance(tr, dict):
+                errs = tr.get("Errors") or tr.get("errors")
+                if isinstance(errs, list):
+                    kept = [e for e in errs if (e.get("ErrorType") or e.get("errorType")) not in bad_errs]
+                    if len(kept) != len(errs):
+                        tr["Errors" if "Errors" in tr else "errors"] = kept
+                        fixes.append(f"[{aid}] {t}: removed invalid Error type(s) {sorted(bad_errs & {e.get('ErrorType') or e.get('errorType') for e in errs})}")
+
+        # --- Inject missing required Error handlers
+        req = REQUIRED_ERRORS_BY_TYPE.get(t)
+        if req and t not in NO_TRANSITION_ACTION_TYPES:
+            tr = a.get("Transitions")
+            trkey = "Transitions"
+            if tr is None:
+                tr = a.get("transitions")
+                trkey = "transitions"
+            if tr is None:
+                tr = {}
+                trkey = "Transitions"
+            errs = tr.get("Errors")
+            if errs is None:
+                errs = tr.get("errors") or []
+            have = {e.get("ErrorType") or e.get("errorType") for e in errs if isinstance(e, dict)}
+            nxt = tr.get("NextAction") or tr.get("nextAction") or fallback
+            added = []
+            for et in req:
+                if et not in have:
+                    errs.append({"ErrorType": et, "NextAction": fallback or nxt})
+                    added.append(et)
+            if added:
+                tr["Errors"] = errs
+                a[trkey] = tr
+                fixes.append(f"[{aid}] {t}: added required Error(s) {added}")
+
+
+def lint_contact_flow(flow_json: str) -> dict:
+    """Validate Amazon Connect Contact Flow JSON structural integrity.
+
+    Catches the issues that make a flow fail to IMPORT or run:
+      - invalid JSON
+      - missing StartAction / Actions
+      - transitions (NextAction / Errors / Conditions) pointing at action ids
+        that don't exist (dangling references)
+      - actions unreachable from StartAction (orphans)
+      - terminal blocks (DisconnectParticipant) present
+    Never raises. Returns {ok, errors:[...], warnings:[...]}.
+    """
+    import json as _json
+    try:
+        doc = _json.loads(flow_json)
+    except Exception as e:
+        return {"ok": False, "errors": [f"Invalid JSON: {e}"], "warnings": [], "fixes_applied": [], "fixed_json": flow_json}
+
+    if not isinstance(doc, dict):
+        return {"ok": False, "errors": ["Flow root is not an object"], "warnings": [], "fixes_applied": [], "fixed_json": flow_json}
+
+    actions = doc.get("Actions") or doc.get("actions") or []
+    errors: list[str] = []
+    warnings: list[str] = []
+    fixes_applied: list[str] = []
+
+    # Deterministic auto-fix: `RealTime` in a Voice AnalyticsModes list breaks
+    # Amazon Connect import (InvalidContactFlowException on
+    # AnalyticsBehavior.ChannelConfiguration.Voice) unless real-time Contact Lens
+    # preconditions are met. Drop it (keep PostContact / others) so the flow
+    # always imports. Verified against create-contact-flow.
+    for a in actions:
+        if not isinstance(a, dict):
+            continue
+        if (a.get("Type") or a.get("type")) != "UpdateContactRecordingBehavior":
+            continue
+        params = a.get("Parameters") or a.get("parameters") or {}
+        ab = params.get("AnalyticsBehavior") or {}
+        cc = ab.get("ChannelConfiguration") or {}
+        voice = cc.get("Voice") or {}
+        modes = voice.get("AnalyticsModes")
+        if isinstance(modes, list) and "RealTime" in modes:
+            new_modes = [m for m in modes if m != "RealTime"] or ["PostContact"]
+            voice["AnalyticsModes"] = new_modes
+            fixes_applied.append(
+                f"Removed 'RealTime' from Voice.AnalyticsModes (→ {new_modes}) — RealTime breaks Connect import"
+            )
+    # Deterministic auto-fix: a `Trigger` / `EntryPoint` block does not exist in
+    # the flow language — a flow starts directly at the action StartAction points
+    # to. The model sometimes emits a no-op Trigger as the StartAction. Rewire
+    # StartAction to the Trigger's NextAction and drop the Trigger block so the
+    # flow imports.
+    _start_id = doc.get("StartAction") or doc.get("startAction")
+    for a in list(actions):
+        if not isinstance(a, dict):
+            continue
+        if (a.get("Type") or a.get("type")) not in ("Trigger", "EntryPoint"):
+            continue
+        aid = a.get("Identifier") or a.get("identifier")
+        trans = a.get("Transitions") or a.get("transitions") or {}
+        nxt = trans.get("NextAction") or trans.get("nextAction")
+        if aid == _start_id and nxt:
+            # Repoint StartAction past the Trigger, then remove the Trigger block.
+            if "StartAction" in doc:
+                doc["StartAction"] = nxt
+            else:
+                doc["startAction"] = nxt
+            actions.remove(a)
+            # Drop its ActionMetadata entry if present.
+            md = doc.get("Metadata") or {}
+            am = md.get("ActionMetadata") if isinstance(md, dict) else None
+            if isinstance(am, dict):
+                am.pop(aid, None)
+            fixes_applied.append(
+                f"Removed invalid '{a.get('Type') or a.get('type')}' block '{aid}'; "
+                f"StartAction → '{nxt}' (no Trigger block exists in flow language)"
+            )
+
+    # Deterministic block-type validation: an Action whose Type is not a real
+    # Amazon Connect flow-language Action Type makes the flow fail to import
+    # (InvalidContactFlowException). The model occasionally hallucinates blocks
+    # like `Trigger`, `CheckCondition`, `InvokeAgentAction`. Catch every such
+    # Type and, for the known 1:1 renames, auto-fix it.
+    invalid_types: list[str] = []
+    for a in actions:
+        if not isinstance(a, dict):
+            continue
+        t = a.get("Type") or a.get("type")
+        if not t or t in VALID_CONTACT_FLOW_ACTION_TYPES:
+            continue
+        hint = INVALID_CONTACT_FLOW_TYPE_HINTS.get(t)
+        if hint and not hint.startswith("("):
+            # Safe 1:1 rename to a real Type.
+            if "Type" in a:
+                a["Type"] = hint
+            else:
+                a["type"] = hint
+            # When renaming a hallucinated AI block to ConnectParticipantWithLexBot,
+            # the old params (AgentAliasArn / IdleSessionTimeout / EndConversationPhrase)
+            # are invalid for the Lex block and Connect rejects them on import.
+            # Rewrite to the minimum valid shape: LexV2Bot.AliasArn + Text.
+            if hint == "ConnectParticipantWithLexBot":
+                p = a.get("Parameters") or a.get("parameters") or {}
+                if "LexV2Bot" not in p and "LexBot" not in p:
+                    old_arn = p.pop("AgentAliasArn", None) or p.pop("BotAliasArn", None)
+                    phrase = p.pop("EndConversationPhrase", None)
+                    p.pop("IdleSessionTimeout", None)
+                    p["LexV2Bot"] = {"AliasArn": old_arn or "{{LEX_BOT_ALIAS_ARN}}"}
+                    if "Text" not in p and "SSML" not in p and "PromptId" not in p and "Media" not in p:
+                        p["Text"] = phrase or "{{WELCOME_MESSAGE}}"
+                    if "Parameters" in a:
+                        a["Parameters"] = p
+                    else:
+                        a["parameters"] = p
+                    fixes_applied.append(
+                        f"Rewrote '{t}' params → ConnectParticipantWithLexBot (LexV2Bot.AliasArn + Text)"
+                    )
+            fixes_applied.append(f"Renamed invalid block Type '{t}' → '{hint}'")
+        else:
+            suffix = f" — {hint}" if hint else " (not a valid Amazon Connect flow Action Type)"
+            invalid_types.append(f"Action '{a.get('Identifier') or a.get('identifier')}' has invalid Type '{t}'{suffix}")
+
+    # Deterministic parameter normalization: rewrite block Parameters/Transitions
+    # to the exact shapes Connect's CreateContactFlow API accepts (derived from
+    # real InvalidContactFlowException problems). This fixes the param-name and
+    # required-error drift that makes generated flows fail to import.
+    try:
+        _normalize_contact_flow_params(actions, {}, fixes_applied)
+    except Exception as _e:  # never let normalization break linting
+        warnings.append(f"param normalization skipped: {_e}")
+
+    flow_json_fixed = _json.dumps(doc, ensure_ascii=False, indent=2) if fixes_applied else flow_json
+
+    if not actions:
+        return {"ok": False, "errors": ["No Actions in flow"], "warnings": []}
+
+    # Read StartAction AFTER the auto-fixes above (the Trigger fix may have
+    # repointed it) so downstream validation reflects the corrected flow.
+    start = doc.get("StartAction") or doc.get("startAction")
+
+    ids = set()
+    for a in actions:
+        if isinstance(a, dict):
+            aid = a.get("Identifier") or a.get("identifier")
+            if aid:
+                ids.add(aid)
+
+    if not start:
+        errors.append("Missing StartAction")
+    elif start not in ids:
+        errors.append(f"StartAction '{start}' is not a defined action")
+
+    def _targets(action: dict):
+        t = action.get("Transitions") or action.get("transitions") or {}
+        out = []
+        if isinstance(t, dict):
+            nxt = t.get("NextAction") or t.get("nextAction")
+            if nxt:
+                out.append(nxt)
+            for err in (t.get("Errors") or t.get("errors") or []):
+                if isinstance(err, dict):
+                    n = err.get("NextAction") or err.get("nextAction")
+                    if n:
+                        out.append(n)
+            for cond in (t.get("Conditions") or t.get("conditions") or []):
+                if isinstance(cond, dict):
+                    n = cond.get("NextAction") or cond.get("nextAction")
+                    if n:
+                        out.append(n)
+        return out
+
+    # Dangling reference check + adjacency for reachability.
+    adj: dict[str, list] = {}
+    for a in actions:
+        if not isinstance(a, dict):
+            continue
+        aid = a.get("Identifier") or a.get("identifier")
+        tgts = _targets(a)
+        adj[aid] = tgts
+        for tg in tgts:
+            if tg not in ids:
+                errors.append(f"Action '{aid}' transitions to undefined action '{tg}'")
+
+    # Reachability from StartAction (orphans → warning, not fatal).
+    if start in ids:
+        seen = set()
+        stack = [start]
+        while stack:
+            cur = stack.pop()
+            if cur in seen:
+                continue
+            seen.add(cur)
+            stack.extend(adj.get(cur, []))
+        orphans = ids - seen
+        if orphans:
+            warnings.append(f"{len(orphans)} action(s) unreachable from StartAction: {sorted(orphans)[:5]}")
+
+    types = {(a.get("Type") or a.get("type")) for a in actions if isinstance(a, dict)}
+    # Re-evaluate terminal block AFTER any Type auto-fixes (e.g. EndFlow→Disconnect).
+    if "DisconnectParticipant" not in types:
+        warnings.append("No DisconnectParticipant (terminal) block — flow may not end cleanly")
+
+    # Invalid Types that could NOT be auto-renamed are hard import-blockers.
+    errors.extend(invalid_types)
+
+    return {"ok": not errors, "errors": errors, "warnings": warnings,
+            "fixes_applied": fixes_applied, "fixed_json": flow_json_fixed}
+
+
+# Matches an Amazon Connect AI-prompt interpolation token: {{ $.something }} or
+# {{ foo }}. Captures the inner expression (trimmed) so we can detect duplicates.
+_AI_PROMPT_VAR_RE = re.compile(r"\{\{\s*(.*?)\s*\}\}")
+
+
+def lint_ai_prompt(prompt_text: str) -> dict:
+    """Validate an Amazon Connect AI-agent prompt against the qconnect
+    CreateAIPrompt import rules. Never raises.
+
+    The one rule the real API enforces that the generator can silently violate:
+    **each variable may appear inside `{{ }}` only ONCE per prompt.** Verified
+    against qconnect create-ai-prompt: a second `{{$.Custom.firstName}}` ->
+    ValidationException "Each variable may only appear once." A bare reference
+    (no braces) is just literal text and is always fine.
+
+    Auto-fix: keep the FIRST `{{var}}` occurrence; strip the braces from every
+    later occurrence of the SAME variable (leaving the inner expression as plain
+    text), which the API accepts. Returns {ok, errors, warnings, fixes_applied,
+    fixed_text}.
+    """
+    if not isinstance(prompt_text, str) or not prompt_text:
+        return {"ok": False, "errors": ["Empty prompt text"], "warnings": [],
+                "fixes_applied": [], "fixed_text": prompt_text or ""}
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    fixes_applied: list[str] = []
+
+    seen: set[str] = set()
+
+    def _dedupe(m: "re.Match") -> str:
+        inner = m.group(1).strip()
+        if inner in seen:
+            # Subsequent reference — strip braces so it becomes literal text,
+            # which the API accepts. This is the documented "use the bare token
+            # after the first {{...}}" behavior.
+            fixes_applied.append(
+                f"AI prompt: variable '{inner}' referenced more than once with "
+                f"{{{{ }}}} — stripped braces on the duplicate (API allows each "
+                f"variable inside {{{{ }}}} only once)"
+            )
+            return inner
+        seen.add(inner)
+        return m.group(0)
+
+    fixed_text = _AI_PROMPT_VAR_RE.sub(_dedupe, prompt_text)
+
+    ok = not errors
+    return {
+        "ok": ok,
+        "errors": errors,
+        "warnings": warnings,
+        "fixes_applied": fixes_applied,
+        "fixed_text": fixed_text,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI driver (appended by scripts/_extract_prompts.py — not part of the backend
+# module). Runs every library-tier linter above over an <output_dir> bundle.
+# ---------------------------------------------------------------------------
+
+import json as _cli_json
+import re as _cli_re
+import sys as _cli_sys
+from pathlib import Path as _CliPath
+
+
+def _cli_assets_root(output_dir):
+    """Newest ``assets/vN`` directory, falling back to a flat ``assets/``."""
+    base = output_dir / "assets"
+    versioned = sorted(
+        (d for d in base.glob("v*") if d.is_dir() and _cli_re.fullmatch(r"v\d+", d.name)),
+        key=lambda d: int(d.name[1:]),
+    )
+    return versioned[-1] if versioned else base
+
+
+def _cli_run(output_dir, apply_fixes):
+    """Return (report, error_count, pending_fix_count)."""
+    assets = _cli_assets_root(output_dir)
+    report = []
+    errors = 0
+    pending = 0
+
+    def add(path, kind, errs, warns, fixes, fixed_text=None, target=None):
+        nonlocal errors, pending
+        errs = [str(e) for e in (errs or [])]
+        warns = [str(w) for w in (warns or [])]
+        fixes = [str(f) for f in (fixes or [])]
+        if not (errs or warns or fixes):
+            return          # clean file: stay quiet rather than print a bare header
+        errors += len(errs)
+        if fixes:
+            if apply_fixes and fixed_text is not None:
+                (target or path).write_text(fixed_text)
+            else:
+                pending += len(fixes)
+        report.append({"file": str(path), "linter": kind, "errors": errs,
+                       "warnings": warns, "fixes_applied": fixes,
+                       "written": bool(fixes and apply_fixes and fixed_text is not None)})
+
+    # ---- Lambda handlers: Python syntax + BUSINESS_OUTCOME_200 status codes ----
+    lam_dir = assets / "lambda"
+    if lam_dir.is_dir():
+        for p in sorted(lam_dir.rglob("*.py")):
+            code = p.read_text()
+            syn = lint_python_source(code)
+            if not syn["ok"]:
+                add(p, "python_syntax",
+                    [f"line {e.get('line')}: {e.get('message')}" for e in syn["errors"]],
+                    [], [])
+                continue    # a file that doesn't compile can't be status-linted
+            status = lint_lambda_status_codes(code)
+            if status["fixes_applied"] or status["warnings"]:
+                add(p, "lambda_status_codes", [], status["warnings"],
+                    status["fixes_applied"], status["fixed_code"])
+
+    # ---- CloudFormation ----
+    infra_dir = assets / "infrastructure"
+    if infra_dir.is_dir():
+        for p in sorted(infra_dir.glob("*.y*ml")):
+            res = lint_and_autofix_cfn(p.read_text())
+            if not res["available"]:
+                report.append({"file": str(p), "linter": "cloudformation",
+                               "errors": [], "warnings": [
+                                   "cfn-lint not installed — autofixes applied but the "
+                                   "template was NOT validated (pip install cfn-lint)"],
+                               "fixes_applied": res["fixes_applied"], "written": False})
+                continue
+            add(p, "cloudformation",
+                [f"{e.get('id')}@L{e.get('line')}: {e.get('message')}" for e in res["errors"]],
+                [f"{w.get('id')}@L{w.get('line')}: {w.get('message')}" for w in res["warnings"]],
+                res["fixes_applied"], res["fixed_yaml"])
+
+    # ---- OpenAPI ----
+    oapi_dir = assets / "openapi"
+    if oapi_dir.is_dir():
+        for p in sorted(oapi_dir.glob("*.y*ml")):
+            res = lint_and_autofix_openapi(p.read_text())
+            warns = [] if res["available"] else [
+                "openapi-spec-validator not installed — autofixes applied but the "
+                "document was NOT validated (pip install openapi-spec-validator)"]
+            add(p, "openapi", res["errors"], warns,
+                res["fixes_applied"], res["fixed_yaml"])
+
+    # ---- Contact Flow ----
+    cf_dir = assets / "contact_flow"
+    if cf_dir.is_dir():
+        for p in sorted(cf_dir.rglob("*.json")):
+            res = lint_contact_flow(p.read_text())
+            add(p, "contact_flow", res["errors"], res["warnings"],
+                res["fixes_applied"], res.get("fixed_json"))
+
+    # ---- AI prompt (qconnect variable-once rule) ----
+    pr_dir = assets / "prompt"
+    if pr_dir.is_dir():
+        for p in sorted(pr_dir.rglob("*")):
+            if p.suffix.lower() not in (".yaml", ".yml", ".md", ".txt") or not p.is_file():
+                continue
+            res = lint_ai_prompt(p.read_text())
+            if res["errors"] or res["fixes_applied"] or res["warnings"]:
+                add(p, "ai_prompt", res["errors"], res["warnings"],
+                    res["fixes_applied"], res.get("fixed_text"))
+
+    return report, errors, pending
+
+
+def _cli_main():
+    argv = _cli_sys.argv[1:]
+    flags = {a for a in argv if a.startswith("-")}
+    args = [a for a in argv if not a.startswith("-")]
+    unknown = flags - {"--fix", "--json"}
+    if len(args) != 1 or unknown:
+        print(f"Usage: {_cli_sys.argv[0]} <output_dir> [--fix] [--json]\n"
+              f"  --fix   write the deterministic auto-fixes back to the files\n"
+              f"  --json  machine-readable report on stdout",
+              file=_cli_sys.stderr)
+        return 2
+    out_dir = _CliPath(args[0]).resolve()
+    if not out_dir.is_dir():
+        print(f"ERROR: not a directory: {out_dir}", file=_cli_sys.stderr)
+        return 2
+
+    apply_fixes = "--fix" in flags
+    report, errors, pending = _cli_run(out_dir, apply_fixes)
+
+    if "--json" in flags:
+        print(_cli_json.dumps({"success": errors == 0 and pending == 0,
+                               "errors": errors, "pending_fixes": pending,
+                               "results": report}, indent=2, ensure_ascii=False))
+        return 0 if (errors == 0 and pending == 0) else 1
+
+    if not report:
+        print(f"OK — nothing to lint under {_cli_assets_root(out_dir)}")
+        return 0
+    for r in report:
+        head = f"{r['linter']}: {r['file']}"
+        print(head)
+        for e in r["errors"]:
+            print(f"  ERROR   {e}")
+        for w in r["warnings"]:
+            print(f"  WARN    {w}")
+        for f in r["fixes_applied"]:
+            print(f"  {'FIXED  ' if r['written'] else 'NEEDS FIX'} {f}")
+    print("")
+    if errors == 0 and pending == 0:
+        print("OK — no blocking lint findings"
+              + (" (auto-fixes written)" if apply_fixes else ""))
+        return 0
+    print(f"FAIL — {errors} error(s), {pending} pending auto-fix(es).")
+    if pending and not apply_fixes:
+        print("Re-run with --fix to apply the deterministic fixes, then re-lint.")
+    return 1
+
+
+if __name__ == "__main__":
+    _cli_sys.exit(_cli_main())

--- a/skills/aicc-builder-skill/resources/scripts/shape_parity.py
+++ b/skills/aicc-builder-skill/resources/scripts/shape_parity.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""Deterministic spec ↔ OpenAPI shape parity validator (Phase 7 HARD GATE).
+
+Ported verbatim from backend/ecs/src/tools/shape_parity.py, with a CLI wrapper
+that reads the skill's on-disk layout instead of the in-memory spec bucket:
+
+    <output_dir>/state/specs/*.json   ×   <output_dir>/assets/v1/openapi/openapi.yaml
+
+Given an OperationSpec (or its model_dump()) and a parsed OpenAPI document,
+walks every input_field / output_field (including nested items / properties and
+multi-tool inputs/outputs) and compares to the corresponding OpenAPI schema
+nodes. Reports every mismatch as a structured record.
+
+## Why this is exhaustive
+
+Both sides are **declarative** data structures:
+  - spec side: FieldSpec trees — finite, named, typed, with declared
+    `items` / `properties` / `enum_values`.
+  - OpenAPI side: schema objects — finite, with `type` / `items` /
+    `properties` / `enum` / `$ref`.
+
+There is no runtime execution to analyze. Every path in the spec has a
+corresponding path in the OpenAPI doc (or the absence is itself a reportable
+mismatch). The comparison function walks both trees in lockstep with:
+  - explicit type-mapping table (spec.field_type → openapi.type),
+  - $ref resolution bounded to the same document,
+  - explicit refusal of constructs the validator does not understand
+    (oneOf / anyOf / allOf / external $ref) — mismatches rather than silent
+    passes,
+  - cycle detection via visited set.
+
+This module intentionally does NOT validate Lambda code. AST analysis of Python
+return statements cannot enumerate every code path (conditional returns, dynamic
+dicts, external API passthrough). Lambda shape fidelity is covered by golden
+rule 16 (LAMBDA_NESTED_RESPONSE_RULE) in resources/sub-agents/_shared_rules.md,
+and the field-level checks in validate_consistency.py.
+
+Usage:
+    python shape_parity.py <output_dir>
+    python shape_parity.py <output_dir> --json
+
+Exit 0 = parity holds. Exit 1 = mismatches. Exit 2 = usage/parse error, or the
+OpenAPI document uses a construct the validator refuses to reason about.
+Requires: PyYAML (pip install pyyaml) — only for the CLI, not the comparison.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Any, Optional
+
+
+# Map spec `field_type` values → the OpenAPI `type` keyword(s) that satisfy them.
+# `enum` is special: satisfied by any OpenAPI node that has an `enum:` keyword
+# regardless of the underlying type (typically `string`).
+_SPEC_TO_OPENAPI_TYPE: dict[str, set[str]] = {
+    "string":   {"string"},
+    "number":   {"number"},
+    "integer":  {"integer", "number"},  # accept either — ints are numbers
+    "boolean":  {"boolean"},
+    "date":     {"string"},
+    "datetime": {"string"},
+    "email":    {"string"},
+    "phone":    {"string"},
+    "enum":     {"string", "integer", "number", "boolean"},  # any scalar + enum keyword
+    "array":    {"array"},
+    "object":   {"object"},
+}
+
+
+@dataclass(frozen=True)
+class ShapeMismatch:
+    """One mismatch between spec and OpenAPI."""
+    path: str          # dotted path from the operation root, e.g. "get_machine_info.output_fields.machineStatus.items.properties.state"
+    reason: str        # short code, e.g. "type_mismatch", "missing_in_openapi", "enum_values_differ"
+    expected: Any      # what the spec declared
+    actual: Any        # what the OpenAPI schema had (or None if missing)
+    detail: str = ""   # human-readable explanation
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+class ShapeParityError(Exception):
+    """Raised for constructs the validator refuses to reason about.
+
+    The validator must not silently pass over constructs it does not fully
+    understand (oneOf / anyOf / allOf / external $ref). Raise so the caller
+    knows the generated OpenAPI uses shapes this validator cannot compare
+    exhaustively.
+    """
+
+
+def _pick_field(d: dict, *keys: str, default: Any = None) -> Any:
+    """Return the first present value among aliases."""
+    for k in keys:
+        if k in d and d[k] is not None:
+            return d[k]
+    return default
+
+
+def _get_enum(field: dict) -> Optional[list]:
+    return _pick_field(field, "enum_values", "enum", "allowed_values", "options")
+
+
+def _get_items(field: dict) -> Optional[dict]:
+    return _pick_field(field, "items", "item", "element", "elementType")
+
+
+def _get_properties(field: dict) -> Optional[list]:
+    """FieldSpec `properties` is a LIST of sub-FieldSpec (not a dict)."""
+    return _pick_field(field, "properties", "sub_fields", "subFields", "fields")
+
+
+def _get_field_type(field: dict) -> str:
+    t = _pick_field(field, "field_type", "type")
+    return (t or "string").lower()
+
+
+def _resolve_ref(doc: dict, ref: str, seen: set) -> dict:
+    """Resolve `#/components/schemas/X` within the same document."""
+    if not ref.startswith("#/"):
+        raise ShapeParityError(
+            f"External $ref not supported by shape validator: {ref!r}. "
+            "Extract the referenced schema into components/schemas of the same document."
+        )
+    if ref in seen:
+        # Cycle — treat as satisfied at the cycle boundary (the first occurrence did the work).
+        return {}
+    seen = seen | {ref}
+    parts = ref.lstrip("#/").split("/")
+    node: Any = doc
+    for p in parts:
+        if not isinstance(node, dict) or p not in node:
+            raise ShapeParityError(f"Unresolvable $ref {ref!r}: segment {p!r} missing.")
+        node = node[p]
+    if not isinstance(node, dict):
+        raise ShapeParityError(f"$ref {ref!r} does not resolve to a schema object.")
+    return node
+
+
+def _follow_ref(schema: dict, doc: dict, seen: set) -> dict:
+    """If `schema` is a $ref, resolve it once; otherwise return as-is."""
+    if not isinstance(schema, dict):
+        raise ShapeParityError(f"Expected OpenAPI schema object, got {type(schema).__name__}: {schema!r}")
+    ref = schema.get("$ref")
+    if ref:
+        return _resolve_ref(doc, ref, seen)
+    return schema
+
+
+def _reject_composition(schema: dict, path: str) -> None:
+    """Refuse oneOf / anyOf / allOf — validator cannot exhaustively compare these."""
+    for kw in ("oneOf", "anyOf", "allOf"):
+        if kw in schema:
+            raise ShapeParityError(
+                f"OpenAPI schema at {path} uses `{kw}` — the shape validator cannot "
+                "compare composition keywords exhaustively. Generate a single concrete "
+                "schema instead, or extend the validator."
+            )
+
+
+def _compare(field: dict, schema: dict, path: str, doc: dict, seen: set, out: list) -> None:
+    """Recursively compare one FieldSpec dict to one OpenAPI schema."""
+    schema = _follow_ref(schema, doc, seen)
+    _reject_composition(schema, path)
+
+    spec_type = _get_field_type(field)
+    openapi_type = schema.get("type")
+
+    # Special case: spec says "enum" → any scalar OpenAPI type with an `enum` keyword is OK.
+    if spec_type == "enum":
+        if "enum" not in schema:
+            out.append(ShapeMismatch(
+                path=path, reason="missing_enum_in_openapi",
+                expected={"enum_values": _get_enum(field)}, actual=schema,
+                detail="Spec declared field_type='enum' but OpenAPI schema has no `enum:` keyword.",
+            ))
+    else:
+        expected_openapi_types = _SPEC_TO_OPENAPI_TYPE.get(spec_type, {"string"})
+        if openapi_type is None:
+            # OpenAPI allows omitting `type` in some contexts; only tolerate if it's clearly a ref we already followed.
+            out.append(ShapeMismatch(
+                path=path, reason="missing_type_in_openapi",
+                expected=spec_type, actual=None,
+                detail=f"OpenAPI schema has no `type`. Spec field_type={spec_type!r}.",
+            ))
+        elif openapi_type not in expected_openapi_types:
+            out.append(ShapeMismatch(
+                path=path, reason="type_mismatch",
+                expected=spec_type, actual=openapi_type,
+                detail=f"Spec field_type={spec_type!r} does not map to OpenAPI type={openapi_type!r} "
+                       f"(allowed: {sorted(expected_openapi_types)}).",
+            ))
+
+    # Enum values — compare verbatim including order.
+    spec_enum = _get_enum(field)
+    openapi_enum = schema.get("enum")
+    if spec_enum is not None:
+        if openapi_enum is None:
+            out.append(ShapeMismatch(
+                path=path, reason="enum_missing_in_openapi",
+                expected=spec_enum, actual=None,
+                detail="Spec has enum_values but OpenAPI schema has no `enum:`.",
+            ))
+        elif list(openapi_enum) != list(spec_enum):
+            out.append(ShapeMismatch(
+                path=path, reason="enum_values_differ",
+                expected=spec_enum, actual=list(openapi_enum),
+                detail="OpenAPI `enum` differs from spec enum_values (order / casing / set).",
+            ))
+
+    # Array: descend into items.
+    spec_items = _get_items(field)
+    if spec_type == "array":
+        if spec_items is None:
+            # Spec itself is under-specified — rule 13 forbids bare type=array without items.
+            out.append(ShapeMismatch(
+                path=path, reason="spec_array_missing_items",
+                expected="items FieldSpec", actual=None,
+                detail="Spec declares field_type='array' but has no `items`. Populate during interview.",
+            ))
+        else:
+            openapi_items = schema.get("items")
+            if openapi_items is None:
+                out.append(ShapeMismatch(
+                    path=path + ".items", reason="items_missing_in_openapi",
+                    expected=spec_items, actual=None,
+                    detail="Spec has `items` but OpenAPI schema has no `items:` block.",
+                ))
+            else:
+                # Give the items a synthetic name if FieldSpec didn't supply one
+                items_field = dict(spec_items)
+                items_field.setdefault("name", "items")
+                _compare(items_field, openapi_items, path + ".items", doc, seen, out)
+
+    # Object: descend into properties.
+    spec_props = _get_properties(field)
+    if spec_type == "object":
+        if spec_props is None:
+            out.append(ShapeMismatch(
+                path=path, reason="spec_object_missing_properties",
+                expected="properties FieldSpec list", actual=None,
+                detail="Spec declares field_type='object' but has no `properties`. Populate during interview.",
+            ))
+        else:
+            openapi_props = schema.get("properties") or {}
+            spec_prop_names = {p.get("name") for p in spec_props if p.get("name")}
+            openapi_prop_names = set(openapi_props.keys())
+
+            missing = spec_prop_names - openapi_prop_names
+            for name in sorted(missing):
+                out.append(ShapeMismatch(
+                    path=path + f".properties.{name}", reason="property_missing_in_openapi",
+                    expected=name, actual=None,
+                    detail=f"Spec declares property {name!r}; OpenAPI `properties` does not contain it.",
+                ))
+
+            extra = openapi_prop_names - spec_prop_names
+            for name in sorted(extra):
+                out.append(ShapeMismatch(
+                    path=path + f".properties.{name}", reason="property_extra_in_openapi",
+                    expected=None, actual=name,
+                    detail=f"OpenAPI has property {name!r} not declared by the spec.",
+                ))
+
+            for p in spec_props:
+                pname = p.get("name")
+                if pname and pname in openapi_props:
+                    _compare(p, openapi_props[pname], path + f".properties.{pname}", doc, seen, out)
+
+
+def _find_operation_schemas(openapi_doc: dict, op_id: str, method: str, op_path: str) -> tuple[Optional[dict], Optional[dict]]:
+    """Locate (request schema, 200 response schema) for a given operation.
+
+    Lookup is by path+method first, falling back to operationId match (more
+    forgiving for generators that store op_id without the /tools/ prefix).
+    """
+    paths = openapi_doc.get("paths") or {}
+    method_lower = (method or "").lower()
+
+    op_node = None
+    # Try exact path + method
+    if op_path and op_path in paths:
+        op_node = (paths[op_path] or {}).get(method_lower)
+    # Fall back to operationId
+    if op_node is None:
+        for _path, methods in paths.items():
+            if not isinstance(methods, dict):
+                continue
+            for _m, node in methods.items():
+                if isinstance(node, dict) and node.get("operationId") == op_id:
+                    op_node = node
+                    break
+            if op_node:
+                break
+
+    if not op_node:
+        return None, None
+
+    # Request body schema
+    req_schema = None
+    rb = op_node.get("requestBody")
+    if isinstance(rb, dict):
+        content = rb.get("content") or {}
+        for _ct, entry in content.items():
+            if isinstance(entry, dict) and "schema" in entry:
+                req_schema = entry["schema"]
+                break
+
+    # 200 response schema
+    res_schema = None
+    responses = op_node.get("responses") or {}
+    for code in ("200", "201", 200, 201):
+        entry = responses.get(code)
+        if isinstance(entry, dict):
+            content = entry.get("content") or {}
+            for _ct, c_entry in content.items():
+                if isinstance(c_entry, dict) and "schema" in c_entry:
+                    res_schema = c_entry["schema"]
+                    break
+            if res_schema:
+                break
+
+    return req_schema, res_schema
+
+
+def _fields_to_synthetic_object(fields: list, object_name: str) -> dict:
+    """Wrap a flat list of FieldSpec dicts into a synthetic object FieldSpec.
+
+    This lets `_compare` treat a request body (input_fields) / response body
+    (output_fields) as if it were an object FieldSpec — matching how OpenAPI
+    declares request/response schemas as objects whose `properties` are the
+    top-level fields.
+    """
+    return {
+        "name": object_name,
+        "field_type": "object",
+        "properties": fields or [],
+    }
+
+
+def validate_shape_parity(spec: dict, openapi_doc: dict) -> list[ShapeMismatch]:
+    """Compare one OperationSpec dict to an OpenAPI document.
+
+    Args:
+        spec: OperationSpec dict (state/specs/<operation_id>.json contents).
+              Must include operation_id, http_method, path, input_fields,
+              output_fields, and optionally `tools[]`.
+        openapi_doc: Parsed OpenAPI document (yaml.safe_load'd or json.loads'd).
+
+    Returns:
+        List of ShapeMismatch records. Empty = parity holds.
+
+    Raises:
+        ShapeParityError: when the OpenAPI document uses constructs the
+            validator refuses to silently reason about (oneOf / anyOf /
+            allOf / external $ref / unresolvable refs).
+    """
+    mismatches: list[ShapeMismatch] = []
+
+    op_id = spec.get("operation_id") or spec.get("tool_id") or ""
+    method = spec.get("http_method") or "POST"
+    op_path = spec.get("path") or (f"/tools/{op_id}" if op_id else "")
+
+    def _compare_bundle(owner_label: str, in_fields: list, out_fields: list, _op_id: str, _method: str, _path: str) -> None:
+        req_schema, res_schema = _find_operation_schemas(openapi_doc, _op_id, _method, _path)
+        if req_schema is None and (in_fields or []):
+            mismatches.append(ShapeMismatch(
+                path=f"{owner_label}.requestBody", reason="operation_missing_in_openapi",
+                expected={"operation_id": _op_id, "method": _method, "path": _path},
+                actual=None,
+                detail="Spec declares operation but OpenAPI has no matching path+method or operationId.",
+            ))
+        elif in_fields:
+            synthetic = _fields_to_synthetic_object(in_fields, f"{owner_label}.requestBody")
+            _compare(synthetic, req_schema, f"{owner_label}.requestBody", openapi_doc, set(), mismatches)
+        if res_schema is None and (out_fields or []):
+            mismatches.append(ShapeMismatch(
+                path=f"{owner_label}.response", reason="response_missing_in_openapi",
+                expected="200 response schema", actual=None,
+                detail="Spec has output_fields but OpenAPI has no 200/201 response schema.",
+            ))
+        elif out_fields:
+            synthetic = _fields_to_synthetic_object(out_fields, f"{owner_label}.response")
+            _compare(synthetic, res_schema, f"{owner_label}.response", openapi_doc, set(), mismatches)
+
+    # Compare operation-level input/output fields (when no tools[] drives them).
+    tools = spec.get("tools") or []
+    if not tools:
+        _compare_bundle(
+            owner_label=op_id or "<anonymous>",
+            in_fields=spec.get("input_fields") or [],
+            out_fields=spec.get("output_fields") or [],
+            _op_id=op_id, _method=method, _path=op_path,
+        )
+    else:
+        for t in tools:
+            t_id = t.get("tool_id") or ""
+            t_method = t.get("http_method") or method
+            t_path = t.get("path") or (f"/tools/{t_id}" if t_id else op_path)
+            _compare_bundle(
+                owner_label=t_id or op_id,
+                in_fields=t.get("input_fields") or [],
+                out_fields=t.get("output_fields") or [],
+                _op_id=t_id, _method=t_method, _path=t_path,
+            )
+
+    return mismatches
+
+
+def format_mismatches(mismatches: list[ShapeMismatch]) -> str:
+    """Human-readable summary for injection into reviewer output."""
+    if not mismatches:
+        return "No shape parity violations."
+    lines = [f"Found {len(mismatches)} shape parity violation(s):"]
+    for m in mismatches:
+        lines.append(f"  - [{m.reason}] {m.path}")
+        if m.detail:
+            lines.append(f"      {m.detail}")
+        if m.expected is not None:
+            lines.append(f"      expected: {m.expected!r}")
+        if m.actual is not None:
+            lines.append(f"      actual:   {m.actual!r}")
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------
+# CLI — reads the skill's on-disk layout
+# --------------------------------------------------------------------------
+
+def _assets_root(output_dir: Path) -> Path:
+    """Newest ``assets/vN`` directory, falling back to a flat ``assets/``."""
+    base = output_dir / "assets"
+    versioned = sorted(
+        (d for d in base.glob("v*") if d.is_dir() and re.fullmatch(r"v\d+", d.name)),
+        key=lambda d: int(d.name[1:]),
+    )
+    return versioned[-1] if versioned else base
+
+
+def _load_openapi_doc(assets_dir: Path) -> Optional[dict]:
+    try:
+        import yaml
+    except ImportError:
+        print("ERROR: PyYAML required. Install with: pip install pyyaml", file=sys.stderr)
+        return None
+    oapi_dir = assets_dir / "openapi"
+    if not oapi_dir.is_dir():
+        return None
+    for p in sorted(oapi_dir.glob("*.y*ml")) + sorted(oapi_dir.glob("*.json")):
+        try:
+            return yaml.safe_load(p.read_text())   # safe_load also parses JSON
+        except Exception as e:
+            print(f"WARN: failed to parse {p}: {e}", file=sys.stderr)
+    return None
+
+
+def main() -> int:
+    args = [a for a in sys.argv[1:] if not a.startswith("-")]
+    as_json = "--json" in sys.argv[1:]
+    if len(args) != 1:
+        print(f"Usage: {sys.argv[0]} <output_dir> [--json]", file=sys.stderr)
+        return 2
+    out_dir = Path(args[0]).resolve()
+    if not out_dir.is_dir():
+        print(f"ERROR: not a directory: {out_dir}", file=sys.stderr)
+        return 2
+
+    specs_dir = out_dir / "state" / "specs"
+    if not specs_dir.is_dir():
+        print(f"ERROR: no specs at {specs_dir} — nothing to compare.", file=sys.stderr)
+        return 2
+
+    doc = _load_openapi_doc(_assets_root(out_dir))
+    if not isinstance(doc, dict):
+        print(f"ERROR: no parsable OpenAPI document under "
+              f"{_assets_root(out_dir) / 'openapi'}", file=sys.stderr)
+        return 2
+
+    all_mismatches: list[dict] = []
+    for p in sorted(specs_dir.glob("*.json")):
+        try:
+            spec = json.loads(p.read_text())
+        except Exception as e:
+            print(f"WARN: failed to parse {p}: {e}", file=sys.stderr)
+            continue
+        try:
+            found = validate_shape_parity(spec, doc)
+        except ShapeParityError as e:
+            print(f"REFUSED ({p.name}): {e}", file=sys.stderr)
+            return 2
+        all_mismatches.extend(m.to_dict() for m in found)
+
+    if as_json:
+        print(json.dumps({"success": not all_mismatches,
+                          "mismatches": all_mismatches}, indent=2))
+        return 1 if all_mismatches else 0
+
+    if not all_mismatches:
+        print(f"OK — spec ↔ OpenAPI shape parity holds for {out_dir}")
+        return 0
+    print(format_mismatches([ShapeMismatch(**m) for m in all_mismatches]))
+    print("\nHARD GATE: fix every violation before the review gate passes. Patch the "
+          "OpenAPI schema (or the spec, if the spec is what is wrong) — do not "
+          "regenerate from the chat log.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/aicc-builder-skill/resources/scripts/validate_consistency.py
+++ b/skills/aicc-builder-skill/resources/scripts/validate_consistency.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """Cross-asset consistency validator for AICC Builder skill output.
 
-Rewritten from backend/ecs/src/tools/validate_consistency.py to operate on a
-LOCAL output directory instead of S3, and to load specs from JSON files on
-disk instead of the in-memory spec_manager bucket.
+Ported from backend/ecs/src/tools/validate_consistency.py to operate on a LOCAL
+output directory instead of S3, and to load specs from JSON files on disk
+instead of the in-memory spec_manager bucket. The checks — and the failure modes
+they were each written for — are the same ones the webapp runs after every
+generation phase.
 
 Directory layout expected (matches what the skill instructs Claude to write):
 
@@ -13,19 +15,48 @@ Directory layout expected (matches what the skill instructs Claude to write):
           <operation_id>.json    # one file per OperationSpec
         infrastructure_schema.json
         session_flow_config.json
-      assets/
+      assets/v1/                 # plain assets/ is also accepted
         lambda/<tool_id>/index.py        # (handler.py also accepted)
         openapi/openapi.yaml
         infrastructure/template.yaml
 
+Checks (check id → what it catches):
+
+  spec ↔ generated asset
+    lambda_input                 spec input field never read by the handler
+    lambda_output                spec output field absent from the response body
+    lambda_tool                  ToolSpec input field never read by its handler
+    openapi_input/openapi_output spec field missing from the OpenAPI schema
+    infra_pk                     spec primary_key is not a key on the infra table
+    lambda_gsi                   IndexName= that is not a GSI in the schema
+    lambda_env                   *_TABLE_NAME env var the schema never defines
+    response_structure           `data` wrapper present on one side only
+    count_lambda/count_openapi   fewer handlers/paths than specs (or tools)
+
+  IAM (D2)
+    iam_permissions              handler calls an AWS API its CFN role never grants
+
+  RDS Data API contract (D3)
+    rds_env_contract             DB_CLUSTER_ARN/DB_SECRET_ARN/DB_NAME drift
+    rds_data_api                 missing includeResultMetadata, positional row
+                                 access, SQL built by interpolation
+
+  SQL vs the database schema (D4/D5)
+    sql_schema_mismatch          column that the resolved table does not have
+    sql_type_mismatch            ::cast to a type the schema never defines
+    sql_missing_required_column  INSERT omits a NOT NULL column with no default
+    sql_param_type_mismatch      :param bound with the wrong Data API value key
+
 Usage:
     python validate_consistency.py <output_dir>
+    python validate_consistency.py <output_dir> --json
 
 Exits 0 if consistent, 1 if mismatches found. Prints a human-readable report.
 Requires: PyYAML (pip install pyyaml).
 """
 from __future__ import annotations
 
+import ast
 import json
 import re
 import sys
@@ -98,6 +129,20 @@ def collect_tools(specs: Dict[str, dict]) -> Dict[str, dict]:
 # Asset extraction
 # --------------------------------------------------------------------------
 
+def assets_root(output_dir: Path) -> Path:
+    """Resolve the asset root, preferring the newest ``assets/vN`` directory.
+
+    The skill writes ``assets/v1/`` (and ``assets/v2/`` on regeneration) to match
+    the webapp; a flat ``assets/`` tree is still accepted.
+    """
+    base = output_dir / "assets"
+    versioned = sorted(
+        (d for d in base.glob("v*") if d.is_dir() and re.fullmatch(r"v\d+", d.name)),
+        key=lambda d: int(d.name[1:]),
+    )
+    return versioned[-1] if versioned else base
+
+
 def _extract_lambda_fields(code: str) -> Set[str]:
     patterns = [
         r"""(?:body|event|params|data)\.get\(\s*['\"](\w+)['\"]""",
@@ -109,29 +154,51 @@ def _extract_lambda_fields(code: str) -> Set[str]:
     return fields
 
 
-def load_lambda_code(assets_dir: Path) -> Dict[str, str]:
-    """tool_id -> Lambda handler contents.
+# Lambdas that are bundled/flow-invoked rather than spec-driven API tools. They
+# still take part in the IAM and SQL checks (the webapp's lambda_all_code), just
+# not in the spec field comparison.
+SUPPORTING_LAMBDAS = {"update_q_session", "customer_lookup"}
+
+
+def load_lambda_code(assets_dir: Path) -> Dict[str, Dict[str, str]]:
+    """Return {"spec": {tool_id: code}, "all": {tool_id: code}}.
 
     Accepts both the backend-canonical ``lambda/<tool_id>/index.py`` and the
-    legacy ``lambda/<tool_id>/handler.py`` layout. The fixed Node.js Lambdas
-    (``update_q_session``) and the flow-invoked ``customer_lookup`` have no
-    OperationSpec to validate against, so they are skipped.
+    legacy ``lambda/<tool_id>/handler.py`` layout, plus ``index.js`` for the
+    fixed Node.js Lambdas (IAM check only).
     """
     lam_dir = assets_dir / "lambda"
     if not lam_dir.is_dir():
-        return {}
-    # Lambdas that are bundled/flow-invoked rather than spec-driven API tools.
-    skip_dirs = {"update_q_session", "customer_lookup"}
-    out: Dict[str, str] = {}
-    for fname in ("index.py", "handler.py"):
-        for handler in lam_dir.rglob(fname):
+        return {"spec": {}, "all": {}}
+    spec_code: Dict[str, str] = {}
+    all_code: Dict[str, str] = {}
+    for fname in ("index.py", "handler.py", "index.js"):
+        for handler in sorted(lam_dir.rglob(fname)):
             rel = handler.relative_to(lam_dir)
             op_id = rel.parts[0] if rel.parts else handler.stem
-            if op_id in skip_dirs:
+            try:
+                content = handler.read_text()
+            except Exception as e:
+                print(f"WARN: failed to read {handler}: {e}", file=sys.stderr)
                 continue
-            # index.py wins if both exist for the same tool.
-            out.setdefault(op_id, handler.read_text())
-    return out
+            all_code.setdefault(op_id, content)
+            if op_id not in SUPPORTING_LAMBDAS and fname != "index.js":
+                # index.py wins if both exist for the same tool.
+                spec_code.setdefault(op_id, content)
+    return {"spec": spec_code, "all": all_code}
+
+
+def load_infra_template(assets_dir: Path) -> Optional[str]:
+    """Raw text of the CloudFormation template (needed for the IAM/env checks)."""
+    infra_dir = assets_dir / "infrastructure"
+    if not infra_dir.is_dir():
+        return None
+    for p in sorted(infra_dir.glob("*.y*ml")):
+        try:
+            return p.read_text()
+        except Exception as e:
+            print(f"WARN: failed to read {p}: {e}", file=sys.stderr)
+    return None
 
 
 def _resolve_ref(spec: dict, ref: str) -> dict:
@@ -186,15 +253,815 @@ def load_openapi(assets_dir: Path) -> Dict[str, Dict[str, Set[str]]]:
 
 
 # --------------------------------------------------------------------------
+# D2: Lambda IAM permission check
+#
+# Root cause this guards against (live workshop QA): a generated Lambda calls an
+# AWS API at runtime (e.g. update_q_session calling connect:DescribeContact +
+# wisdom:UpdateSessionData) but the CFN role for that function only carries
+# AWSLambdaBasicExecutionRole → AccessDeniedException mid-call.
+# --------------------------------------------------------------------------
+
+# boto3/aws-sdk service name → IAM action prefix (only where they differ)
+_IAM_PREFIX_OVERRIDES = {
+    "qconnect": "wisdom",   # qconnect: is NOT a real IAM namespace
+    "wisdom": "wisdom",
+    "sesv2": "ses",
+    "ses": "ses",
+}
+
+# JS v3 client class name → IAM service prefix
+_JS_CLIENT_PREFIXES = {
+    "QConnectClient": "wisdom",
+    "ConnectClient": "connect",
+    "DynamoDBClient": "dynamodb",
+    "DynamoDBDocumentClient": "dynamodb",
+    "S3Client": "s3",
+    "LambdaClient": "lambda",
+    "SNSClient": "sns",
+    "SQSClient": "sqs",
+    "SESv2Client": "ses",
+    "SESClient": "ses",
+    "SecretsManagerClient": "secretsmanager",
+    "RDSDataClient": "rds-data",
+    "BedrockRuntimeClient": "bedrock",
+    "PinpointClient": "mobiletargeting",
+}
+
+# Actions implicitly granted (basic execution role) — never reported
+_IMPLICITLY_GRANTED = {"logs:CreateLogGroup", "logs:CreateLogStream", "logs:PutLogEvents"}
+
+
+def _snake_to_pascal(name: str) -> str:
+    return "".join(w.capitalize() for w in name.split("_"))
+
+
+def _extract_required_iam_actions(code: str) -> Set[str]:
+    """Derive IAM actions a Lambda handler needs from its AWS SDK calls.
+
+    Handles Python boto3 (client/resource method calls) and JS SDK v3
+    (``new XClient`` + ``XCommand``). Best-effort static analysis: unknown
+    services fall back to using the SDK service name as the IAM prefix.
+    """
+    required: Set[str] = set()
+
+    # ---- Python: boto3.client("svc") / boto3.resource("svc") ----
+    var_to_svc: Dict[str, str] = {}
+    for m in re.finditer(
+            r'(\w+)\s*=\s*boto3\.(?:client|resource)\(\s*[\'"]([\w-]+)[\'"]', code):
+        var_to_svc[m.group(1)] = m.group(2)
+    for var, svc in var_to_svc.items():
+        prefix = _IAM_PREFIX_OVERRIDES.get(svc, svc)
+        for cm in re.finditer(rf'\b{re.escape(var)}\.([a-z_]+)\(', code):
+            method = cm.group(1)
+            if method in ("close", "get_paginator", "get_waiter", "Table", "meta"):
+                continue
+            required.add(f"{prefix}:{_snake_to_pascal(method)}")
+    # boto3 dynamodb resource Table(...) usage
+    if re.search(r'boto3\.resource\(\s*[\'"]dynamodb[\'"]', code):
+        for cm in re.finditer(r'\btable\.([a-z_]+)\(', code, re.IGNORECASE):
+            method = cm.group(1)
+            if method in ("close",):
+                continue
+            required.add(f"dynamodb:{_snake_to_pascal(method)}")
+
+    # ---- JS SDK v3: new XClient(...) + new YCommand(...) via .send() ----
+    js_prefixes = {_JS_CLIENT_PREFIXES[c] for c in _JS_CLIENT_PREFIXES if c in code}
+    if js_prefixes:
+        commands = set(re.findall(r'new\s+(\w+)Command\(', code))
+        for cmd in commands:
+            if len(js_prefixes) == 1:
+                required.add(f"{next(iter(js_prefixes))}:{cmd}")
+                continue
+            # Several clients imported — attribute each command to the import
+            # block that names it.
+            for m in re.finditer(
+                    r'(?:const|import)\s*\{([^}]*)\}\s*'
+                    r'(?:=\s*require\([\'"]@aws-sdk/client-([\w-]+)[\'"]\)'
+                    r'|from\s+[\'"]@aws-sdk/client-([\w-]+)[\'"])',
+                    code):
+                names, pkg = m.group(1), (m.group(2) or m.group(3) or "")
+                if f"{cmd}Command" in names:
+                    svc = pkg.replace("qconnect", "wisdom")
+                    prefix = _IAM_PREFIX_OVERRIDES.get(svc, svc)
+                    required.add(f"{prefix}:{cmd}")
+                    break
+
+    return {a for a in required if a not in _IMPLICITLY_GRANTED}
+
+
+def _extract_role_actions_from_template(infra_yaml: str) -> Dict[str, Set[str]]:
+    """Map each Lambda function logical id to the IAM actions its role grants.
+
+    Best-effort YAML parse tolerant of CFN intrinsics (!Sub/!Ref/!GetAtt).
+    """
+    try:
+        sanitized = re.sub(
+            r'!(Sub|Ref|GetAtt|Join|If|ImportValue|Select|FindInMap)\b', '', infra_yaml)
+        doc = yaml.safe_load(sanitized) or {}
+    except Exception as e:
+        print(f"WARN: could not parse infrastructure template for IAM check: {e}",
+              file=sys.stderr)
+        return {}
+
+    resources = doc.get("Resources", {}) or {}
+
+    role_actions: Dict[str, Set[str]] = {}
+    for rid, res in resources.items():
+        if not isinstance(res, dict) or res.get("Type") != "AWS::IAM::Role":
+            continue
+        actions: Set[str] = set()
+        props = res.get("Properties", {}) or {}
+        for pol in (props.get("Policies") or []):
+            stmts = ((pol or {}).get("PolicyDocument") or {}).get("Statement") or []
+            for st in stmts:
+                if not isinstance(st, dict) or st.get("Effect") != "Allow":
+                    continue
+                acts = st.get("Action")
+                acts = acts if isinstance(acts, list) else [acts]
+                actions.update(a for a in acts if isinstance(a, str))
+        for mp in (props.get("ManagedPolicyArns") or []):
+            if isinstance(mp, str) and "AWSLambdaBasicExecutionRole" in mp:
+                actions.update(_IMPLICITLY_GRANTED)
+        role_actions[rid] = actions
+
+    fn_actions: Dict[str, Set[str]] = {}
+    for rid, res in resources.items():
+        if not isinstance(res, dict) or res.get("Type") != "AWS::Lambda::Function":
+            continue
+        props = res.get("Properties", {}) or {}
+        role_ref = props.get("Role")
+        role_id = ""
+        if isinstance(role_ref, str):
+            # sanitized "!GetAtt X.Arn" became " X.Arn"
+            role_id = role_ref.strip().split(".")[0]
+        elif isinstance(role_ref, dict):
+            ga = role_ref.get("Fn::GetAtt")
+            if isinstance(ga, list) and ga:
+                role_id = ga[0]
+            elif isinstance(ga, str):
+                role_id = ga.split(".")[0]
+        fn_actions[rid] = role_actions.get(role_id, set())
+    return fn_actions
+
+
+def _action_granted(action: str, granted: Set[str]) -> bool:
+    """True if *action* is covered by *granted*, honoring '*' wildcards."""
+    if action in granted:
+        return True
+    svc, _, op = action.partition(":")
+    for g in granted:
+        if g == "*":
+            return True
+        gsvc, _, gop = g.partition(":")
+        if gsvc != svc:
+            continue
+        if gop == "*" or (gop.endswith("*") and op.startswith(gop[:-1])):
+            return True
+    return False
+
+
+# --------------------------------------------------------------------------
+# D4: SQL identifiers vs the scanned/provided schema
+#
+# Only reports a column when the owning table is unambiguous — either the
+# reference is alias-qualified, or the statement touches exactly one known
+# table. Columns the schema summary simply omitted are ignored, so it cannot
+# false-positive on an incomplete column list.
+# --------------------------------------------------------------------------
+_SQL_KEYWORD_RE = re.compile(r'^\s*(SELECT|INSERT|UPDATE|DELETE|WITH)\b', re.I)
+# alias declarations:  FROM orders o  /  JOIN order_items AS oi
+_SQL_ALIAS_RE = re.compile(
+    r'\b(?:FROM|JOIN)\s+([A-Za-z_][\w]*)\s+(?:AS\s+)?([A-Za-z_][\w]*)\b', re.I)
+_SQL_QUALIFIED_RE = re.compile(r'\b([A-Za-z_][\w]*)\.([A-Za-z_][\w]*)\b')
+_SQL_RESERVED = {
+    "select", "insert", "update", "delete", "with", "from", "join", "inner",
+    "left", "right", "outer", "on", "where", "and", "or", "not", "null", "as",
+    "order", "by", "group", "having", "limit", "offset", "into", "values", "set",
+    "asc", "desc", "distinct", "case", "when", "then", "else", "end", "returning",
+    "union", "all", "exists", "in", "is", "like", "ilike", "between", "interval",
+    "coalesce", "count", "sum", "max", "min", "avg", "now", "cast",
+}
+
+
+def _string_consts(tree) -> Dict[str, str]:
+    consts: Dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant) \
+                and isinstance(node.value.value, str):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    consts[target.id] = node.value.value
+    return consts
+
+
+def _as_text(node, consts: Dict[str, str]) -> Optional[str]:
+    """Best-effort static text of a string expression (handles implicit concat)."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):   # f-string
+        parts = []
+        for value in node.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                parts.append(value.value)
+            elif isinstance(value, ast.FormattedValue) and \
+                    isinstance(value.value, ast.Name) and value.value.id in consts:
+                parts.append(consts[value.value.id])
+            else:
+                parts.append(" ")
+        return "".join(parts)
+    if isinstance(node, ast.Name):
+        return consts.get(node.id)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left, right = _as_text(node.left, consts), _as_text(node.right, consts)
+        if left is not None and right is not None:
+            return left + right
+    return None
+
+
+def _extract_sql_statements(code: str) -> List[str]:
+    """Pull SQL statements out of a generated Python handler.
+
+    Uses the AST rather than a regex so that implicit string concatenation
+    (``"SELECT a " "FROM t " "WHERE ..."`` split across lines — which is what
+    the generators actually emit) is seen as ONE statement. A regex sees each
+    fragment separately and never observes the FROM clause, so alias resolution
+    silently finds nothing.
+    """
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return []
+
+    consts = _string_consts(tree)
+    found: List[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            for arg in list(node.args) + [k.value for k in node.keywords if k.arg == "sql"]:
+                text = _as_text(arg, consts)
+                if text and _SQL_KEYWORD_RE.match(text):
+                    found.append(text)
+    for text in consts.values():
+        if _SQL_KEYWORD_RE.match(text) and text not in found:
+            found.append(text)
+    return found
+
+
+# --------------------------------------------------------------------------
+# D5: Data API parameter type-binding check
+#
+# Root cause this guards against (found in live E2E): the handler bound a BIGINT
+# key as a string —
+#     parameters=[{"name": "orderId", "value": {"stringValue": str(order_id)}}]
+# — and PostgreSQL rejected the query with
+#     operator does not exist: bigint = text  (SQLState 42883)
+# on the first invocation. MySQL silently coerces instead, which hides the bug
+# but throws away index usage on the compared column.
+# --------------------------------------------------------------------------
+_INT_TYPE_RE = re.compile(
+    r'^(small|big|tiny|medium)?(int|integer|serial)\d*(\s+unsigned)?$', re.I)
+_BOOL_TYPE_RE = re.compile(r'^(bool|boolean|bit|tinyint\(1\))$', re.I)
+_TEXT_TYPE_RE = re.compile(
+    r'^n?(var)?char(acter)?(\s+varying)?(\(\s*(\d+|max)\s*\))?$|'
+    r'^n?(tiny|medium|long)?text$', re.I)
+# columns where a stringValue binding is the correct Data API representation
+_STRING_OK_TYPE_RE = re.compile(
+    r'date|time|timestamp|uuid|json|xml|enum|set\(|numeric|decimal|money|'
+    r'interval|inet|cidr|bytea|blob|user-defined', re.I)
+
+_PARAM_COMPARISON_RE = re.compile(
+    r'\b(?:([A-Za-z_]\w*)\.)?([A-Za-z_]\w*)\s*(?:=|<>|!=|>=|<=|>|<)\s*:(\w+)')
+_PARAM_INSERT_RE = re.compile(
+    r'INSERT\s+INTO\s+"?`?([A-Za-z_]\w*)`?"?\s*\(([^)]*)\)\s*VALUES\s*\(([^)]*)\)',
+    re.I | re.S)
+_VALUE_KEYS = ("stringValue", "longValue", "doubleValue", "booleanValue",
+               "blobValue", "isNull", "arrayValue")
+
+
+def _extract_sql_with_bindings(code: str) -> List[tuple]:
+    """Return [(sql_text, {param_name: dataApiValueKey})] per SQL call site."""
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return []
+
+    consts = _string_consts(tree)
+
+    def bindings(node) -> Dict[str, str]:
+        """Parse a parameters=[{"name": ..., "value": {"longValue": ...}}] list."""
+        out: Dict[str, str] = {}
+        if not isinstance(node, (ast.List, ast.Tuple)):
+            return out
+        for element in node.elts:
+            if not isinstance(element, ast.Dict):
+                continue
+            name = None
+            value_key = None
+            for k, v in zip(element.keys, element.values):
+                key = k.value if isinstance(k, ast.Constant) else None
+                if key == "name" and isinstance(v, ast.Constant):
+                    name = v.value
+                elif key == "value" and isinstance(v, ast.Dict):
+                    for vk in v.keys:
+                        if isinstance(vk, ast.Constant) and vk.value in _VALUE_KEYS:
+                            value_key = vk.value
+                            break
+            if name and value_key:
+                out[name] = value_key
+        return out
+
+    pairs = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        sql = None
+        for arg in list(node.args) + [k.value for k in node.keywords if k.arg == "sql"]:
+            text = _as_text(arg, consts)
+            if text and _SQL_KEYWORD_RE.match(text):
+                sql = text
+                break
+        if not sql:
+            continue
+        binds: Dict[str, str] = {}
+        for kw in node.keywords:
+            if kw.arg in ("parameters", "params"):
+                binds = bindings(kw.value)
+        if not binds:
+            for arg in node.args:
+                if isinstance(arg, (ast.List, ast.Tuple)):
+                    binds = bindings(arg)
+                    if binds:
+                        break
+        pairs.append((sql, binds))
+    return pairs
+
+
+def _column_type_index(schema: dict) -> Dict[tuple, str]:
+    """(table, column) -> declared sql type, plus (None, column) when unambiguous."""
+    per_table: Dict[tuple, str] = {}
+    by_column: Dict[str, Set[str]] = {}
+    tables = schema.get("tables", []) if isinstance(schema, dict) else []
+    if isinstance(tables, dict):
+        tables = list(tables.values())
+    for t in tables or []:
+        if not isinstance(t, dict):
+            continue
+        table = t.get("name") or t.get("table_name")
+        for c in t.get("columns", []) or []:
+            if not isinstance(c, dict):
+                continue
+            col = c.get("name") or c.get("column_name")
+            sql_type = c.get("sql_type") or c.get("full_type") or c.get("type")
+            if not col or not sql_type:
+                continue
+            per_table[(table, col)] = str(sql_type)
+            by_column.setdefault(col, set()).add(str(sql_type))
+    for col, types in by_column.items():
+        if len(types) == 1:
+            per_table[(None, col)] = next(iter(types))
+    return per_table
+
+
+def _expected_value_key(sql_type: str) -> Optional[str]:
+    """The Data API value key a column of this type must be bound with."""
+    t = str(sql_type).strip()
+    if _STRING_OK_TYPE_RE.search(t):
+        return None          # a stringValue binding is legitimate here
+    if _BOOL_TYPE_RE.match(t):
+        return "booleanValue"
+    if _INT_TYPE_RE.match(t):
+        return "longValue"
+    if _TEXT_TYPE_RE.match(t):
+        return "stringValue"
+    return None
+
+
+def _check_sql_param_types(op_id: str, code: str, type_index: Dict[tuple, str]) -> List[dict]:
+    """Report Data API parameters bound with a type the column cannot accept."""
+    issues: List[dict] = []
+    if not type_index:
+        return issues
+
+    for sql, binds in _extract_sql_with_bindings(code):
+        if not binds:
+            continue
+        aliases = {}
+        for table, alias in _SQL_ALIAS_RE.findall(sql):
+            if alias.lower() not in _SQL_RESERVED:
+                aliases[alias] = table
+                aliases[table] = table
+
+        mapping = {}   # param -> (table, column)
+        for qualifier, column, param in _PARAM_COMPARISON_RE.findall(sql):
+            table = aliases.get(qualifier) if qualifier else None
+            mapping[param] = (table, column)
+        for table, col_list, val_list in _PARAM_INSERT_RE.findall(sql):
+            cols = [c.strip().strip('"`') for c in col_list.split(",") if c.strip()]
+            vals = [v.strip() for v in val_list.split(",")]
+            for col, val in zip(cols, vals):
+                m = re.match(r'^:(\w+)', val)
+                if m:
+                    mapping.setdefault(m.group(1), (table, col))
+
+        for param, (table, column) in mapping.items():
+            bound = binds.get(param)
+            if not bound or bound in ("isNull", "arrayValue", "blobValue"):
+                continue
+            sql_type = type_index.get((table, column)) or type_index.get((None, column))
+            if not sql_type:
+                continue
+            expected = _expected_value_key(sql_type)
+            if not expected or expected == bound:
+                continue
+            issues.append({
+                "check": "sql_param_type_mismatch", "operation_id": op_id,
+                "field": f":{param}",
+                "issue": f"Lambda '{op_id}' binds `:{param}` as `{bound}` but "
+                         f"`{(table + '.') if table else ''}{column}` is "
+                         f"`{sql_type}`, which needs `{expected}`. PostgreSQL "
+                         f"rejects this outright (e.g. 'operator does not exist: "
+                         f"bigint = text', SQLState 42883); MySQL silently coerces "
+                         f"and stops using the index. Bind it as {expected}.",
+            })
+    return issues
+
+
+def _schema_column_index(schema: dict) -> Dict[str, Set[str]]:
+    """table_name -> set(column names) from the infrastructure schema."""
+    index: Dict[str, Set[str]] = {}
+    tables = schema.get("tables", []) if isinstance(schema, dict) else []
+    if isinstance(tables, dict):
+        tables = list(tables.values())
+    for t in tables or []:
+        if not isinstance(t, dict):
+            continue
+        name = t.get("name") or t.get("table_name") or t.get("tableName")
+        if not name:
+            continue
+        cols: Set[str] = set()
+        for c in t.get("columns", []) or []:
+            if isinstance(c, str):
+                cols.add(c)
+            elif isinstance(c, dict):
+                cn = c.get("name") or c.get("column_name")
+                if cn:
+                    cols.add(cn)
+        pk = t.get("primary_key")
+        if isinstance(pk, str):
+            for part in re.split(r'[+,]', pk):
+                part = part.strip()
+                if part:
+                    cols.add(part)
+        elif isinstance(pk, list):
+            cols.update(str(p) for p in pk)
+        if cols:
+            index[name] = cols
+    return index
+
+
+_SQL_SELECT_LIST_RE = re.compile(r'\bSELECT\b(?P<list>.*?)\bFROM\b', re.I | re.S)
+_SQL_FROM_TARGETS_RE = re.compile(r'\b(?:FROM|JOIN)\s+"?`?\[?([A-Za-z_]\w*)\]?`?"?', re.I)
+# Left-hand side of a predicate: after WHERE/AND/OR, an unqualified identifier
+# followed by a comparison operator. The negative lookahead on '(' keeps
+# function calls out; requiring the operator keeps bare keywords out.
+_SQL_PREDICATE_LHS_RE = re.compile(
+    r'\b(?:WHERE|AND|OR)\s+"?`?\[?([A-Za-z_]\w*)\]?`?"?\s*'
+    r'(?:=|<>|!=|>=|<=|>|<|\bIS\b|\bIN\b|\bLIKE\b|\bBETWEEN\b)(?!\s*\()',
+    re.I)
+
+
+def _unqualified_columns(sql: str) -> List[str]:
+    """Column identifiers used without a table qualifier.
+
+    Read from the SELECT list, the INSERT column list, and the left-hand side of
+    WHERE/AND/OR comparisons — never the whole statement, so SQL keywords,
+    function names and literals are not mistaken for columns.
+    """
+    names: List[str] = []
+    m = _SQL_SELECT_LIST_RE.search(sql)
+    if m:
+        for item in m.group("list").split(","):
+            item = re.split(r'\s+AS\s+|\s+', item.strip(), flags=re.I)[0].strip()
+            if "." in item or "(" in item or "*" in item:
+                continue          # qualified, a function call, or SELECT *
+            ident = item.strip('"`[]')
+            if re.fullmatch(r'[A-Za-z_]\w*', ident) and ident.lower() not in _SQL_RESERVED:
+                names.append(ident)
+    for _, col_list, _ in _PARAM_INSERT_RE.findall(sql):
+        for c in col_list.split(","):
+            ident = c.strip().strip('"`[]')
+            if re.fullmatch(r'[A-Za-z_]\w*', ident) and ident.lower() not in _SQL_RESERVED:
+                names.append(ident)
+    for ident in _SQL_PREDICATE_LHS_RE.findall(sql):
+        ident = ident.strip('"`[]')
+        if re.fullmatch(r'[A-Za-z_]\w*', ident) and ident.lower() not in _SQL_RESERVED:
+            names.append(ident)
+    return names
+
+
+def _check_sql_identifiers(op_id: str, code: str, col_index: Dict[str, Set[str]]) -> List[dict]:
+    """Report SQL columns that the table they are used against does not have.
+
+    Covers both `alias.column` references and unqualified columns — the latter
+    only when the statement touches exactly one known table, which makes the
+    owning table unambiguous. Observed live: a handler selected `product_name`
+    straight out of `order_items` (it lives on `products`) and inserted
+    `created_at` into `returns` (that column is `requested_at`).
+    """
+    issues: List[dict] = []
+    if not col_index:
+        return issues
+    owner: Dict[str, Set[str]] = {}
+    for tbl, cols in col_index.items():
+        for c in cols:
+            owner.setdefault(c, set()).add(tbl)
+
+    def report(qualifier, column, table):
+        if column in col_index.get(table, set()):
+            return
+        shown = f"{qualifier}.{column}" if qualifier else column
+        real_owners = sorted(owner.get(column, set()) - {table})
+        if real_owners:
+            where = (f"but `{column}` belongs to {real_owners} — not to `{table}`. "
+                     f"Join through to {real_owners[0]} or use the correct column "
+                     f"from `{table}`.")
+        else:
+            where = (f"but `{table}` has no column `{column}`, and no scanned table "
+                     f"does. Use one of the columns the scan reported for "
+                     f"`{table}`: {sorted(col_index.get(table, set()))}.")
+        issues.append({
+            "check": "sql_schema_mismatch", "operation_id": op_id, "field": shown,
+            "issue": f"Lambda '{op_id}' SQL references `{shown}` against `{table}`, "
+                     f"{where} This fails at runtime with 'column does not exist' "
+                     f"(SQLState 42703).",
+        })
+
+    for sql in _extract_sql_statements(code):
+        aliases = {}
+        for tbl, alias in _SQL_ALIAS_RE.findall(sql):
+            if alias.lower() in _SQL_RESERVED:
+                continue
+            if tbl in col_index:
+                aliases[alias] = tbl
+                aliases[tbl] = tbl
+
+        for qualifier, column in _SQL_QUALIFIED_RE.findall(sql):
+            table = aliases.get(qualifier)
+            if table and column.lower() not in _SQL_RESERVED:
+                report(qualifier, column, table)
+
+        targets = {t for t in _SQL_FROM_TARGETS_RE.findall(sql) if t in col_index}
+        targets |= {t for t, _, _ in _PARAM_INSERT_RE.findall(sql) if t in col_index}
+        if len(targets) == 1:
+            only = next(iter(targets))
+            for column in _unqualified_columns(sql):
+                report(None, column, only)
+
+    return issues
+
+
+_PG_BUILTIN_TYPES = {
+    "text", "varchar", "char", "bpchar", "citext", "name",
+    "int", "int2", "int4", "int8", "smallint", "integer", "bigint",
+    "numeric", "decimal", "real", "float4", "float8", "double precision", "money",
+    "bool", "boolean", "bytea", "uuid", "json", "jsonb", "xml",
+    "date", "time", "timetz", "timestamp", "timestamptz", "interval",
+    "inet", "cidr", "macaddr", "tsvector", "tsquery", "oid", "regclass",
+    "array", "character", "user-defined", "record", "void", "anyelement",
+}
+_SQL_CAST_RE = re.compile(r'::\s*"?([A-Za-z_][\w ]*?)"?\s*(?=[\s,)\]]|$)')
+
+
+def _check_sql_casts(op_id: str, code: str, enum_types: Set[str]) -> List[dict]:
+    """Report ``::type`` casts to a type the schema does not define.
+
+    Observed live: the generator correctly cast a real PostgreSQL enum
+    (``:reason::return_reason``) and then invented the same pattern for two plain
+    VARCHAR columns (``:approvalStatus::approval_status``). Postgres rejects
+    those with ``type "approval_status" does not exist`` on the first write.
+    """
+    issues: List[dict] = []
+    for sql in _extract_sql_statements(code):
+        for raw in _SQL_CAST_RE.findall(sql):
+            type_name = raw.strip().lower().rstrip("[]")
+            base = type_name.replace("[]", "").strip()
+            if not base or base in _PG_BUILTIN_TYPES or base in enum_types:
+                continue
+            if re.match(r'^(varchar|char|numeric|decimal|timestamp|time)\s*\(', base):
+                continue
+            issues.append({
+                "check": "sql_type_mismatch", "operation_id": op_id,
+                "field": f"::{raw.strip()}",
+                "issue": f"Lambda '{op_id}' SQL casts to type `{raw.strip()}`, which is "
+                         f"neither a built-in type nor one of the schema's enum types "
+                         f"({sorted(enum_types) if enum_types else 'none'}). Postgres "
+                         f"fails with 'type \"{raw.strip()}\" does not exist' on the first "
+                         f"call. If that column is a plain VARCHAR, drop the cast.",
+            })
+    return issues
+
+
+def _schema_enum_types(schema: dict) -> Set[str]:
+    """Collect enum type names the schema declares."""
+    names: Set[str] = set()
+    if not isinstance(schema, dict):
+        return names
+    enum_types = schema.get("enum_types") or {}
+    if isinstance(enum_types, dict):
+        names.update(k.lower() for k in enum_types)
+    elif isinstance(enum_types, list):
+        for e in enum_types:
+            if isinstance(e, str):
+                names.add(e.lower())
+            elif isinstance(e, dict) and e.get("name"):
+                names.add(str(e["name"]).lower())
+    tables = schema.get("tables", [])
+    if isinstance(tables, dict):
+        tables = list(tables.values())
+    for t in tables or []:
+        if not isinstance(t, dict):
+            continue
+        enums = t.get("enums")
+        if isinstance(enums, dict):
+            # {"status": [...]} — the column name is not the type name, but the
+            # generator commonly casts to it, so accept it rather than false-flag.
+            names.update(k.lower() for k in enums)
+        for c in t.get("columns", []) or []:
+            if isinstance(c, dict):
+                st = (c.get("sql_type") or c.get("full_type") or "")
+                m = re.match(r'^([a-z_][\w]*)$', str(st).strip().lower())
+                if m and m.group(1) not in _PG_BUILTIN_TYPES:
+                    names.add(m.group(1))
+    return names
+
+
+_SQL_INSERT_RE = re.compile(
+    r'INSERT\s+INTO\s+"?([A-Za-z_][\w]*)"?\s*\(([^)]*)\)', re.I | re.S)
+
+
+def _check_sql_insert_required_columns(op_id: str, code: str, schema: dict) -> List[dict]:
+    """Report INSERTs that omit a NOT NULL column having no default.
+
+    Observed live: the generated `create_return` INSERT listed every column
+    except `returns.quantity`, which is NOT NULL with no default, so the first
+    write failed with 'null value in column "quantity" violates not-null
+    constraint'.
+    """
+    issues: List[dict] = []
+    required: Dict[str, Set[str]] = {}
+    tables = schema.get("tables", []) if isinstance(schema, dict) else []
+    if isinstance(tables, dict):
+        tables = list(tables.values())
+    for t in tables or []:
+        if not isinstance(t, dict):
+            continue
+        name = t.get("name") or t.get("table_name")
+        cols = t.get("columns") or []
+        if not name or not cols or not isinstance(cols[0], dict):
+            continue  # need per-column metadata to judge
+        needed: Set[str] = set()
+        for c in cols:
+            nullable = c.get("nullable")
+            if nullable in (True, "YES", "yes"):
+                continue
+            if nullable is None:
+                continue  # unknown → don't guess
+            if c.get("default") not in (None, "", "None"):
+                continue
+            if c.get("generated") or c.get("auto_increment"):
+                continue
+            cname = c.get("name") or c.get("column_name")
+            if cname:
+                needed.add(cname)
+        if needed:
+            required[name] = needed
+
+    if not required:
+        return issues
+
+    for sql in _extract_sql_statements(code):
+        for table, col_list in _SQL_INSERT_RE.findall(sql):
+            if table not in required:
+                continue
+            provided = {c.strip().strip('"') for c in col_list.split(",") if c.strip()}
+            missing = sorted(required[table] - provided)
+            # a single-column PK that looks generated is usually a serial
+            missing = [m for m in missing if not m.endswith("_id") or m in provided]
+            if missing:
+                issues.append({
+                    "check": "sql_missing_required_column", "operation_id": op_id,
+                    "field": ", ".join(missing),
+                    "issue": f"Lambda '{op_id}' INSERTs into `{table}` without the NOT NULL "
+                             f"column(s) {missing}, which have no default. The write fails "
+                             f"with 'null value in column ... violates not-null "
+                             f"constraint'. Add them to the INSERT column list and "
+                             f"parameters.",
+                })
+    return issues
+
+
+# --------------------------------------------------------------------------
+# D3: RDS Data API contract
+# --------------------------------------------------------------------------
+_RDS_ENV_CANON = ("DB_CLUSTER_ARN", "DB_SECRET_ARN", "DB_NAME")
+_RDS_ENV_WRONG = {
+    "RDS_CLUSTER_ARN": "DB_CLUSTER_ARN",
+    "RDS_SECRET_ARN": "DB_SECRET_ARN",
+    "RDS_DATABASE_NAME": "DB_NAME",
+    "RDS_DB_NAME": "DB_NAME",
+    "CLUSTER_ARN": "DB_CLUSTER_ARN",
+    "SECRET_ARN": "DB_SECRET_ARN",
+}
+
+
+def _check_rds_contract(op_id: str, code: str, infra_yaml: Optional[str]) -> List[dict]:
+    """Deterministic RDS Data API checks; only runs on rds-data handlers.
+
+    Catches: env var name drift (KeyError on cold start), execute_statement
+    without includeResultMetadata=True (rows readable only by position),
+    positional row access, and SQL built by string interpolation.
+    """
+    issues: List[dict] = []
+    if "rds-data" not in code and "rds_data" not in code:
+        return issues
+
+    env_reads = set(re.findall(
+        r'os\.environ(?:\.get)?[\[\(]\s*["\']([A-Z0-9_]+)["\']', code))
+
+    for wrong, right in _RDS_ENV_WRONG.items():
+        if wrong in env_reads and right not in env_reads:
+            issues.append({
+                "check": "rds_env_contract", "operation_id": op_id, "field": wrong,
+                "issue": f"Lambda '{op_id}' reads os.environ['{wrong}'] but the RDS "
+                         f"env var contract is '{right}'. Rename it in the handler and "
+                         f"make sure infrastructure.yaml sets the same name, otherwise "
+                         f"the function raises KeyError on cold start.",
+            })
+
+    if infra_yaml:
+        for env_name in sorted(env_reads & set(_RDS_ENV_CANON)):
+            if env_name not in infra_yaml:
+                issues.append({
+                    "check": "rds_env_contract", "operation_id": op_id, "field": env_name,
+                    "issue": f"Lambda '{op_id}' reads os.environ['{env_name}'] but "
+                             f"infrastructure.yaml never defines it — the function "
+                             f"fails with KeyError at runtime. Add it to the function's "
+                             f"Environment.Variables.",
+                })
+
+    if "execute_statement" in code and "includeResultMetadata" not in code:
+        issues.append({
+            "check": "rds_data_api", "operation_id": op_id, "field": "includeResultMetadata",
+            "issue": f"Lambda '{op_id}' calls rds-data execute_statement without "
+                     f"includeResultMetadata=True. The response then has no "
+                     f"columnMetadata, so columns can only be read by position and "
+                     f"results break on any schema change. Pass "
+                     f"includeResultMetadata=True and map rows to dicts by column name.",
+        })
+
+    positional = (
+        re.search(r'\[\s*["\']records["\']\s*\]\s*\[\s*\d+\s*\]', code)
+        or re.search(r'\brecords\s*\[\s*\d+\s*\]\s*\[\s*\d+\s*\]', code)
+        or re.search(r'\brecord\s*\[\s*\d+\s*\]', code)
+        or re.search(r'\.get\(\s*["\']records["\']\s*[^)]*\)\s*\[\s*\d+\s*\]\s*\[\s*\d+\s*\]', code)
+    )
+    if positional:
+        issues.append({
+            "check": "rds_data_api", "operation_id": op_id, "field": "",
+            "issue": f"Lambda '{op_id}' reads Data API rows by position "
+                     f"(record[0], records[0][1], …). Read columns by name using "
+                     f"columnMetadata instead — positional access silently returns the "
+                     f"wrong column when the table changes.",
+        })
+
+    injection = (
+        re.search(r'\bsql\s*=\s*f["\']', code)
+        or re.search(r'\bsql\s*=\s*["\'][^"\']*["\']\s*(?:\+|%|\.format\()', code)
+        or re.search(r'(?:execute_sql|execute_statement)\s*\(\s*f["\']', code)
+        or re.search(r'(?:execute_sql|execute_statement)\s*\(\s*["\'][^"\']*["\']\s*(?:\+|%|\.format\()', code)
+    )
+    if injection:
+        issues.append({
+            "check": "rds_data_api", "operation_id": op_id, "field": "",
+            "issue": f"Lambda '{op_id}' builds SQL by string interpolation/concatenation "
+                     f"— SQL injection risk. Use Data API named parameters "
+                     f"(:param) with the parameters=[...] argument.",
+        })
+    return issues
+
+
+# --------------------------------------------------------------------------
 # Checks
 # --------------------------------------------------------------------------
 
 def validate(output_dir: Path) -> List[dict]:
     state = output_dir / "state"
-    assets = output_dir / "assets"
+    assets = assets_root(output_dir)
     specs = load_specs(state)
     infra = load_infra_schema(state)
-    lam = load_lambda_code(assets)
+    code_sets = load_lambda_code(assets)
+    lam = code_sets["spec"]          # spec-driven handlers only
+    lam_all = code_sets["all"]       # + update_q_session / customer_lookup
+    infra_yaml = load_infra_template(assets)
     oapi = load_openapi(assets)
     tools = collect_tools(specs)
 
@@ -208,6 +1075,13 @@ def validate(output_dir: Path) -> List[dict]:
             "output": _field_set(s.get("output_fields", [])),
         }
         for op_id, s in specs.items()
+    }
+    tool_expected = {
+        tool_id: {
+            "input": _field_set(t.get("input_fields", [])),
+            "output": _field_set(t.get("output_fields", [])),
+        }
+        for tool_id, t in tools.items()
     }
 
     # 1) Lambda vs spec
@@ -256,7 +1130,8 @@ def validate(output_dir: Path) -> List[dict]:
     if infra:
         tables = infra.get("tables") or infra.get("dynamodb_tables") or {}
         if isinstance(tables, list):
-            tables = {t.get("table_name") or t.get("tableName"): t for t in tables}
+            tables = {t.get("table_name") or t.get("tableName") or t.get("name"): t
+                      for t in tables}
         for tdef in tables.values():
             if not isinstance(tdef, dict):
                 continue
@@ -329,17 +1204,76 @@ def validate(output_dir: Path) -> List[dict]:
                 ),
             })
 
-    # 9) Count parity
-    if lam and len(lam) < len(expected):
+    # 9) Count parity — tool-level when the specs declare more tools than
+    #    operations (multi-tool operations), operation-level otherwise.
+    target = tool_expected if len(tool_expected) > len(expected) else expected
+    label = "tool" if target is tool_expected else "spec"
+    if lam and len(lam) < len(target):
         mismatches.append({
             "check": "count_lambda", "operation_id": "__all__", "field": "",
-            "issue": f"Lambda count ({len(lam)}) < spec count ({len(expected)}). Missing: {set(expected) - set(lam)}",
+            "issue": f"Lambda count ({len(lam)}) < {label} count ({len(target)}). Missing: {sorted(set(target) - set(lam))}",
         })
-    if oapi and len(oapi) < len(expected):
+    if oapi and len(oapi) < len(target):
         mismatches.append({
             "check": "count_openapi", "operation_id": "__all__", "field": "",
-            "issue": f"OpenAPI path count ({len(oapi)}) < spec count ({len(expected)}). Missing: {set(expected) - set(oapi)}",
+            "issue": f"OpenAPI path count ({len(oapi)}) < {label} count ({len(target)}). Missing: {sorted(set(target) - set(oapi))}",
         })
+
+    # 10) ToolSpec-level Lambda field consistency (one handler per tool_id)
+    for tool_id, fields in tool_expected.items():
+        code = lam.get(tool_id)
+        if not code:
+            continue
+        lf = _extract_lambda_fields(code)
+        for name in fields["input"]:
+            if name not in lf:
+                mismatches.append({
+                    "check": "lambda_tool", "operation_id": tool_id, "field": name,
+                    "issue": f"ToolSpec input field '{name}' not found in Lambda handler for tool '{tool_id}'",
+                })
+
+    # D2) Lambda runtime AWS calls vs IAM role grants in the CFN template
+    if infra_yaml and lam_all:
+        fn_actions = _extract_role_actions_from_template(infra_yaml)
+        # index CFN function grants by normalized name for fuzzy matching
+        norm_grants = {re.sub(r'(function|lambda)$', '', k.lower()): v
+                       for k, v in fn_actions.items()}
+        for op_id, code in lam_all.items():
+            required = _extract_required_iam_actions(code)
+            if not required:
+                continue
+            norm_op = op_id.replace("_", "").replace("-", "").lower()
+            granted = None
+            for nk, v in norm_grants.items():
+                if norm_op in nk or nk in norm_op:
+                    granted = v
+                    break
+            if granted is None:
+                continue  # function not in template (deployed elsewhere) — skip
+            missing = sorted(a for a in required if not _action_granted(a, granted))
+            if missing:
+                mismatches.append({
+                    "check": "iam_permissions", "operation_id": op_id, "field": "",
+                    "issue": f"Lambda '{op_id}' calls AWS APIs requiring {missing} but its "
+                             f"IAM role in the CloudFormation template does not grant them "
+                             f"— this fails with AccessDeniedException at runtime. Add an "
+                             f"inline policy with these actions to the function's role.",
+                })
+
+    # D3) RDS Data API contract (only for handlers that use rds-data)
+    for op_id, code in lam_all.items():
+        mismatches.extend(_check_rds_contract(op_id, code, infra_yaml))
+
+    # D4/D5) SQL vs the scanned/provided database schema
+    if infra and lam_all:
+        col_index = _schema_column_index(infra)
+        enum_types = _schema_enum_types(infra)
+        type_index = _column_type_index(infra)
+        for op_id, code in lam_all.items():
+            mismatches.extend(_check_sql_identifiers(op_id, code, col_index))
+            mismatches.extend(_check_sql_casts(op_id, code, enum_types))
+            mismatches.extend(_check_sql_insert_required_columns(op_id, code, infra))
+            mismatches.extend(_check_sql_param_types(op_id, code, type_index))
 
     return mismatches
 
@@ -349,20 +1283,27 @@ def validate(output_dir: Path) -> List[dict]:
 # --------------------------------------------------------------------------
 
 def main() -> int:
-    if len(sys.argv) != 2:
-        print(f"Usage: {sys.argv[0]} <output_dir>", file=sys.stderr)
+    args = [a for a in sys.argv[1:] if not a.startswith("-")]
+    as_json = "--json" in sys.argv[1:]
+    if len(args) != 1:
+        print(f"Usage: {sys.argv[0]} <output_dir> [--json]", file=sys.stderr)
         return 2
-    out_dir = Path(sys.argv[1]).resolve()
+    out_dir = Path(args[0]).resolve()
     if not out_dir.is_dir():
         print(f"ERROR: not a directory: {out_dir}", file=sys.stderr)
         return 2
     mismatches = validate(out_dir)
+    if as_json:
+        print(json.dumps({"success": not mismatches, "mismatches": mismatches}, indent=2))
+        return 1 if mismatches else 0
     if not mismatches:
         print(f"OK — no consistency issues found in {out_dir}")
         return 0
     print(f"FAIL — {len(mismatches)} consistency issue(s) found in {out_dir}:\n")
     for m in mismatches:
-        print(f"  [{m['check']:<16}] {m['operation_id']}.{m['field']}: {m['issue']}")
+        print(f"  [{m['check']:<27}] {m['operation_id']}.{m['field']}: {m['issue']}")
+    print("\nFix simple renames by patching the file; for structural drift re-run the "
+          "affected generator with a modification_request.")
     return 1
 
 

--- a/skills/aicc-builder-skill/resources/sub-agents/_shared_rules.md
+++ b/skills/aicc-builder-skill/resources/sub-agents/_shared_rules.md
@@ -127,7 +127,8 @@ turns the tool into something the model can't call.
 If a spec field has `enum_values` populated, those EXACT values — same
 casing, same spelling, same order, same punctuation (underscores vs
 hyphens matter) — must appear verbatim in OpenAPI `enum:` and in any
-Lambda validation code (e.g., `if value not in {...}: return 400`).
+Lambda validation code (e.g., `if value not in {...}: ...` returning a
+200 rejection body per BUSINESS_OUTCOME_200_RULE).
 Do NOT paraphrase, translate, abbreviate, or alphabetize. If the customer
 supplied 18 Electrolux program modes, emit all 18 verbatim.
 
@@ -145,6 +146,49 @@ camelCase spelled by the spec. Do NOT rename, flatten, or drop keys.
 `event`-parsing and response-building must use the spec's nested field
 names verbatim. For scalar output fields with `enum_values`, validate
 against those exact values before returning.
+
+### 17. BUSINESS_OUTCOME_200_RULE  (CRITICAL — fixes "there is an issue with the tool")
+An Amazon Connect AI agent treats **any non-2xx HTTP response as a tool
+execution failure**. It never reads the response body, so it cannot tell the
+customer what happened — it just reports that the tool is broken and the turn
+is lost.
+
+Therefore: **a business outcome is NOT an HTTP error.** Every outcome the AI
+agent is supposed to talk about MUST return `200`, with the outcome expressed
+as a field IN THE BODY.
+
+"Business outcome" means any answer the operation is designed to produce,
+including the negative ones:
+
+  - authentication did not match (wrong SSN digits / accountId / PIN)
+  - record not found, no reservation for that phone number
+  - too many attempts / account locked out
+  - date unavailable, seat taken, insufficient balance
+  - a validation problem the customer can fix ("I need your account number")
+
+All of the above → `200` + a discriminator field. Do NOT use 400, 401, 403,
+404, 409 or 429 for any of them.
+
+```python
+# ❌ WRONG — the AI agent says "there is an issue with the tool" and gives up
+if last_four_digits != stored_last_four:
+    return create_response(403, {"verified": False, "lockout": True})
+
+# ✅ RIGHT — the AI agent reads verified/lockout and responds to the customer
+if last_four_digits != stored_last_four:
+    return create_response(200, {"verified": False, "remainingAttempts": remaining,
+                                 "lockout": False})
+```
+
+Reserve non-2xx for faults the AI agent genuinely cannot act on:
+  - `5xx` — the operation itself broke (unhandled exception, database down).
+    Connect retries 5xx, which is the correct behaviour for a transient fault.
+
+The body must let the model distinguish outcomes without the status code, so
+always include an explicit discriminator (`verified`, `found`, `success`,
+`status`, `outcome`, …) plus enough detail to speak to the customer. State the
+same in the OpenAPI `200` schema and in the tool description, so the model
+knows the negative outcome is a normal, expected response.
 
 ## 🔒 END OF GOLDEN RULES — APPLY ALL OF THE ABOVE TO THE OUTPUT BELOW 🔒
 

--- a/skills/aicc-builder-skill/resources/sub-agents/contact_flow_generator.md
+++ b/skills/aicc-builder-skill/resources/sub-agents/contact_flow_generator.md
@@ -83,7 +83,7 @@ silently dropping customer-specific behaviors. DO NOT do that.
 **For EVERY behavior present in the requirements, the corresponding blocks MUST
 appear in the generated flow. This is mandatory, not optional:**
 - `callback_enabled: true` → you MUST include `UpdateContactCallbackNumber` →
-  `TransferContactToQueue` (with InvalidNumber/NotDialable/NoMatchingError handlers).
+  `TransferContactToQueue` (callback errors: InvalidCallbackNumber + CallbackNumberNotDialable).
 - A named target queue / "transfer to the X queue" → you MUST include
   `UpdateContactTargetQueue` → `TransferContactToQueue` using that queue.
 - `hours_of_operation` / business-hours branching → you MUST include
@@ -172,7 +172,7 @@ If you are uncertain about ANY block type, parameter format, or syntax:
 ❌ WRONG: `{"ProfileId": "...", "ContactId": "..."}`
 ✅ CORRECT: `{"ProfileRequestData": {"ProfileId": "...", "ContactId": "..."}}`
 
-### InvokeLambdaFunction - MUST use STRING_MAP ResponseType
+### InvokeLambdaFunction - ResponseType STRING_MAP or JSON
 ```json
 {
   "Type": "InvokeLambdaFunction",
@@ -185,8 +185,9 @@ If you are uncertain about ANY block type, parameter format, or syntax:
   }
 }
 ```
-❌ WRONG: `"ResponseType": "JSON"`
-✅ CORRECT: `"ResponseType": "STRING_MAP"`
+`ResponseType` accepts `STRING_MAP` (flat key/value — prefer this) OR `JSON` (nested).
+Both import (API-verified). `ResponseValidation` is OPTIONAL and may be omitted.
+❌ WRONG: `"ResponseType": "JSON_OBJECT"` (rejected — "Invalid Action property value")
 
 ---
 
@@ -288,16 +289,16 @@ on a correct, complete, importable JSON.
 | Type | Purpose | Required Parameters | Error Types |
 |------|---------|---------------------|-------------|
 | MessageParticipant | Play TTS/text to customer | Text OR PromptId OR Media | NoMatchingError |
-| GetParticipantInput | Collect DTMF input (TWO modes — see below) | Text/SSML, StoreInput, InputTimeLimitSeconds | InputTimeLimitExceeded, NoMatchingCondition, NoMatchingError |
-| StoreUserInput | Store numeric input as attribute | AttributeName | NoMatchingError |
+| GetParticipantInput | Collect DTMF input (TWO modes — see below) | Text/SSML, StoreInput, InputTimeLimitSeconds (required) | MENU: InputTimeLimitExceeded+NoMatchingCondition+NoMatchingError / STORE: NoMatchingError only |
 | DisconnectParticipant | End the contact | (none) | (none - terminal block) |
-| Wait | Pause for specified time | WaitTime (seconds, max 7 days) | TimeExpired, Error |
+| Wait | Pause for specified time | TimeLimitSeconds + Conditions operand `WaitCompleted` + NextAction | NoMatchingError |
 
 ### Voice & Recording Blocks
 | Type | Purpose | Required Parameters | Error Types |
 |------|---------|---------------------|-------------|
 | UpdateContactTextToSpeechVoice | Set TTS voice | TextToSpeechVoice, TextToSpeechEngine | NoMatchingError |
-| UpdateContactRecordingBehavior | Recording + Contact Lens | RecordingBehavior, AnalyticsBehavior | (Success only) |
+| UpdateContactRecordingAndAnalyticsBehavior | Recording + Contact Lens (CURRENT console block) | VoiceBehavior{VoiceRecordingBehavior,VoiceAnalyticsBehavior} or ChatBehavior{ChatAnalyticsBehavior} | NoMatchingError, ChannelMismatch (+InFlightRedactionConfigurationFailed for chat) |
+| UpdateContactRecordingBehavior | LEGACY (do not generate; still importable) | RecordingBehavior, AnalyticsBehavior | (Success only) |
 | UpdateFlowLoggingBehavior | Control flow logging | FlowLoggingBehavior ("Enabled"/"Disabled") | (Success only) |
 
 ### AI/Bot Integration Blocks
@@ -310,36 +311,33 @@ on a correct, complete, importable JSON.
 ### Routing & Transfer Blocks
 | Type | Purpose | Required Parameters | Error Types |
 |------|---------|---------------------|-------------|
-| TransferContactToQueue | Transfer to queue | QueueId (optional if UpdateContactTargetQueue used) | QueueAtCapacity, NoMatchingError |
-| DequeueContactAndTransferToQueue | Queue-to-queue transfer | QueueId | QueueAtCapacity, NoMatchingError |
-| TransferContactToAgent | Transfer to specific agent | AgentId | AgentNotAvailable, NoMatchingError |
-| TransferToFlow | Transfer to another flow | FlowId | NoMatchingError |
-| TransferParticipantToThirdParty | Transfer to external number | PhoneNumber | CallFailed, NoMatchingError |
-| UpdateContactTargetQueue | Set active queue | QueueId (UUID format) | NoMatchingError |
-| CheckMetricData | Check agent availability | (uses working queue) | True, False, Error |
-| CheckMetricData | Get real-time queue metrics | MetricNames | NoMatchingError |
+| TransferContactToQueue | Transfer to queue | (NO QueueId — set via UpdateContactTargetQueue first) | QueueAtCapacity, NoMatchingError |
+| DequeueContactAndTransferToQueue | Queue-to-queue transfer | QueueId (or AgentId) | QueueAtCapacity, NoMatchingError |
+| TransferToFlow | Transfer to another flow | ContactFlowId | NoMatchingError |
+| TransferParticipantToThirdParty | Transfer to external number | ThirdPartyPhoneNumber | CallFailed, ConnectionTimeLimitExceeded, NoMatchingError |
+| UpdateContactTargetQueue | Set active queue | QueueId (UUID/ARN) OR AgentId | NoMatchingError |
+| CheckMetricData | Check agent availability / queue metrics | MetricType (`NumberOfAgentsAvailable`/`NumberOfContactsInQueue`/`OldestContactInQueueAgeSeconds`/`NumberOfAgentsStaffed`/`NumberOfAgentsOnline`); optional QueueId; branch via Conditions | NoMatchingCondition, NoMatchingError |
 
 ### Condition & Logic Blocks
 | Type | Purpose | Required Transitions | Error Types |
 |------|---------|----------------------|-------------|
 | Compare | Compare attribute values | NextAction, Conditions[] | NoMatchingCondition |
-| CheckContactAttributes | Evaluate attribute values | Conditions[] | NoMatchingCondition |
-| CheckHoursOfOperation | Check business hours | HoursOfOperationId | True(InHours), False(OutOfHours), Error |
-| DistributeByPercentage | A/B testing | Percentage branches | NoMatchingError |
-| Loop | Repeat actions | LoopCount | Looping, Complete |
+| CheckHoursOfOperation | Check business hours | HoursOfOperationId + NextAction + BOTH True/False Conditions | NoMatchingError (NOT NoMatchingCondition) |
+| DistributeByPercentage | A/B testing | Percentage branches | NoMatchingCondition |
+| Loop | Repeat actions | LoopCount + NextAction | Conditions operands `ContinueLooping`/`DoneLooping` |
 
 ### Lambda & Module Blocks
 | Type | Purpose | Required Parameters | Error Types |
 |------|---------|---------------------|-------------|
 | InvokeLambdaFunction | Call Lambda function | LambdaFunctionARN, InvocationTimeLimitSeconds (max 8) | NoMatchingError |
 | InvokeFlowModule | Call flow module | FlowModuleId | NoMatchingCondition, NoMatchingError |
-| EndFlowModuleExecution | Return from module | (optional ReturnValue) | (terminal block) |
+| EndFlowExecution | End flow (terminal) | (none) | (terminal block — NO Transitions) |
 
 ### Contact Attribute Blocks
 | Type | Purpose | Required Parameters | Error Types |
 |------|---------|---------------------|-------------|
 | UpdateContactAttributes | Set/update contact attributes | Attributes object | NoMatchingError (32KB limit) |
-| UpdateContactCallbackNumber | Set callback number for queue callback | CallbackNumber | InvalidNumber, NotDialable, NoMatchingError |
+| UpdateContactCallbackNumber | Set callback number for queue callback | CallbackNumber (JSONPath, e.g. $.CustomerEndpoint.Address — not a literal) | InvalidCallbackNumber, CallbackNumberNotDialable (NOT NoMatchingError) |
 | CustomerProfiles | Query/create customer profiles | ProfileRequestData | NoMatchingError |
 | Cases | Link to cases | CaseId | NoMatchingError |
 
@@ -352,9 +350,9 @@ When you need to implement a feature, use ONLY these block combinations:
 | Use Case | Block Sequence | Key Attributes |
 |----------|----------------|----------------|
 | **Callback scheduling** | `UpdateContactCallbackNumber` → `TransferContactToQueue` | `$.CustomerEndpoint.Address` |
-| **Agent availability check** | `UpdateContactTargetQueue` → `CheckMetricData` | Conditions: `True`/`False` |
-| **Queue-depth check** | `CheckMetricData` → `Compare` | `$.Metrics.Queue.Size` |
-| **Retry loop** | `Loop` → `Wait` → action | Branches: `Looping`/`Complete` |
+| **Agent availability check** | `UpdateContactTargetQueue` → `CheckMetricData` (MetricType `NumberOfAgentsAvailable`) | Condition: `NumberGreaterThan 0` |
+| **Queue-depth check** | `CheckMetricData` (MetricType `NumberOfContactsInQueue`) | Condition: `NumberGreaterThan N` |
+| **Retry loop** | `Loop` → `Wait` → action | Operands: `ContinueLooping`/`DoneLooping` |
 | **DTMF input** | `GetParticipantInput` | `$.StoredCustomerInput` |
 | **AI bot dialogue** | `ConnectParticipantWithLexBot` → `Compare` | `$.Lex.SessionAttributes.*` |
 | **Hours-of-operation check** | `CheckHoursOfOperation` | Conditions: `True`/`False` |
@@ -370,13 +368,13 @@ ANY of them makes the flow fail to import with `InvalidContactFlowException`.
 
 | ❌ Wrong | ✅ Correct Alternative |
 |----------|------------------------|
-| `Trigger` / `EntryPoint` | **NONE — there is no entry/trigger block.** A flow simply starts at the action `StartAction` points to. The FIRST real action (e.g. `UpdateFlowLoggingBehavior` or `UpdateContactRecordingBehavior`) IS the start. NEVER emit a `Trigger`/`EntryPoint` wrapper action. |
+| `Trigger` / `EntryPoint` | **NONE — there is no entry/trigger block.** A flow simply starts at the action `StartAction` points to. The FIRST real action (e.g. `UpdateFlowLoggingBehavior` or `UpdateContactRecordingAndAnalyticsBehavior`) IS the start. NEVER emit a `Trigger`/`EntryPoint` wrapper action. |
 | `InvokeAgentAction` | `ConnectParticipantWithLexBot` (AI self-service runs through a Q-in-Connect-enabled **Lex V2 bot** — params are `LexV2Bot.AliasArn` + one of `Text`/`SSML`/`PromptId`. There is NO `AgentAliasArn`, `IdleSessionTimeout`, or `EndConversationPhrase` param.) |
 | `InvokeBedrockAgent` / `InvokeAmazonQConnect` / `InvokeQConnect` | `CreateWisdomSession` (early) + `ConnectParticipantWithLexBot` |
 | `CheckCondition` / `CheckValue` / `Condition` / `CheckAttribute` | `Compare` (params: `ComparisonValue` + `Conditions`) |
 | `SetWorkingQueue` | `UpdateContactTargetQueue` |
 | `SetCallbackNumber` | `UpdateContactCallbackNumber` |
-| `CheckStaffing` / `CheckQueueStatus` | `CheckMetricData` (MetricType: `AgentsAvailable` / `ContactsInQueue`) |
+| `CheckStaffing` / `CheckQueueStatus` | `CheckMetricData` (MetricType: `NumberOfAgentsAvailable` / `NumberOfContactsInQueue`) |
 | `GetQueueMetrics` | `CheckMetricData` or `GetMetricData` |
 | `TransferToAgent` | `TransferContactToQueue` |
 | `TransferToPhoneNumber` / `TransferToThirdParty` | `TransferParticipantToThirdParty` |
@@ -399,7 +397,7 @@ ANY of them makes the flow fail to import with `InvalidContactFlowException`.
 
 **RULE: `StartAction` MUST point at a REAL functional first action (not a
 Trigger/EntryPoint).** The flow's first executed block is typically
-`UpdateFlowLoggingBehavior`, `UpdateContactRecordingBehavior`, or
+`UpdateFlowLoggingBehavior`, `UpdateContactRecordingAndAnalyticsBehavior`, or
 `UpdateContactTextToSpeechVoice` — never a synthetic entry wrapper.
 
 ---
@@ -414,14 +412,14 @@ Trigger/EntryPoint).** The flow's first executed block is typically
 | `TransferContactToQueue` | `{}` (uses queue set by UpdateContactTargetQueue) | `QueueAtCapacity`, `NoMatchingError` |
 | `UpdateContactTargetQueue` | `QueueId` (string ARN — NOT nested object) | `NoMatchingError` |
 | `Compare` | `ComparisonValue` (valid JSONPath root) | `NoMatchingCondition` ONLY (never `NoMatchingError`) |
-| `Loop` | `LoopCount` | Branches: `Looping`, `Complete` |
-| `Wait` | `WaitTime` (seconds) | `NoMatchingError` |
-| `GetParticipantInput` (MENU) | exactly ONE of `Text`/`SSML`, `StoreInput:"False"`, **NO `DTMFConfiguration`** | `InputTimeLimitExceeded`, `NoMatchingCondition`, `NoMatchingError` |
-| `GetParticipantInput` (STORE) | exactly ONE of `Text`/`SSML`, `StoreInput:"True"`, optional `DTMFConfiguration{DisableCancelKey}` only | `InputTimeLimitExceeded`, `NoMatchingError` |
-| `UpdateContactCallbackNumber` | `CallbackNumber` | `InvalidNumber`, `NotDialable`, `NoMatchingError` |
+| `Loop` | `LoopCount` + `Transitions.NextAction` (required) | Conditions operands `ContinueLooping`/`DoneLooping`; Errors optional |
+| `Wait` | `TimeLimitSeconds` (NOT `WaitTime`) + Conditions operand `WaitCompleted` + `NextAction` | `NoMatchingError` |
+| `GetParticipantInput` (MENU) | exactly ONE of `Text`/`SSML`, `StoreInput:"False"`, `InputTimeLimitSeconds` (required), **NO `DTMFConfiguration`** | `InputTimeLimitExceeded`, `NoMatchingCondition`, `NoMatchingError` |
+| `GetParticipantInput` (STORE) | exactly ONE of `Text`/`SSML`, `StoreInput:"True"`, `InputTimeLimitSeconds` (required), `InputValidation.CustomValidation.MaximumLength`, optional `DTMFConfiguration{DisableCancelKey (string!),InputTerminationSequence}` | `NoMatchingError` ONLY |
+| `UpdateContactCallbackNumber` | `CallbackNumber` (JSONPath, not a literal) | `InvalidCallbackNumber`, `CallbackNumberNotDialable` (NOT `NoMatchingError`/`InvalidNumber`/`NotDialable`) |
 | `CheckHoursOfOperation` | `HoursOfOperationId` (non-null) | `NoMatchingError`; Conditions MUST include BOTH `True` AND `False` |
 | `CheckMetricData` | `QueueId` | `NoMatchingError` |
-| `InvokeLambdaFunction` | `LambdaFunctionARN`, `InvocationTimeLimitSeconds` (max 8), `LambdaInvocationAttributes` (NOT `RequestAttributes`), `ResponseValidation.ResponseType`=`STRING_MAP` | `NoMatchingError` |
+| `InvokeLambdaFunction` | `LambdaFunctionARN`, `InvocationTimeLimitSeconds` (1-8), `LambdaInvocationAttributes` (NOT `RequestAttributes`), optional `ResponseValidation.ResponseType`=`STRING_MAP` or `JSON` (NOT `JSON_OBJECT`) | `NoMatchingError` |
 | `ConnectParticipantWithLexBot` | `LexV2Bot.AliasArn` + exactly ONE of `Text`/`SSML`/`PromptId`; optional `LexSessionAttributes` | `NoMatchingError`, `NoMatchingCondition` (NEVER `AgentError`) |
 | `UpdateContactTextToSpeechVoice` | `TextToSpeechVoice`, `TextToSpeechEngine` (NOT `VoiceId`/`Engine`/`LanguageCode`) | `NoMatchingError` |
 | `UpdateContactRecordingBehavior` | `RecordingBehavior{RecordedParticipants,IVRRecordingBehavior}` + `AnalyticsBehavior` (NOT `Agent`/`Customer`) | (none) |
@@ -483,36 +481,48 @@ ActionMetadata for set-voice (REQUIRED — DO NOT OMIT languageCode or overrideC
 ```
 Language code mapping: ko-KR → Seoyeon, en-US → Matthew, ja-JP → Kazuha
 
-### 1b. Recording & Analytics (REQUIRED — use ChannelConfiguration!)
+### 1b. Recording & Analytics (REQUIRED — use the CURRENT block type!)
+**Use `UpdateContactRecordingAndAnalyticsBehavior`** — this is what the Connect
+console emits today. The legacy `UpdateContactRecordingBehavior` block is
+OUTDATED (still accepted for back-compat, but do not generate it).
+
 Voice recording (when channel is VOICE):
 ```json
-{"Identifier": "voice-recording", "Type": "UpdateContactRecordingBehavior",
+{"Identifier": "voice-recording", "Type": "UpdateContactRecordingAndAnalyticsBehavior",
  "Parameters": {
-   "RecordingBehavior": {"RecordedParticipants": ["Agent", "Customer"], "IVRRecordingBehavior": "Enabled"},
-   "AnalyticsBehavior": {"Enabled": "True", "AnalyticsLanguage": "en-US",
-     "ChannelConfiguration": {"Chat": {"AnalyticsModes": []}, "Voice": {"AnalyticsModes": ["PostContact"]}},
-     "SummaryConfiguration": {"SummaryModes": ["PostContact"]},
-     "SentimentConfiguration": {"Enabled": "True"}}},
- "Transitions": {"NextAction": "next_block"}}
+   "VoiceBehavior": {
+     "VoiceRecordingBehavior": {"RecordedParticipants": ["Agent", "Customer"], "IVRRecordingBehavior": "Enabled"},
+     "VoiceAnalyticsBehavior": {"Enabled": "True", "AnalyticsLanguage": "en-US",
+       "AnalyticsModes": ["RealTime", "AutomatedInteraction"],
+       "ConversationalAnalyticsRedactionConfiguration": {"Enabled": "False"},
+       "SentimentConfiguration": {"Enabled": "True"},
+       "SummaryConfiguration": {"SummaryModes": ["PostContact", "AutomatedInteraction"]}}}},
+ "Transitions": {"NextAction": "next_block",
+   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "next_block"},
+              {"ErrorType": "ChannelMismatch", "NextAction": "next_block"}]}}
 ```
-⚠️ **Voice `AnalyticsModes` MUST be `["PostContact"]` (NOT `["RealTime", ...]`).**
-`RealTime` in `Voice.AnalyticsModes` is rejected by Amazon Connect on import
-(`InvalidContactFlowException: Invalid Action property value ... ChannelConfiguration.Voice`)
-unless the instance/flow meets real-time Contact Lens preconditions — it breaks
-import for everyone. Use `PostContact`. (Q in Connect real-time assistance does
-NOT require RealTime voice *analytics* in this block — the Lex/Wisdom session
-drives the assistant; post-contact analytics is the safe, always-importable choice.)
+⚠️ **API-verified requirements for this block:** the `Errors` list MUST include
+BOTH `NoMatchingError` and `ChannelMismatch` — import fails without them.
+`AnalyticsModes` here supports `RealTime` + `AutomatedInteraction` together
+(unlike the legacy block). `AutomatedInteraction` covers the AI-agent (IVR)
+portion of the call; `RealTime` gives escalated human agents live transcript +
+sentiment.
 Chat recording (when channel is CHAT):
 ```json
-{"Identifier": "chat-recording", "Type": "UpdateContactRecordingBehavior",
+{"Identifier": "chat-recording", "Type": "UpdateContactRecordingAndAnalyticsBehavior",
  "Parameters": {
-   "RecordingBehavior": {"RecordedParticipants": [], "IVRRecordingBehavior": "Disabled"},
-   "AnalyticsBehavior": {"Enabled": "True", "AnalyticsLanguage": "en-US",
-     "ChannelConfiguration": {"Chat": {"AnalyticsModes": ["ContactLens"]}, "Voice": {"AnalyticsModes": []}},
-     "SummaryConfiguration": {"SummaryModes": ["PostContact"]},
-     "SentimentConfiguration": {"Enabled": "True"}}},
- "Transitions": {"NextAction": "next_block"}}
+   "ChatBehavior": {
+     "ChatAnalyticsBehavior": {"Enabled": "True", "AnalyticsLanguage": "en-US",
+       "AnalyticsModes": ["ContactLens"],
+       "SentimentConfiguration": {"Enabled": "True"},
+       "SummaryConfiguration": {"SummaryModes": ["PostContact"]}}}},
+ "Transitions": {"NextAction": "next_block",
+   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "next_block"},
+              {"ErrorType": "ChannelMismatch", "NextAction": "next_block"},
+              {"ErrorType": "InFlightRedactionConfigurationFailed", "NextAction": "next_block"}]}}
 ```
+⚠️ The CHAT variant additionally requires the
+`InFlightRedactionConfigurationFailed` error branch (API-verified).
 
 ### 2. Connect Assistant Session (REQUIRED - must be early in flow!)
 This 2-action pattern creates the Connect Assistant (Wisdom) session. Place BEFORE recording setup.
@@ -553,18 +563,23 @@ This 2-action pattern creates the Connect Assistant (Wisdom) session. Place BEFO
               {"ErrorType": "NoMatchingError", "NextAction": "error_handler"}]}}
 ```
 
-### 4. Callback Pattern (UpdateContactCallbackNumber + Transfer)
+### 4. Callback Pattern (set queue → UpdateContactCallbackNumber + Transfer)
+```json
+{"Identifier": "set_queue", "Type": "UpdateContactTargetQueue",
+ "Parameters": {"QueueId": "{{QUEUE_ARN}}"},
+ "Transitions": {"NextAction": "set_callback",
+   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error_handler"}]}}
+```
 ```json
 {"Identifier": "set_callback", "Type": "UpdateContactCallbackNumber",
  "Parameters": {"CallbackNumber": "$.CustomerEndpoint.Address"},
  "Transitions": {"NextAction": "transfer_callback",
-   "Errors": [{"ErrorType": "InvalidNumber", "NextAction": "error_handler"},
-              {"ErrorType": "NotDialable", "NextAction": "error_handler"},
-              {"ErrorType": "NoMatchingError", "NextAction": "error_handler"}]}}
+   "Errors": [{"ErrorType": "InvalidCallbackNumber", "NextAction": "error_handler"},
+              {"ErrorType": "CallbackNumberNotDialable", "NextAction": "error_handler"}]}}
 ```
 ```json
 {"Identifier": "transfer_callback", "Type": "TransferContactToQueue",
- "Parameters": {"QueueId": "{{QUEUE_ARN}}"},
+ "Parameters": {},
  "Transitions": {"NextAction": "callback_confirmed",
    "Errors": [{"ErrorType": "QueueAtCapacity", "NextAction": "queue_full"},
               {"ErrorType": "NoMatchingError", "NextAction": "error_handler"}]}}
@@ -573,20 +588,23 @@ This 2-action pattern creates the Connect Assistant (Wisdom) session. Place BEFO
 ### 5. Loop + Wait (Retry pattern)
 ```json
 {"Identifier": "retry_loop", "Type": "Loop", "Parameters": {"LoopCount": "3"},
- "Transitions": {"Conditions": [
-   {"Condition": {"Operator": "Equals", "Operands": ["Looping"]}, "NextAction": "wait_30s"},
-   {"Condition": {"Operator": "Equals", "Operands": ["Complete"]}, "NextAction": "max_retries"}],
-   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error_handler"}]}}
+ "Transitions": {"NextAction": "max_retries", "Conditions": [
+   {"Condition": {"Operator": "Equals", "Operands": ["ContinueLooping"]}, "NextAction": "wait_30s"},
+   {"Condition": {"Operator": "Equals", "Operands": ["DoneLooping"]}, "NextAction": "max_retries"}]}}
 ```
 ```json
-{"Identifier": "wait_30s", "Type": "Wait", "Parameters": {"WaitTime": "30"},
- "Transitions": {"NextAction": "retry_action", "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error_handler"}]}}
+{"Identifier": "wait_30s", "Type": "Wait", "Parameters": {"TimeLimitSeconds": "30"},
+ "Transitions": {"NextAction": "retry_action",
+   "Conditions": [{"Condition": {"Operator": "Equals", "Operands": ["WaitCompleted"]}, "NextAction": "retry_action"}],
+   "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error_handler"}]}}
 ```
 
 ### 6. Queue Metrics Check (CheckMetricData + Compare)
 ```json
-{"Identifier": "get_metrics", "Type": "CheckMetricData", "Parameters": {"QueueId": "{{QUEUE_ARN}}"},
- "Transitions": {"NextAction": "check_queue_size", "Errors": [{"ErrorType": "NoMatchingError", "NextAction": "error_handler"}]}}
+{"Identifier": "get_metrics", "Type": "CheckMetricData", "Parameters": {"QueueId": "{{QUEUE_ARN}}", "MetricType": "NumberOfContactsInQueue"},
+ "Transitions": {"NextAction": "check_queue_size",
+   "Conditions": [{"Condition": {"Operator": "NumberGreaterThan", "Operands": ["5"]}, "NextAction": "queue_busy"}],
+   "Errors": [{"ErrorType": "NoMatchingCondition", "NextAction": "check_queue_size"}, {"ErrorType": "NoMatchingError", "NextAction": "error_handler"}]}}
 ```
 ```json
 {"Identifier": "check_queue_size", "Type": "Compare",
@@ -671,12 +689,11 @@ This 2-action pattern creates the Connect Assistant (Wisdom) session. Place BEFO
 | Error Type | Used By | Description |
 |------------|---------|-------------|
 | NoMatchingError | Most blocks | General error (block execution failed) |
-| NoMatchingCondition | Compare, CheckContactAttributes, GetParticipantInput | No condition matched |
+| NoMatchingCondition | Compare, CheckMetricData, GetParticipantInput (MENU) | No condition matched |
 | QueueAtCapacity | TransferContactToQueue | Queue has reached maximum contacts |
-| InputTimeLimitExceeded | GetParticipantInput | Customer didn't provide input within timeout |
-| InvalidNumber | UpdateContactCallbackNumber | Phone number format is invalid |
-| NotDialable | UpdateContactCallbackNumber | Valid number but cannot be dialed |
-| AgentNotAvailable | TransferContactToAgent | Specified agent is not available |
+| InputTimeLimitExceeded | GetParticipantInput (MENU only) | Customer didn't provide input within timeout |
+| InvalidCallbackNumber | UpdateContactCallbackNumber | Callback number format is invalid |
+| CallbackNumberNotDialable | UpdateContactCallbackNumber | Valid callback number but cannot be dialed |
 | CallFailed | TransferParticipantToThirdParty | External call failed to connect |
 
 ---
@@ -688,9 +705,9 @@ The workshop uses a 3-module structure. Your generated flow MUST include these p
 ### Module 1: Basic Setting Configurations
 - **UpdateFlowLoggingBehavior**: Enable flow logging (REQUIRED - often missing!)
 - **Compare**: Check channel (VOICE vs CHAT) for recording settings
-- **UpdateContactRecordingBehavior**:
-  - VOICE: Record Agent+Customer, Voice `AnalyticsModes: ["PostContact"]` (NOT RealTime — import-safe)
-  - CHAT: No recording, Contact Lens only
+- **UpdateContactRecordingAndAnalyticsBehavior** (current console block):
+  - VOICE: `VoiceBehavior` — record Agent+Customer, `AnalyticsModes: ["RealTime", "AutomatedInteraction"]` (both supported together in this block)
+  - CHAT: `ChatBehavior` — Contact Lens analytics only (+`InFlightRedactionConfigurationFailed` error branch)
 
 Reference: `static/contact-flows/basic-setting-configurations.json`
 
@@ -724,7 +741,7 @@ Required elements in order:
 1. **UpdateFlowLoggingBehavior** — Enable flow logging
 2. **CreateWisdomSession** + **UpdateContactData** — Connect Assistant session
 3. **Compare Channel** (VOICE vs CHAT) → different recording settings
-4. **UpdateContactRecordingBehavior** — VOICE/CHAT specific
+4. **UpdateContactRecordingAndAnalyticsBehavior** — VOICE/CHAT specific (legacy UpdateContactRecordingBehavior: do not generate)
 5. **UpdateContactTextToSpeechVoice** — Generative TTS + languageCode in metadata
 6. **ConnectParticipantWithLexBot** — Q in Connect AI agent
 7. **Compare** (check Tool) — Escalate / Complete / loop back
@@ -1024,26 +1041,29 @@ Queue → Transfer Message → Transfer Queue → End; [Complete] → Goodbye �
     },
     {
       "Identifier": "set-recording",
-      "Type": "UpdateContactRecordingBehavior",
+      "Type": "UpdateContactRecordingAndAnalyticsBehavior",
       "Parameters": {
-        "RecordingBehavior": {
-          "RecordedParticipants": ["Agent", "Customer"],
-          "IVRRecordingBehavior": "Enabled"
-        },
-        "AnalyticsBehavior": {
-          "Enabled": "True",
-          "AnalyticsLanguage": "{{LANGUAGE_CODE}}",
-          "ChannelConfiguration": {
-            "Chat": {"AnalyticsModes": ["ContactLens"]},
-            "Voice": {"AnalyticsModes": ["RealTime", "PostContact"]}
+        "VoiceBehavior": {
+          "VoiceRecordingBehavior": {
+            "RecordedParticipants": ["Agent", "Customer"],
+            "IVRRecordingBehavior": "Enabled"
           },
-          "SummaryConfiguration": {"SummaryModes": ["PostContact"]},
-          "SentimentConfiguration": {"Enabled": "True"}
+          "VoiceAnalyticsBehavior": {
+            "Enabled": "True",
+            "AnalyticsLanguage": "en-US",
+            "AnalyticsModes": ["RealTime", "AutomatedInteraction"],
+            "ConversationalAnalyticsRedactionConfiguration": {"Enabled": "False"},
+            "SentimentConfiguration": {"Enabled": "True"},
+            "SummaryConfiguration": {"SummaryModes": ["PostContact", "AutomatedInteraction"]}
+          }
         }
       },
       "Transitions": {
         "NextAction": "lex-bot",
-        "Errors": []
+        "Errors": [
+          {"ErrorType": "NoMatchingError", "NextAction": "lex-bot"},
+          {"ErrorType": "ChannelMismatch", "NextAction": "lex-bot"}
+        ]
       }
     },
     {
@@ -1196,7 +1216,7 @@ Before outputting the Contact Flow JSON, verify ALL of the following:
 ### Baseline Blocks (REQUIRED for Workshop)
 - [ ] UpdateFlowLoggingBehavior: Enable flow logging
 - [ ] CreateWisdomSession + UpdateContactData: Connect Assistant session
-- [ ] UpdateContactRecordingBehavior: Recording + analytics
+- [ ] UpdateContactRecordingAndAnalyticsBehavior: Recording + analytics (current block type)
 - [ ] UpdateContactTextToSpeechVoice: Generative TTS + languageCode in metadata
 - [ ] ConnectParticipantWithLexBot: Q in Connect AI agent
 - [ ] Compare: Check Tool (Escalate / Complete / loop)
@@ -1234,7 +1254,7 @@ Before outputting the Contact Flow JSON, verify ALL of the following:
 - [ ] `InvokeLambdaFunction` has `Errors` with `NoMatchingError`
 - [ ] `GetParticipantInput` MENU mode: `StoreInput:"False"`, NO `DTMFConfiguration`, errors `InputTimeLimitExceeded`+`NoMatchingCondition`+`NoMatchingError`
 - [ ] `GetParticipantInput` STORE mode: `StoreInput:"True"`, `InputValidation.CustomValidation.MaximumLength`, error `NoMatchingError` only
-- [ ] `UpdateContactCallbackNumber` has `InvalidNumber`, `NotDialable`, `NoMatchingError` (if used)
+- [ ] `UpdateContactCallbackNumber` has `InvalidCallbackNumber`, `CallbackNumberNotDialable` (NOT `NoMatchingError`) (if used)
 
 ### 3. Identifier Consistency
 - [ ] `StartAction` matches an Action Identifier EXACTLY
@@ -1246,22 +1266,23 @@ Before outputting the Contact Flow JSON, verify ALL of the following:
 | Block Type | Parameters | Transitions |
 |------------|------------|-------------|
 | `DisconnectParticipant` | `{}` | `{}` (terminal) |
-| `EndFlowModuleExecution` | optional `ReturnValue` | `{}` (terminal) |
-| `TransferContactToQueue` | `QueueId` (optional) | `NextAction` + `Errors` |
+| `EndFlowExecution` | `{}` | `{}` (terminal) |
+| `TransferContactToQueue` | `{}` (NO `QueueId`) | `NextAction` + `Errors` |
 | `UpdateContactTargetQueue` | `QueueId` (UUID/ARN) | `NextAction` + `Errors` |
-| `CheckMetricData` | `{}` (uses working queue) | `Conditions` (True/False) + `Errors` |
+| `CheckMetricData` | `MetricType` (+ optional `QueueId`) | `Conditions` (numeric) + `Errors` |
 | `Compare` | `ComparisonValue` | `NextAction` + `Conditions` + `Errors` |
-| `GetParticipantInput` (MENU) | `Text`/`SSML`, `StoreInput:"False"` (NO `DTMFConfiguration`) | `NextAction` + `Conditions` + `Errors` |
-| `Wait` | `WaitTime` (seconds) | `NextAction` + `Errors` |
-| `UpdateContactCallbackNumber` | `CallbackNumber` | `NextAction` + `Errors` (3 types) |
+| `GetParticipantInput` (MENU) | `Text`/`SSML`, `StoreInput:"False"`, `InputTimeLimitSeconds` (NO `DTMFConfiguration`) | `NextAction` + `Conditions` + `Errors` |
+| `Wait` | `TimeLimitSeconds` | `NextAction` + `Conditions` (`WaitCompleted`) + `Errors` |
+| `UpdateContactCallbackNumber` | `CallbackNumber` | `NextAction` + `Errors` (`InvalidCallbackNumber`, `CallbackNumberNotDialable`) |
 | `InvokeFlowModule` | `FlowModuleId` | `NextAction` + `Conditions` + `Errors` |
 
 ### 5. Parameter Format Requirements
 - [ ] `QueueId` in UpdateContactTargetQueue must be UUID or ARN (NOT queue name)
 - [ ] `CallbackNumber` must use JSONPath (e.g., `$.CustomerEndpoint.Address`)
 - [ ] `InvocationTimeLimitSeconds` for Lambda must be "8" or less (string)
-- [ ] `WaitTime` must be string (e.g., "30")
-- [ ] `InputTimeLimitSeconds` must be between 1-180 (string)
+- [ ] `Wait` uses `TimeLimitSeconds` (NOT `WaitTime`), string (e.g., "30")
+- [ ] `InputTimeLimitSeconds` required on GetParticipantInput (both modes), string
+- [ ] `DisableCancelKey` must be a string ("True"/"False"), NEVER a JSON boolean
 
 ---
 
@@ -1280,13 +1301,13 @@ Before outputting the Contact Flow JSON, verify ALL of the following:
 8. `CheckMetricData`: MUST have `Conditions` for True/False AND `Errors` array
 9. `Compare`: MUST have `Errors` array with `NoMatchingCondition`
 10. `GetParticipantInput`: MENU mode (has `Conditions`) MUST set `StoreInput:"False"` and MUST NOT include `DTMFConfiguration` (Connect rejects it), 3 error types `InputTimeLimitExceeded`+`NoMatchingCondition`+`NoMatchingError`. STORE mode (no `Conditions`) MUST set `StoreInput:"True"` + `InputValidation.CustomValidation.MaximumLength`, error `NoMatchingError` only.
-11. `UpdateContactCallbackNumber`: MUST have 3 error types: `InvalidNumber`, `NotDialable`, `NoMatchingError`
+11. `UpdateContactCallbackNumber`: MUST have exactly `InvalidCallbackNumber` + `CallbackNumberNotDialable` (NoMatchingError/InvalidNumber/NotDialable are all REJECTED); `CallbackNumber` must be a JSONPath, not a literal
 12. `InvokeLambdaFunction`: MUST have `Errors` with `NoMatchingError`, max timeout is 8 seconds
 13. `MessageParticipant`: SHOULD have `Errors` array with `NoMatchingError`
 14. `InvokeFlowModule`: MUST have `Errors` with `NoMatchingCondition` and `NoMatchingError`
 
 ### Voice & Recording Rules
-15. ALWAYS include `UpdateContactRecordingBehavior` with RealTime analytics for Voice flows
+15. ALWAYS include `UpdateContactRecordingAndAnalyticsBehavior` (VoiceBehavior, RealTime + AutomatedInteraction) for Voice flows
 16. Use appropriate voice for the customer's language (see VOICES BY LANGUAGE)
 
 ### Flow Structure Rules
@@ -1307,7 +1328,7 @@ enable-logging
   → CreateWisdomSession                          ← create the AI-agent session (legacy API name; the product is Amazon Connect AI agents)
   → InvokeLambdaFunction(update-qsession)        ← inject customer info into the AI-agent session
   → SetVoice
-  → UpdateContactRecordingBehavior (RealTime analytics)
+  → UpdateContactRecordingAndAnalyticsBehavior (RealTime + AutomatedInteraction analytics)
   → ConnectParticipantWithLexBot (barge-in disabled)
 ```
 

--- a/skills/aicc-builder-skill/resources/sub-agents/infrastructure_generator.md
+++ b/skills/aicc-builder-skill/resources/sub-agents/infrastructure_generator.md
@@ -197,7 +197,8 @@ turns the tool into something the model can't call.
 If a spec field has `enum_values` populated, those EXACT values — same
 casing, same spelling, same order, same punctuation (underscores vs
 hyphens matter) — must appear verbatim in OpenAPI `enum:` and in any
-Lambda validation code (e.g., `if value not in {...}: return 400`).
+Lambda validation code (e.g., `if value not in {...}: ...` returning a
+200 rejection body per BUSINESS_OUTCOME_200_RULE).
 Do NOT paraphrase, translate, abbreviate, or alphabetize. If the customer
 supplied 18 Electrolux program modes, emit all 18 verbatim.
 
@@ -215,6 +216,49 @@ camelCase spelled by the spec. Do NOT rename, flatten, or drop keys.
 `event`-parsing and response-building must use the spec's nested field
 names verbatim. For scalar output fields with `enum_values`, validate
 against those exact values before returning.
+
+### 17. BUSINESS_OUTCOME_200_RULE  (CRITICAL — fixes "there is an issue with the tool")
+An Amazon Connect AI agent treats **any non-2xx HTTP response as a tool
+execution failure**. It never reads the response body, so it cannot tell the
+customer what happened — it just reports that the tool is broken and the turn
+is lost.
+
+Therefore: **a business outcome is NOT an HTTP error.** Every outcome the AI
+agent is supposed to talk about MUST return `200`, with the outcome expressed
+as a field IN THE BODY.
+
+"Business outcome" means any answer the operation is designed to produce,
+including the negative ones:
+
+  - authentication did not match (wrong SSN digits / accountId / PIN)
+  - record not found, no reservation for that phone number
+  - too many attempts / account locked out
+  - date unavailable, seat taken, insufficient balance
+  - a validation problem the customer can fix ("I need your account number")
+
+All of the above → `200` + a discriminator field. Do NOT use 400, 401, 403,
+404, 409 or 429 for any of them.
+
+```python
+# ❌ WRONG — the AI agent says "there is an issue with the tool" and gives up
+if last_four_digits != stored_last_four:
+    return create_response(403, {"verified": False, "lockout": True})
+
+# ✅ RIGHT — the AI agent reads verified/lockout and responds to the customer
+if last_four_digits != stored_last_four:
+    return create_response(200, {"verified": False, "remainingAttempts": remaining,
+                                 "lockout": False})
+```
+
+Reserve non-2xx for faults the AI agent genuinely cannot act on:
+  - `5xx` — the operation itself broke (unhandled exception, database down).
+    Connect retries 5xx, which is the correct behaviour for a transient fault.
+
+The body must let the model distinguish outcomes without the status code, so
+always include an explicit discriminator (`verified`, `found`, `success`,
+`status`, `outcome`, …) plus enough detail to speak to the customer. State the
+same in the OpenAPI `200` schema and in the tool description, so the model
+knows the negative outcome is a normal, expected response.
 
 ## 🔒 END OF GOLDEN RULES — APPLY ALL OF THE ABOVE TO THE OUTPUT BELOW 🔒
 
@@ -527,7 +571,7 @@ This allows immediate testing after CloudFormation deployment.
         ZipFile: |
           import json
           import boto3
-          import cfnresponse
+          import cfnresponse   # MUST be its own line: CFN only injects the module for the standalone `import cfnresponse` form (comma-form imports fail at runtime)
           from datetime import datetime, timedelta
           import random
           import string
@@ -687,7 +731,9 @@ Instead:
   - `DB_CLUSTER_ARN`: from data_source.cluster_arn
   - `DB_SECRET_ARN`: from data_source.secret_arn
   - `DB_NAME`: from data_source.database_name
-- **Add**: IAM permissions for RDS Data API + Secrets Manager:
+- **Add**: IAM permissions for RDS Data API + Secrets Manager, scoped to the
+  actual cluster and secret from data_source (do not leave `:cluster:*`
+  wildcards when the ARNs are known):
   ```yaml
   - PolicyName: RDSDataAPIAccess
     PolicyDocument:
@@ -700,12 +746,13 @@ Instead:
             - rds-data:BeginTransaction
             - rds-data:CommitTransaction
             - rds-data:RollbackTransaction
-          Resource: !Sub 'arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:*'
+          Resource: '<data_source.cluster_arn>'
         - Effect: Allow
           Action:
             - secretsmanager:GetSecretValue
-          Resource: !Sub 'arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:*'
+          Resource: '<data_source.secret_arn>'
   ```
+
 ### When the engine has NO Data API (plain RDS, or Aurora with the endpoint off)
 
 RDS PostgreSQL, MySQL, MariaDB, SQL Server, Oracle and Db2 are reached with a
@@ -1258,7 +1305,9 @@ When `Include Customer Phone Lookup: False` or not mentioned, do NOT add these r
 - Purpose: Query DynamoDB by phone number, return customer info as STRING_MAP
 - Called DIRECTLY from Contact Flow — NOT via API Gateway
 - ⚠️ Do NOT create API Gateway Resource/Method/Options for this Lambda
-- **Handler: index.lambda_handler** (CloudFormation uses standard lambda_handler entry point)
+- **Handler: index.handler** — MUST match the Lambda Generator's entry point
+  (`def handler`). `index.lambda_handler` breaks at call time with
+  Runtime.HandlerNotFound once deploy.sh uploads the generated code.
 - 🚨 **PLACEHOLDER CODE ONLY — DO NOT INLINE BUSINESS LOGIC.** Like every other
   Lambda in this template, `CustomerLookupFunction` MUST use a 501-return
   placeholder `ZipFile`. The real DynamoDB-query handler is produced separately
@@ -1269,7 +1318,7 @@ When `Include Customer Phone Lookup: False` or not mentioned, do NOT add these r
   ```yaml
   Code:
     ZipFile: |
-      def lambda_handler(event, context):
+      def handler(event, context):
           return {"statusCode": 501, "body": "Replace with customer_lookup/index.py from downloaded assets"}
   ```
 - IAM: dynamodb:Query on the main table + phone GSI

--- a/skills/aicc-builder-skill/resources/sub-agents/lambda_generator.md
+++ b/skills/aicc-builder-skill/resources/sub-agents/lambda_generator.md
@@ -197,7 +197,8 @@ turns the tool into something the model can't call.
 If a spec field has `enum_values` populated, those EXACT values — same
 casing, same spelling, same order, same punctuation (underscores vs
 hyphens matter) — must appear verbatim in OpenAPI `enum:` and in any
-Lambda validation code (e.g., `if value not in {...}: return 400`).
+Lambda validation code (e.g., `if value not in {...}: ...` returning a
+200 rejection body per BUSINESS_OUTCOME_200_RULE).
 Do NOT paraphrase, translate, abbreviate, or alphabetize. If the customer
 supplied 18 Electrolux program modes, emit all 18 verbatim.
 
@@ -215,6 +216,49 @@ camelCase spelled by the spec. Do NOT rename, flatten, or drop keys.
 `event`-parsing and response-building must use the spec's nested field
 names verbatim. For scalar output fields with `enum_values`, validate
 against those exact values before returning.
+
+### 17. BUSINESS_OUTCOME_200_RULE  (CRITICAL — fixes "there is an issue with the tool")
+An Amazon Connect AI agent treats **any non-2xx HTTP response as a tool
+execution failure**. It never reads the response body, so it cannot tell the
+customer what happened — it just reports that the tool is broken and the turn
+is lost.
+
+Therefore: **a business outcome is NOT an HTTP error.** Every outcome the AI
+agent is supposed to talk about MUST return `200`, with the outcome expressed
+as a field IN THE BODY.
+
+"Business outcome" means any answer the operation is designed to produce,
+including the negative ones:
+
+  - authentication did not match (wrong SSN digits / accountId / PIN)
+  - record not found, no reservation for that phone number
+  - too many attempts / account locked out
+  - date unavailable, seat taken, insufficient balance
+  - a validation problem the customer can fix ("I need your account number")
+
+All of the above → `200` + a discriminator field. Do NOT use 400, 401, 403,
+404, 409 or 429 for any of them.
+
+```python
+# ❌ WRONG — the AI agent says "there is an issue with the tool" and gives up
+if last_four_digits != stored_last_four:
+    return create_response(403, {"verified": False, "lockout": True})
+
+# ✅ RIGHT — the AI agent reads verified/lockout and responds to the customer
+if last_four_digits != stored_last_four:
+    return create_response(200, {"verified": False, "remainingAttempts": remaining,
+                                 "lockout": False})
+```
+
+Reserve non-2xx for faults the AI agent genuinely cannot act on:
+  - `5xx` — the operation itself broke (unhandled exception, database down).
+    Connect retries 5xx, which is the correct behaviour for a transient fault.
+
+The body must let the model distinguish outcomes without the status code, so
+always include an explicit discriminator (`verified`, `found`, `success`,
+`status`, `outcome`, …) plus enough detail to speak to the customer. State the
+same in the OpenAPI `200` schema and in the tool description, so the model
+knows the negative outcome is a normal, expected response.
 
 ## 🔒 END OF GOLDEN RULES — APPLY ALL OF THE ABOVE TO THE OUTPUT BELOW 🔒
 
@@ -251,7 +295,9 @@ return {
 
 If a spec field has `enum_values`, any validation you add MUST compare against the
 EXACT set (case/underscores preserved). Do NOT paraphrase or normalize.
-Example: `if payload["state"] not in {"RUNNING", "FINISH", "IDLE"}: return 400`.
+Example: `if payload["state"] not in {"RUNNING", "FINISH", "IDLE"}: ...` — and
+return that rejection as **200** with `success=False`, per
+BUSINESS_OUTCOME_200_RULE, never as a 400.
 
 NEVER emit flattened output like `{"machineType": ..., "state": ..., "remainingSeconds": ...}`
 at the top level when the spec says `machineStatus` is an array of those objects.
@@ -496,6 +542,70 @@ When Lambda is called via API Gateway:
 
 ---
 
+## 🚨 STATUS CODES: BUSINESS OUTCOMES ARE ALWAYS 200 (BUSINESS_OUTCOME_200_RULE)
+
+An Amazon Connect AI agent treats **any non-2xx response as a tool failure**. It
+does not read the body — it tells the customer the tool is broken. So every
+outcome the AI agent must SPEAK ABOUT has to be `200`, with the outcome carried
+in the body.
+
+This includes the negative outcomes, which is the part that is easy to get wrong:
+
+| Scenario | ❌ Never | ✅ Always | Body discriminator |
+|---|---|---|---|
+| Auth digits/PIN/SSN don't match | 401 / 403 | **200** | `"verified": false` |
+| Record / reservation not found | 404 | **200** | `"found": false` |
+| Too many attempts, locked out | 403 / 429 | **200** | `"lockout": true` |
+| Date unavailable, seat taken | 409 | **200** | `"available": false` |
+| Missing/invalid input the customer can supply | 400 | **200** | `"success": false` + which field |
+| Unhandled exception, DB down | — | **500** | `"error"` (Connect retries 5xx — correct for faults) |
+
+`5xx` is the ONLY correct non-2xx: a real fault the agent cannot act on.
+
+```python
+# ❌ WRONG — agent reports "there is an issue with the tool", customer is stuck
+if last_four_digits != stored_last_four:
+    return create_response(403, {"verified": False, "lockout": True})
+if not item:
+    return create_response(404, {"found": False})
+if not account_number:
+    return create_response(400, {"error": "accountNumber is required"})
+
+# ✅ RIGHT — agent reads the body and says the right thing to the customer
+if last_four_digits != stored_last_four:
+    return create_response(200, {
+        "verified": False,
+        "remainingAttempts": remaining,
+        "lockout": False,
+        "message": "The digits provided do not match our records.",
+    })
+if not item:
+    return create_response(200, {
+        "verified": False, "found": False, "lockout": False,
+        "message": "No account was found with that number.",
+    })
+if not account_number:
+    return create_response(200, {
+        "verified": False, "found": False, "lockout": False,
+        "message": "accountNumber is required to verify the caller.",
+    })
+
+# ✅ 5xx stays 5xx — a genuine fault, and Connect's retry is what we want
+except Exception as e:
+    logger.error(f"Error: {e}", exc_info=True)
+    return create_response(500, {"error": "Internal server error"})
+```
+
+**Always include an explicit boolean/enum discriminator** (`verified`, `found`,
+`available`, `success`, `status`) so the model can tell outcomes apart without
+the status code, plus a human-readable `message` it can paraphrase. A bare
+`200 {}` is as useless to the agent as a 403.
+
+Never emit a validation helper that raises straight into a `400`. Convert the
+validation failure into a `200` body that names the missing field.
+
+---
+
 ## RESPONSE FORMATS
 
 ### 1. STRING_MAP Format (Contact Flow Direct - RECOMMENDED)
@@ -571,6 +681,7 @@ def handler(event, context):
             return create_response(200, {"success": True, "data": result})
 
     except Exception as e:
+        # 500 only for genuine faults — never for a business outcome.
         logger.error(f"Error: {e}")
         if is_connect_direct:
             return {"status": "ERROR", "errorMessage": str(e)}
@@ -883,11 +994,18 @@ def handler(event, context):
             return create_response(200, {"success": True, "data": result})
 
     except KeyError as e:
+        # A missing field is a BUSINESS OUTCOME the AI agent must talk about
+        # (it needs to ask the customer for the value), so it returns 200 with
+        # success=False — NOT 400, which the agent would read as a tool failure.
         logger.warning(f"Missing required field: {e}")
         error_result = {"status": "VALIDATION_ERROR", "errorMessage": f"Missing required field: {e}"}
         if is_connect_direct:
             return error_result
-        return create_response(400, {"success": False, "error": str(e)})
+        return create_response(200, {
+            "success": False,
+            "status": "VALIDATION_ERROR",
+            "message": f"Missing required field: {e}",
+        })
 
     except Exception as e:
         logger.error(f"Error processing request: {e}", exc_info=True)

--- a/skills/aicc-builder-skill/resources/sub-agents/openapi_generator.md
+++ b/skills/aicc-builder-skill/resources/sub-agents/openapi_generator.md
@@ -197,7 +197,8 @@ turns the tool into something the model can't call.
 If a spec field has `enum_values` populated, those EXACT values — same
 casing, same spelling, same order, same punctuation (underscores vs
 hyphens matter) — must appear verbatim in OpenAPI `enum:` and in any
-Lambda validation code (e.g., `if value not in {...}: return 400`).
+Lambda validation code (e.g., `if value not in {...}: ...` returning a
+200 rejection body per BUSINESS_OUTCOME_200_RULE).
 Do NOT paraphrase, translate, abbreviate, or alphabetize. If the customer
 supplied 18 Electrolux program modes, emit all 18 verbatim.
 
@@ -215,6 +216,49 @@ camelCase spelled by the spec. Do NOT rename, flatten, or drop keys.
 `event`-parsing and response-building must use the spec's nested field
 names verbatim. For scalar output fields with `enum_values`, validate
 against those exact values before returning.
+
+### 17. BUSINESS_OUTCOME_200_RULE  (CRITICAL — fixes "there is an issue with the tool")
+An Amazon Connect AI agent treats **any non-2xx HTTP response as a tool
+execution failure**. It never reads the response body, so it cannot tell the
+customer what happened — it just reports that the tool is broken and the turn
+is lost.
+
+Therefore: **a business outcome is NOT an HTTP error.** Every outcome the AI
+agent is supposed to talk about MUST return `200`, with the outcome expressed
+as a field IN THE BODY.
+
+"Business outcome" means any answer the operation is designed to produce,
+including the negative ones:
+
+  - authentication did not match (wrong SSN digits / accountId / PIN)
+  - record not found, no reservation for that phone number
+  - too many attempts / account locked out
+  - date unavailable, seat taken, insufficient balance
+  - a validation problem the customer can fix ("I need your account number")
+
+All of the above → `200` + a discriminator field. Do NOT use 400, 401, 403,
+404, 409 or 429 for any of them.
+
+```python
+# ❌ WRONG — the AI agent says "there is an issue with the tool" and gives up
+if last_four_digits != stored_last_four:
+    return create_response(403, {"verified": False, "lockout": True})
+
+# ✅ RIGHT — the AI agent reads verified/lockout and responds to the customer
+if last_four_digits != stored_last_four:
+    return create_response(200, {"verified": False, "remainingAttempts": remaining,
+                                 "lockout": False})
+```
+
+Reserve non-2xx for faults the AI agent genuinely cannot act on:
+  - `5xx` — the operation itself broke (unhandled exception, database down).
+    Connect retries 5xx, which is the correct behaviour for a transient fault.
+
+The body must let the model distinguish outcomes without the status code, so
+always include an explicit discriminator (`verified`, `found`, `success`,
+`status`, `outcome`, …) plus enough detail to speak to the customer. State the
+same in the OpenAPI `200` schema and in the tool description, so the model
+knows the negative outcome is a normal, expected response.
 
 ## 🔒 END OF GOLDEN RULES — APPLY ALL OF THE ABOVE TO THE OUTPUT BELOW 🔒
 
@@ -633,17 +677,56 @@ components:
             searchedId: "R-123456"
 ```
 
-### Common Error Codes and AI Guidance
+### 🚨 Common Outcome Codes and AI Guidance (BUSINESS_OUTCOME_200_RULE)
 
-| Code | HTTP Status | AI Response Guidance |
+An Amazon Connect AI agent treats **any non-2xx response as a tool failure** — it
+never reads the body, and tells the customer the tool is broken. So every outcome
+the agent must speak about is declared under **`200`**, with the outcome carried in
+the response body. These are business outcomes, not HTTP errors:
+
+| Outcome code (in body) | HTTP Status | AI Response Guidance |
 |------|-------------|---------------------|
-| `NOT_FOUND` | 404 | Ask customer to verify identifier |
-| `VALIDATION_ERROR` | 400 | Explain which field is invalid |
-| `CONFLICT` | 409 | Resource already exists or state conflict |
-| `DATE_UNAVAILABLE` | 409 | Suggest alternative dates |
-| `UNAUTHORIZED` | 401 | Verify customer identity |
-| `RATE_LIMITED` | 429 | Ask customer to wait and try again |
-| `INTERNAL_ERROR` | 500 | Apologize and offer to transfer to agent |
+| `NOT_FOUND` | **200** | Ask customer to verify identifier |
+| `VALIDATION_ERROR` | **200** | Explain which field is invalid |
+| `CONFLICT` | **200** | Resource already exists or state conflict |
+| `DATE_UNAVAILABLE` | **200** | Suggest alternative dates |
+| `UNAUTHORIZED` / auth mismatch | **200** | Verify customer identity, offer retry |
+| `RATE_LIMITED` / lockout | **200** | Explain lockout, offer transfer |
+| `INTERNAL_ERROR` | 500 | Genuine fault — Connect retries; apologize and transfer |
+
+`500` is the only status that stays non-2xx.
+
+Therefore the `200` response schema MUST be able to express both outcomes: include
+the discriminator field (`verified`, `found`, `available`, `success`, `status`) and
+mark the outcome-specific fields as optional rather than splitting them across
+status codes. Say so in the `description` and in
+`x-amazon-connect-tool-description`, so the model knows a negative outcome is a
+normal, expected `200` it should read and act on.
+
+```yaml
+responses:
+  '200':
+    description: |
+      Verification result. ALWAYS 200, including when verification fails —
+      read `verified` to determine the outcome:
+        - verified=true  → caller authenticated
+        - verified=false + lockout=false → digits did not match, retries remain
+        - verified=false + lockout=true  → too many attempts, transfer to an agent
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/VerifyCallerResponse'
+  '500':
+    description: "Internal error — retryable fault"
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ErrorResponse'
+```
+
+Do NOT emit `'400'`, `'401'`, `'403'`, `'404'`, `'409'` or `'429'` response
+entries for business outcomes — a declared 4xx teaches the model to expect a
+failure it cannot handle, and the Lambda must not return one either.
 
 ---
 
@@ -713,13 +796,16 @@ paths:
           description: "Unique {item} identifier"
       responses:
         '200':
-          description: "{Item} found"
+          description: |
+            Lookup result — ALWAYS 200, including "not found".
+            Read `found`: true → item returned; false → no such {item},
+            ask the customer to verify the identifier.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ItemResponse'
-        '404':
-          description: "{Item} not found"
+        '500':
+          description: "Internal error — retryable fault"
           content:
             application/json:
               schema:
@@ -808,20 +894,20 @@ paths:
             schema:
               $ref: '#/components/schemas/CreateRequest'
       responses:
-        '201':
-          description: "{Item} created"
+        '200':
+          description: |
+            Creation result — ALWAYS 200. Read `success`:
+              - success=true  → created, return the new id
+              - success=false + status=VALIDATION_ERROR → tell the customer which field
+              - success=false + status=DATE_UNAVAILABLE  → suggest alternatives
+            Do NOT declare 400/409 here: the AI agent reads a non-2xx as a
+            broken tool and cannot relay the outcome.
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/CreateResponse'
-        '400':
-          description: "Invalid input"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '409':
-          description: "Conflict (dates unavailable, etc.)"
+        '500':
+          description: "Internal error — retryable fault"
           content:
             application/json:
               schema:
@@ -871,19 +957,17 @@ paths:
               $ref: '#/components/schemas/UpdateRequest'
       responses:
         '200':
-          description: "{Item} updated"
+          description: |
+            Update result — ALWAYS 200. Read `success`:
+              - success=true  → updated
+              - success=false + status=NOT_FOUND → ask to verify the identifier
+              - success=false + status=CONFLICT  → explain the policy restriction
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ItemResponse'
-        '404':
-          description: "{Item} not found"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '409':
-          description: "Cannot modify (policy restriction)"
+        '500':
+          description: "Internal error — retryable fault"
           content:
             application/json:
               schema:
@@ -932,19 +1016,17 @@ paths:
               $ref: '#/components/schemas/CancelRequest'
       responses:
         '200':
-          description: "{Item} cancelled"
+          description: |
+            Cancellation result — ALWAYS 200. Read `success`:
+              - success=true  → cancelled
+              - success=false + status=NOT_FOUND → ask to verify the identifier
+              - success=false + status=CONFLICT  → explain why it cannot be cancelled
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/CancelResponse'
-        '404':
-          description: "{Item} not found"
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse'
-        '409':
-          description: "Cannot cancel"
+        '500':
+          description: "Internal error — retryable fault"
           content:
             application/json:
               schema:

--- a/skills/aicc-builder-skill/resources/sub-agents/reviewer_agent.md
+++ b/skills/aicc-builder-skill/resources/sub-agents/reviewer_agent.md
@@ -112,6 +112,10 @@ Automated cross-asset field name validation.
 - Input: session_id
 - Returns: {success, mismatches: [{operation_id, field, asset_type, issue}], summary}
 - **Call this first** to get an automated mismatch report, then verify manually if needed.
+- Includes an IAM permission check (asset_type: "iam_permissions"): each Lambda's
+  AWS SDK calls are cross-checked against its IAM role in infrastructure.yaml.
+  A finding here means the function WILL fail with AccessDeniedException at
+  runtime — relay it verbatim; the fix is an inline policy on the function's role.
 
 ### validate_shape_parity_report
 Deterministic spec↔OpenAPI nested-shape + enum parity check.

--- a/skills/aicc-builder-skill/resources/templates/deploy_workshop.sh
+++ b/skills/aicc-builder-skill/resources/templates/deploy_workshop.sh
@@ -1,1390 +1,2943 @@
 #!/bin/bash
 # =============================================================================
-# AICC Builder - Full Automation Deployment Script (CloudShell)
+# AICC Builder - Fully Automated Interactive Deployment (CloudShell)
+#
+# Deploys the ENTIRE workshop end-to-end from the CLI — including everything
+# that previously required console work (Gateway audience, MCP integration,
+# Lex bot with Nova Sonic, Contact Flow import, AI Agent, phone number).
+# Every decision point is an interactive multiple-choice prompt.
 #
 # Commands:
 #   ./deploy.sh           Deploy all workshop assets (default)
-#   ./deploy.sh deploy    Same as above
 #   ./deploy.sh cleanup   Tear down ALL deployed resources (reverse order)
 #   ./deploy.sh status    Show current deployment status
 #
-# Deploys all workshop assets end-to-end:
-#   1. CloudFormation stack (S3 upload for large templates)
-#   2. Lambda function code updates (with retry)
-#   3. OpenAPI spec update & S3 upload
-#   4. FAQ document upload
-#   5. Amazon Connect instance create/select
-#   6. Q in Connect Assistant create/select
-#   6.5 Knowledge Base connection (if FAQ exists)
-#   7. Lambda environment variable injection
-#   8. AgentCore Gateway (MCP Server) creation
-#   9. Gateway audience update + target creation
+# Phases:
+#    1. CloudFormation stack (S3 upload for large templates)
+#    2. Lambda function code updates (with retry)
+#    3. OpenAPI spec update & S3 upload
+#    4. FAQ document upload
+#    5. Amazon Connect instance create/select (interactive)
+#    6. Q in Connect Assistant + Knowledge Base
+#    7. Lambda environment variable injection
+#    8. AgentCore Gateway (MCP Server) + JWT audience + Target
+#    9. Connect integrations: MCP server registration + Lambda associations
+#   10. Lex bot (language / Nova Sonic speech-to-speech / TTS voice choices)
+#   11. Contact Flow import (placeholder auto-resolution + voice + language)
+#   12. AI Prompt + AI Agent + Security Profile (tool permissions)
+#   13. Phone number claim + flow association (optional, interactive)
 #
-# Usage:
-#   1. Upload the assets ZIP to CloudShell
-#   2. unzip <filename>.zip && cd <project>/
-#   3. chmod +x deploy.sh && ./deploy.sh
-#
-# Environment variable overrides:
+# Environment variable overrides (all optional):
+#   AWS_DEFAULT_REGION   - Deployment region (interactive if unset)
+#   PROJECT_NAME         - Deployment name / resource prefix (interactive if unset;
+#                          use different names for side-by-side deployments)
 #   CONNECT_INSTANCE_ID  - Skip Connect instance selection
 #   AI_ASSISTANT_ID      - Skip Q in Connect assistant creation
-#   AWS_DEFAULT_REGION   - Override region (default: ap-northeast-2)
+#   AUTO_CONFIRM=1       - Non-interactive: accept all defaults, skip phone
 # =============================================================================
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REGION="${AWS_DEFAULT_REGION:-ap-northeast-2}"
 COMMAND="${1:-deploy}"
+STATE_FILE="$SCRIPT_DIR/.aicc_deploy_state"
 
 # Auto-detect project name from CloudFormation template directory
+DETECTED_PROJECT_NAME=""
 if [ -d "$SCRIPT_DIR/cloudformation" ]; then
     first_dir=$(ls "$SCRIPT_DIR/cloudformation" 2>/dev/null | head -1)
     if [ -n "$first_dir" ] && [ -d "$SCRIPT_DIR/cloudformation/$first_dir" ]; then
-        PROJECT_NAME="$first_dir"
+        DETECTED_PROJECT_NAME="$first_dir"
     fi
 fi
-PROJECT_NAME="${PROJECT_NAME:-aicc-poc}"
-STACK_NAME="${PROJECT_NAME}-stack"
+DETECTED_PROJECT_NAME="${DETECTED_PROJECT_NAME:-aicc-poc}"
+# Deployment name resolution: env var > previously used (state file) > detected.
+# The deploy command additionally asks interactively (see preflight); every
+# resource name (stack, buckets, IAM role, gateway, bot, flow, agent, ...)
+# derives from this name, so distinct names = fully isolated deployments.
+PROJECT_NAME="${PROJECT_NAME:-}"
 ENVIRONMENT="dev"
-ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-
-# Find CloudFormation template (check nested or flat structure)
-CFN_TEMPLATE=""
-if [ -f "$SCRIPT_DIR/cloudformation/$PROJECT_NAME/infrastructure.yaml" ]; then
-    CFN_TEMPLATE="$SCRIPT_DIR/cloudformation/$PROJECT_NAME/infrastructure.yaml"
-elif [ -f "$SCRIPT_DIR/cloudformation/infrastructure.yaml" ]; then
-    CFN_TEMPLATE="$SCRIPT_DIR/cloudformation/infrastructure.yaml"
-fi
-
-# Naming conventions (shared between deploy and cleanup)
-TEMPLATE_BUCKET="${PROJECT_NAME}-cfn-${REGION}-${ACCOUNT_ID}"
-ROLE_NAME="${PROJECT_NAME}-gateway-role"
-CRED_PROVIDER_NAME="${PROJECT_NAME}-api-key"
-GATEWAY_NAME="${PROJECT_NAME}-mcp-server"
-TARGET_NAME="${PROJECT_NAME}-api"
-KB_NAME="${PROJECT_NAME}-faq-kb"
-UPDATE_Q_FUNC="${PROJECT_NAME}-update-qsession-${ENVIRONMENT}"
 
 # =============================================================================
-# Helper: get CloudFormation output
+# Interactive helpers
 # =============================================================================
+IS_TTY=false
+[ -t 0 ] && IS_TTY=true
+AUTO="${AUTO_CONFIRM:-}"
+
+say()  { echo "$@"; }
+info() { echo "   $*"; }
+warn() { echo "   ⚠️  $*"; }
+ok()   { echo "   ✅ $*"; }
+hr()   { echo "============================================="; }
+
+# choose "Prompt" "default_index(1-based)" "opt1" "opt2" ...
+#   -> sets CHOICE (1-based index) and CHOICE_VALUE (option text)
+choose() {
+    local prompt="$1"; shift
+    local default_idx="$1"; shift
+    local opts=("$@")
+    local n=${#opts[@]}
+    echo ""
+    echo "   ❓ $prompt"
+    local i=1
+    for opt in "${opts[@]}"; do
+        if [ "$i" -eq "$default_idx" ]; then
+            echo "      [$i] $opt   (default)"
+        else
+            echo "      [$i] $opt"
+        fi
+        i=$((i+1))
+    done
+    if [ -n "$AUTO" ] || [ "$IS_TTY" = "false" ]; then
+        CHOICE=$default_idx
+        CHOICE_VALUE="${opts[$((default_idx-1))]}"
+        echo "      -> auto-selected: [$CHOICE] $CHOICE_VALUE"
+        return 0
+    fi
+    while true; do
+        read -r -p "      Select [1-$n] (Enter=default $default_idx): " sel
+        sel="${sel:-$default_idx}"
+        if [[ "$sel" =~ ^[0-9]+$ ]] && [ "$sel" -ge 1 ] && [ "$sel" -le "$n" ]; then
+            CHOICE=$sel
+            CHOICE_VALUE="${opts[$((sel-1))]}"
+            return 0
+        fi
+        echo "      Invalid input. Enter a number between 1 and $n."
+    done
+}
+
+# ask_yn "Prompt" "y|n(default)" -> returns 0 for yes, 1 for no
+ask_yn() {
+    local prompt="$1"
+    local def="${2:-y}"
+    local hint="[Y/n]"
+    [ "$def" = "n" ] && hint="[y/N]"
+    if [ -n "$AUTO" ] || [ "$IS_TTY" = "false" ]; then
+        echo "   ❓ $prompt $hint -> auto: $def"
+        [ "$def" = "y" ] && return 0 || return 1
+    fi
+    read -r -p "   ❓ $prompt $hint: " ans
+    ans=$(echo "${ans:-$def}" | tr '[:upper:]' '[:lower:]')
+    case "$ans" in y|yes) return 0 ;; *) return 1 ;; esac
+}
+
+# ask_text "Prompt" "default" -> sets ANSWER
+ask_text() {
+    local prompt="$1"
+    local def="${2:-}"
+    if [ -n "$AUTO" ] || [ "$IS_TTY" = "false" ]; then
+        ANSWER="$def"
+        echo "   ❓ $prompt -> auto: $def"
+        return 0
+    fi
+    read -r -p "   ❓ $prompt${def:+ (default: $def)}: " ANSWER
+    ANSWER="${ANSWER:-$def}"
+}
+
+# Delete every object version + delete marker from a versioned bucket
+# (plain `aws s3 rm --recursive` leaves versions behind -> bucket delete fails)
+purge_bucket_versions() {
+    local bucket="$1"
+    python3 - "$bucket" "$REGION" <<'PYEOF' 2>/dev/null || true
+import sys, subprocess, json
+bucket, region = sys.argv[1], sys.argv[2]
+def run(*args):
+    r = subprocess.run(["aws"] + list(args) + ["--region", region, "--output", "json"],
+                       capture_output=True, text=True)
+    return json.loads(r.stdout) if r.stdout.strip() else {}
+while True:
+    d = run("s3api", "list-object-versions", "--bucket", bucket, "--max-items", "500")
+    objs = [{"Key": o["Key"], "VersionId": o["VersionId"]}
+            for k in ("Versions", "DeleteMarkers") for o in d.get(k, [])]
+    if not objs:
+        break
+    for i in range(0, len(objs), 500):
+        run("s3api", "delete-objects", "--bucket", bucket,
+            "--delete", json.dumps({"Objects": objs[i:i+500], "Quiet": True}))
+PYEOF
+}
+
+# =============================================================================
+# State file (records created resource IDs for idempotent re-runs & cleanup)
+# =============================================================================
+state_get() { [ -f "$STATE_FILE" ] && grep "^$1=" "$STATE_FILE" 2>/dev/null | tail -1 | cut -d= -f2- || true; }
+state_set() {
+    touch "$STATE_FILE"
+    grep -v "^$1=" "$STATE_FILE" > "$STATE_FILE.tmp" 2>/dev/null || true
+    echo "$1=$2" >> "$STATE_FILE.tmp"
+    mv "$STATE_FILE.tmp" "$STATE_FILE"
+}
+
+# =============================================================================
+# JSON helpers (python3 is preinstalled on CloudShell)
+# =============================================================================
+jget() {
+    # jget '<json>' '<dotted.path or [idx]>'  — prints value or empty
+    # JSON is passed via env var to avoid any shell quoting issues
+    J="$1" P="$2" python3 -c "
+import os, json
+try:
+    cur = json.loads(os.environ['J'])
+    for part in os.environ['P'].replace(']', '').replace('[', '.').split('.'):
+        if part == '': continue
+        cur = cur[int(part)] if isinstance(cur, list) else cur.get(part)
+        if cur is None: break
+    if cur is not None:
+        print(cur if isinstance(cur, str) else json.dumps(cur, ensure_ascii=False))
+except Exception:
+    pass
+"
+}
+
 get_output() {
     aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" \
         --query "Stacks[0].Outputs[?OutputKey=='$1'].OutputValue" --output text 2>/dev/null || echo ""
 }
 
-# #############################################################################
-#
-#  CLEANUP COMMAND
-#
-# #############################################################################
-do_cleanup() {
-    echo "============================================="
-    echo "  AICC Builder - Resource Cleanup"
+# Lambda name resolution against actual stack resources
+STACK_LAMBDA_NAMES=""
+_load_stack_lambda_names() {
+    [ -n "$STACK_LAMBDA_NAMES" ] && return 0
+    STACK_LAMBDA_NAMES=$(aws cloudformation list-stack-resources \
+        --stack-name "$STACK_NAME" --region "$REGION" \
+        --query "StackResourceSummaries[?ResourceType=='AWS::Lambda::Function'].PhysicalResourceId" \
+        --output text 2>/dev/null || echo "")
+}
+resolve_stack_function() {
+    local dir_name="$1"
+    _load_stack_lambda_names
+    [ -z "$STACK_LAMBDA_NAMES" ] && { echo ""; return; }
+    local needle fn norm
+    needle=$(echo "$dir_name" | tr '[:upper:]' '[:lower:]' | tr -d '_-')
+    for fn in $STACK_LAMBDA_NAMES; do
+        norm=$(echo "$fn" | tr '[:upper:]' '[:lower:]' | tr -d '_-')
+        case "$norm" in *"$needle"*) echo "$fn"; return ;; esac
+    done
+    echo ""
+}
+
+# =============================================================================
+# Region + naming (region is chosen interactively in preflight for deploy)
+# =============================================================================
+REGION="${AWS_DEFAULT_REGION:-us-west-2}"
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+# finish deployment-name resolution (state file helpers are defined above)
+[ -z "$PROJECT_NAME" ] && PROJECT_NAME="$(state_get PROJECT_NAME)"
+[ -z "$PROJECT_NAME" ] && PROJECT_NAME="$DETECTED_PROJECT_NAME"
+
+set_names() {
+    STACK_NAME="${PROJECT_NAME}-stack"
+    TEMPLATE_BUCKET="${PROJECT_NAME}-cfn-${REGION}-${ACCOUNT_ID}"
+    ROLE_NAME="${PROJECT_NAME}-gateway-role"
+    CRED_PROVIDER_NAME="${PROJECT_NAME}-api-key"
+    GATEWAY_NAME="${PROJECT_NAME}-mcp-server"
+    TARGET_NAME="${PROJECT_NAME}-api"
+    KB_NAME="${PROJECT_NAME}-faq-kb"
+    MCP_APP_NAME="${PROJECT_NAME}-mcp"
+    BOT_NAME=$(echo "${PROJECT_NAME}" | sed 's/[^0-9a-zA-Z]/_/g')Bot
+    FLOW_NAME="${PROJECT_NAME}-flow"
+    PROMPT_NAME="${PROJECT_NAME}-orchestration-prompt"
+    AGENT_NAME="${PROJECT_NAME}-agent"
+    SP_NAME=$(echo "${PROJECT_NAME}" | sed 's/[^0-9a-zA-Z_-]/-/g')-ai-agent
+    UPDATE_Q_FUNC="${PROJECT_NAME}-update-qsession-${ENVIRONMENT}"
+}
+set_names
+
+# Find CloudFormation template (nested or flat structure)
+CFN_TEMPLATE=""
+if [ -f "$SCRIPT_DIR/cloudformation/$DETECTED_PROJECT_NAME/infrastructure.yaml" ]; then
+    CFN_TEMPLATE="$SCRIPT_DIR/cloudformation/$DETECTED_PROJECT_NAME/infrastructure.yaml"
+elif [ -f "$SCRIPT_DIR/cloudformation/infrastructure.yaml" ]; then
+    CFN_TEMPLATE="$SCRIPT_DIR/cloudformation/infrastructure.yaml"
+fi
+
+# Contact flow asset
+FLOW_JSON=""
+if [ -d "$SCRIPT_DIR/contact-flow" ]; then
+    FLOW_JSON=$(find "$SCRIPT_DIR/contact-flow" -name "*.json" | head -1)
+fi
+
+# AI prompt asset
+PROMPT_FILE=""
+if [ -d "$SCRIPT_DIR/prompts" ]; then
+    PROMPT_FILE=$(find "$SCRIPT_DIR/prompts" -name "*.yaml" -o -name "*.yml" -o -name "*.md" 2>/dev/null | head -1)
+fi
+
+# OpenAPI asset
+OPENAPI_FILE=""
+if [ -d "$SCRIPT_DIR/openapi" ]; then
+    OPENAPI_FILE=$(find "$SCRIPT_DIR/openapi" -name "*.yaml" -o -name "*.yml" 2>/dev/null | head -1)
+fi
+
+# =============================================================================
+# Phase 0: Preflight — asset scan, region & account confirmation
+# =============================================================================
+do_preflight() {
+    hr
+    echo "  AICC Builder - Full Automation Deployment"
+    hr
+    echo ""
+    echo "  📂 Asset scan results:"
+    [ -n "$CFN_TEMPLATE" ]  && echo "     ✅ CloudFormation:  ${CFN_TEMPLATE#$SCRIPT_DIR/}" || echo "     ❌ CloudFormation template NOT FOUND"
+    if [ -d "$SCRIPT_DIR/lambda" ]; then
+        echo "     ✅ Lambda:          $(ls "$SCRIPT_DIR/lambda" | tr '\n' ' ')"
+    fi
+    [ -n "$OPENAPI_FILE" ]  && echo "     ✅ OpenAPI:         ${OPENAPI_FILE#$SCRIPT_DIR/}"
+    [ -n "$FLOW_JSON" ]     && echo "     ✅ Contact Flow:    ${FLOW_JSON#$SCRIPT_DIR/}"
+    [ -n "$PROMPT_FILE" ]   && echo "     ✅ AI Prompt:       ${PROMPT_FILE#$SCRIPT_DIR/}"
+    [ -d "$SCRIPT_DIR/faq" ] && echo "     ✅ FAQ:             faq/"
+
+    # Detect language from contact flow set-voice metadata or flow_config
+    DETECTED_LANG=""
+    if [ -n "$FLOW_JSON" ]; then
+        DETECTED_LANG=$(python3 - "$FLOW_JSON" <<'PYEOF' 2>/dev/null || true
+import sys, json, re
+d = json.load(open(sys.argv[1]))
+# 1) Metadata set-voice languageCode
+meta = d.get('Metadata', {}).get('ActionMetadata', {})
+for k, v in meta.items():
+    p = v.get('parameters', {}).get('TextToSpeechVoice', {})
+    if isinstance(p, dict) and p.get('languageCode'):
+        print(p['languageCode']); sys.exit()
+# 2) any ko/ja/etc. hint in TTS voice names is unreliable; give up
+PYEOF
+)
+    fi
+    if [ -z "$DETECTED_LANG" ] && [ -f "$SCRIPT_DIR/state/flow_config.json" ]; then
+        # Heuristic: greeting language detection (Hangul/Kana/Han)
+        DETECTED_LANG=$(python3 - "$SCRIPT_DIR/state/flow_config.json" <<'PYEOF' 2>/dev/null || true
+import sys, json, re
+d = json.load(open(sys.argv[1]))
+text = (d.get('common_greeting') or '') + (d.get('agent_persona') or '')
+if re.search(r'[가-힣]', text): print('ko-KR')
+elif re.search(r'[ぁ-んァ-ン]', text): print('ja-JP')
+elif re.search(r'[一-鿿]', text): print('zh-CN')
+else: print('en-US')
+PYEOF
+)
+    fi
+    DETECTED_LANG="${DETECTED_LANG:-en-US}"
+    echo "     🌐 Detected language: $DETECTED_LANG"
+    echo ""
+
+    # Region selection
+    local cfg_region
+    cfg_region=$(aws configure get region 2>/dev/null || echo "")
+    if [ -n "${AWS_DEFAULT_REGION:-}" ]; then
+        REGION="$AWS_DEFAULT_REGION"
+        info "Region (env): $REGION"
+    else
+        local opts=()
+        local default_idx=1
+        opts+=("us-west-2  (workshop default — Nova Sonic supported)")
+        [ -n "$cfg_region" ] && [ "$cfg_region" != "us-west-2" ] && opts+=("$cfg_region  (current AWS CLI default region)")
+        opts+=("Enter manually")
+        choose "Which region do you want to deploy to?" "$default_idx" "${opts[@]}"
+        case "$CHOICE_VALUE" in
+            "Enter manually") ask_text "Region code (e.g. ap-northeast-2)" "us-west-2"; REGION="$ANSWER" ;;
+            *) REGION=$(echo "$CHOICE_VALUE" | awk '{print $1}') ;;
+        esac
+    fi
+    set_names
+
+    # ── Deployment name (prefix for the stack and EVERY resource) ───────────
+    #    Distinct names = fully isolated side-by-side deployments in one account
+    #    (stack, S3 buckets, IAM role, gateway, bot, flow, AI agent, ...)
+    while true; do
+        ask_text "Deployment name — used as the stack/resource prefix (a-z, 0-9, '-', 3-24 chars)" "$PROJECT_NAME"
+        CANDIDATE=$(echo "$ANSWER" | tr '[:upper:]' '[:lower:]')
+        if echo "$CANDIDATE" | grep -qE '^[a-z][a-z0-9-]{2,23}$'; then
+            PROJECT_NAME="$CANDIDATE"
+            break
+        fi
+        echo "      Invalid name: must start with a letter, only a-z 0-9 '-', 3-24 chars."
+        [ -n "$AUTO" ] && { PROJECT_NAME="$DETECTED_PROJECT_NAME"; break; }
+    done
+    set_names
+    state_set PROJECT_NAME "$PROJECT_NAME"
+    info "Deployment name: $PROJECT_NAME  (stack: $STACK_NAME)"
+
+    echo ""
     echo "  Project: $PROJECT_NAME"
     echo "  Region:  $REGION"
     echo "  Account: $ACCOUNT_ID"
-    echo "============================================="
+    echo "  Caller:  $(aws sts get-caller-identity --query Arn --output text 2>/dev/null || echo '?')"
     echo ""
-    echo "  ⚠️  이 명령은 아래 리소스를 모두 삭제합니다:"
-    echo "     - AgentCore Gateway + Target + Credential Provider"
-    echo "     - Gateway IAM Role"
-    echo "     - Q in Connect Assistant + Knowledge Base"
-    echo "     - WISDOM_ASSISTANT Integration Association"
-    echo "     - CloudFormation Stack (Lambda, API GW, DynamoDB 등)"
-    echo "     - S3 버킷 내 에셋 (OpenAPI, FAQ)"
-    echo "     - CFN 템플릿 S3 버킷"
-    echo ""
-    echo "     ※ Connect Instance 자체는 삭제하지 않습니다."
-    echo ""
-    read -p "  정말 삭제하시겠습니까? (yes/no): " CONFIRM
-    if [ "$CONFIRM" != "yes" ]; then
-        echo "  취소되었습니다."
+    if ! ask_yn "Proceed with this account/region?" "y"; then
+        echo "  Aborted."
         exit 0
     fi
-    echo ""
-
-    # ─── Remove WISDOM_ASSISTANT integration associations ──────────────────
-    echo "🔗 Removing WISDOM_ASSISTANT integration associations..."
-
-    CLEANUP_CONNECT_ID="${CONNECT_INSTANCE_ID:-}"
-    if [ -z "$CLEANUP_CONNECT_ID" ]; then
-        INSTANCES_JSON=$(aws connect list-instances --region "$REGION" --output json 2>/dev/null || echo '{"InstanceSummaryList":[]}')
-        INSTANCE_COUNT=$(echo "$INSTANCES_JSON" | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('InstanceSummaryList',[])))" 2>/dev/null || echo "0")
-        if [ "$INSTANCE_COUNT" -eq 1 ]; then
-            CLEANUP_CONNECT_ID=$(echo "$INSTANCES_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['InstanceSummaryList'][0]['Id'])")
-        elif [ "$INSTANCE_COUNT" -gt 1 ]; then
-            echo "   Multiple Connect instances found. Specify CONNECT_INSTANCE_ID env var."
-            echo "   Skipping integration cleanup."
-        fi
-    fi
-
-    if [ -n "$CLEANUP_CONNECT_ID" ]; then
-        WISDOM_ASSOCS=$(aws connect list-integration-associations \
-            --instance-id "$CLEANUP_CONNECT_ID" --integration-type WISDOM_ASSISTANT \
-            --region "$REGION" --output json 2>/dev/null || echo '{"IntegrationAssociationSummaryList":[]}')
-        echo "$WISDOM_ASSOCS" | python3 -c "
-import sys, json
-assocs = json.load(sys.stdin).get('IntegrationAssociationSummaryList', [])
-for a in assocs:
-    print(a['IntegrationAssociationId'])
-" 2>/dev/null | while read -r assoc_id; do
-            [ -z "$assoc_id" ] && continue
-            echo "   Deleting WISDOM_ASSISTANT association: $assoc_id"
-            aws connect delete-integration-association \
-                --instance-id "$CLEANUP_CONNECT_ID" \
-                --integration-association-id "$assoc_id" \
-                --region "$REGION" 2>/dev/null || true
-        done
-        echo "   ✅ Integration associations removed"
-    fi
-
-    # ─── Delete Gateway + Target + Credential Provider ───────────────────────
-    echo ""
-    echo "🌐 Removing AgentCore Gateway resources..."
-
-    if aws bedrock-agentcore-control help &>/dev/null 2>&1; then
-        # Find gateway by name
-        GW_LIST=$(aws bedrock-agentcore-control list-gateways \
-            --region "$REGION" --output json 2>/dev/null || echo '{"gateways":[]}')
-        CLEANUP_GW_ID=$(echo "$GW_LIST" | python3 -c "
-import sys, json
-for gw in json.load(sys.stdin).get('gateways', []):
-    if gw.get('name') == '${GATEWAY_NAME}':
-        print(gw['gatewayId']); break
-else: print('')
-" 2>/dev/null || echo "")
-
-        if [ -n "$CLEANUP_GW_ID" ]; then
-            # Delete gateway targets first
-            TARGETS=$(aws bedrock-agentcore-control list-gateway-targets \
-                --gateway-identifier "$CLEANUP_GW_ID" \
-                --region "$REGION" --output json 2>/dev/null || echo '{"targets":[]}')
-            echo "$TARGETS" | python3 -c "
-import sys, json
-for t in json.load(sys.stdin).get('targets', []):
-    print(t.get('targetId',''))
-" 2>/dev/null | while read -r tid; do
-                [ -z "$tid" ] && continue
-                echo "   Deleting gateway target: $tid"
-                aws bedrock-agentcore-control delete-gateway-target \
-                    --gateway-identifier "$CLEANUP_GW_ID" \
-                    --target-identifier "$tid" \
-                    --region "$REGION" 2>/dev/null || true
-            done
-
-            # Delete gateway
-            echo "   Deleting gateway: $CLEANUP_GW_ID"
-            aws bedrock-agentcore-control delete-gateway \
-                --gateway-identifier "$CLEANUP_GW_ID" \
-                --region "$REGION" 2>/dev/null || true
-
-            # Wait for gateway deletion
-            echo -n "   Waiting for gateway deletion..."
-            for i in $(seq 1 30); do
-                if ! aws bedrock-agentcore-control get-gateway \
-                    --gateway-identifier "$CLEANUP_GW_ID" \
-                    --region "$REGION" &>/dev/null 2>&1; then
-                    echo " ✅"
-                    break
-                fi
-                echo -n "."
-                sleep 5
-            done
-        else
-            echo "   No gateway found with name: $GATEWAY_NAME"
-        fi
-
-        # Delete credential provider
-        CRED_LIST=$(aws bedrock-agentcore-control list-api-key-credential-providers \
-            --region "$REGION" --output json 2>/dev/null || echo '{"credentialProviders":[]}')
-        CLEANUP_CRED_ARN=$(echo "$CRED_LIST" | python3 -c "
-import sys, json
-for p in json.load(sys.stdin).get('credentialProviders', []):
-    if p.get('name') == '${CRED_PROVIDER_NAME}':
-        print(p['credentialProviderArn']); break
-else: print('')
-" 2>/dev/null || echo "")
-
-        if [ -n "$CLEANUP_CRED_ARN" ]; then
-            echo "   Deleting credential provider: $CRED_PROVIDER_NAME"
-            aws bedrock-agentcore-control delete-api-key-credential-provider \
-                --credential-provider-id "$CLEANUP_CRED_ARN" \
-                --region "$REGION" 2>/dev/null || true
-        fi
-        echo "   ✅ Gateway resources removed"
-    else
-        echo "   ⚠️ bedrock-agentcore-control not available, skipping."
-    fi
-
-    # ─── Delete Gateway IAM Role ─────────────────────────────────────────────
-    echo ""
-    echo "🔑 Removing Gateway IAM role..."
-    if aws iam get-role --role-name "$ROLE_NAME" &>/dev/null 2>&1; then
-        # Delete inline policies first
-        POLICIES=$(aws iam list-role-policies --role-name "$ROLE_NAME" \
-            --query 'PolicyNames' --output json 2>/dev/null || echo '[]')
-        echo "$POLICIES" | python3 -c "
-import sys, json
-for p in json.load(sys.stdin):
-    print(p)
-" 2>/dev/null | while read -r pname; do
-            [ -z "$pname" ] && continue
-            aws iam delete-role-policy --role-name "$ROLE_NAME" --policy-name "$pname" 2>/dev/null || true
-        done
-        # Delete attached managed policies
-        ATTACHED=$(aws iam list-attached-role-policies --role-name "$ROLE_NAME" \
-            --query 'AttachedPolicies[].PolicyArn' --output json 2>/dev/null || echo '[]')
-        echo "$ATTACHED" | python3 -c "
-import sys, json
-for p in json.load(sys.stdin):
-    print(p)
-" 2>/dev/null | while read -r parn; do
-            [ -z "$parn" ] && continue
-            aws iam detach-role-policy --role-name "$ROLE_NAME" --policy-arn "$parn" 2>/dev/null || true
-        done
-        aws iam delete-role --role-name "$ROLE_NAME" 2>/dev/null || true
-        echo "   ✅ IAM role deleted: $ROLE_NAME"
-    else
-        echo "   No IAM role found: $ROLE_NAME"
-    fi
-
-    # ─── Step 6.5 reverse: Delete Knowledge Base ─────────────────────────────
-    echo ""
-    echo "📖 Removing Q in Connect Knowledge Base..."
-    KB_LIST=$(aws qconnect list-knowledge-bases --region "$REGION" --output json 2>/dev/null || echo '{"knowledgeBaseSummaries":[]}')
-    CLEANUP_KB_ID=$(echo "$KB_LIST" | python3 -c "
-import sys, json
-for kb in json.load(sys.stdin).get('knowledgeBaseSummaries', []):
-    if kb.get('name') == '${KB_NAME}':
-        print(kb['knowledgeBaseId']); break
-else: print('')
-" 2>/dev/null || echo "")
-
-    if [ -n "$CLEANUP_KB_ID" ]; then
-        echo "   Deleting knowledge base: $CLEANUP_KB_ID"
-        aws qconnect delete-knowledge-base --knowledge-base-id "$CLEANUP_KB_ID" \
-            --region "$REGION" 2>/dev/null || true
-        echo "   ✅ Knowledge base deleted"
-    else
-        echo "   No knowledge base found: $KB_NAME"
-    fi
-
-    # ─── Step 6 reverse: Delete Q in Connect Assistant ───────────────────────
-    echo ""
-    echo "🤖 Removing Q in Connect Assistant..."
-    ASST_LIST=$(aws qconnect list-assistants --region "$REGION" --output json 2>/dev/null || echo '{"assistantSummaries":[]}')
-    CLEANUP_ASST_ID=$(echo "$ASST_LIST" | python3 -c "
-import sys, json
-for a in json.load(sys.stdin).get('assistantSummaries', []):
-    if a.get('name') == '${PROJECT_NAME}-assistant':
-        print(a['assistantId']); break
-else: print('')
-" 2>/dev/null || echo "")
-
-    if [ -n "$CLEANUP_ASST_ID" ]; then
-        # Delete assistant associations first
-        ASST_ASSOCS=$(aws qconnect list-assistant-associations \
-            --assistant-id "$CLEANUP_ASST_ID" --region "$REGION" --output json 2>/dev/null || echo '{"assistantAssociationSummaries":[]}')
-        echo "$ASST_ASSOCS" | python3 -c "
-import sys, json
-for a in json.load(sys.stdin).get('assistantAssociationSummaries', []):
-    print(a['assistantAssociationId'])
-" 2>/dev/null | while read -r aaid; do
-            [ -z "$aaid" ] && continue
-            echo "   Deleting assistant association: $aaid"
-            aws qconnect delete-assistant-association \
-                --assistant-id "$CLEANUP_ASST_ID" \
-                --assistant-association-id "$aaid" \
-                --region "$REGION" 2>/dev/null || true
-        done
-
-        echo "   Deleting assistant: $CLEANUP_ASST_ID"
-        aws qconnect delete-assistant --assistant-id "$CLEANUP_ASST_ID" \
-            --region "$REGION" 2>/dev/null || true
-        echo "   ✅ Assistant deleted"
-    else
-        echo "   No assistant found: ${PROJECT_NAME}-assistant"
-    fi
-
-    # ─── Step 3-4 reverse: Clean S3 assets ───────────────────────────────────
-    echo ""
-    echo "📚 Cleaning S3 assets..."
-    KB_BUCKET=$(get_output "KnowledgeBaseBucketName")
-    if [ -n "$KB_BUCKET" ]; then
-        echo "   Emptying s3://$KB_BUCKET..."
-        aws s3 rm "s3://$KB_BUCKET" --recursive --region "$REGION" 2>/dev/null || true
-        echo "   ✅ S3 assets cleaned"
-    else
-        echo "   No KB bucket found in stack outputs"
-    fi
-
-    # ─── Step 1 reverse: Delete CloudFormation Stack ─────────────────────────
-    echo ""
-    echo "📦 Deleting CloudFormation stack: $STACK_NAME..."
-    if aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" &>/dev/null; then
-        aws cloudformation delete-stack --stack-name "$STACK_NAME" --region "$REGION"
-        echo "   Waiting for stack deletion..."
-        aws cloudformation wait stack-delete-complete --stack-name "$STACK_NAME" --region "$REGION"
-        echo "   ✅ Stack deleted"
-    else
-        echo "   Stack not found: $STACK_NAME"
-    fi
-
-    # ─── Delete CFN template S3 bucket ───────────────────────────────────────
-    echo ""
-    echo "🪣 Cleaning CFN template bucket..."
-    if aws s3 ls "s3://$TEMPLATE_BUCKET" --region "$REGION" &>/dev/null 2>&1; then
-        aws s3 rm "s3://$TEMPLATE_BUCKET" --recursive --region "$REGION" 2>/dev/null || true
-        aws s3api delete-bucket --bucket "$TEMPLATE_BUCKET" --region "$REGION" 2>/dev/null || true
-        echo "   ✅ Template bucket deleted: $TEMPLATE_BUCKET"
-    else
-        echo "   Template bucket not found: $TEMPLATE_BUCKET"
-    fi
-
-    echo ""
-    echo "============================================="
-    echo "  ✅ Cleanup Complete!"
-    echo "============================================="
-    echo ""
-    echo "  삭제된 리소스:"
-    echo "    - CloudFormation stack: $STACK_NAME"
-    echo "    - Gateway: $GATEWAY_NAME"
-    echo "    - IAM role: $ROLE_NAME"
-    echo "    - Credential provider: $CRED_PROVIDER_NAME"
-    echo "    - Assistant: ${PROJECT_NAME}-assistant"
-    echo "    - Knowledge Base: $KB_NAME"
-    echo "    - S3 assets & template bucket"
-    echo ""
-    echo "  ※ Connect Instance는 삭제되지 않았습니다."
-    echo "    수동 삭제: aws connect delete-instance --instance-id <ID>"
-    echo ""
-    echo "============================================="
 }
 
-# #############################################################################
-#
-#  STATUS COMMAND
-#
-# #############################################################################
-do_status() {
-    echo "============================================="
-    echo "  AICC Builder - Deployment Status"
-    echo "  Project: $PROJECT_NAME | Region: $REGION"
-    echo "============================================="
+# =============================================================================
+# Phase 1: CloudFormation
+# =============================================================================
+phase_cloudformation() {
     echo ""
+    echo "📦 Phase 1: Deploying CloudFormation stack..."
 
-    # CloudFormation
-    STACK_STATUS=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" \
-        --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "NOT_FOUND")
-    echo "  📦 CloudFormation Stack: $STACK_STATUS"
-
-    if [ "$STACK_STATUS" != "NOT_FOUND" ]; then
-        API_ENDPOINT=$(get_output "ApiEndpoint")
-        echo "     API Endpoint: ${API_ENDPOINT:-N/A}"
-    fi
-
-    # Connect
-    INSTANCES_JSON=$(aws connect list-instances --region "$REGION" --output json 2>/dev/null || echo '{"InstanceSummaryList":[]}')
-    INSTANCE_COUNT=$(echo "$INSTANCES_JSON" | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('InstanceSummaryList',[])))" 2>/dev/null || echo "0")
-    echo "  📞 Connect Instances: $INSTANCE_COUNT"
-
-    # Q in Connect Assistant
-    ASST_LIST=$(aws qconnect list-assistants --region "$REGION" --output json 2>/dev/null || echo '{"assistantSummaries":[]}')
-    ASST_COUNT=$(echo "$ASST_LIST" | python3 -c "
-import sys, json
-count = sum(1 for a in json.load(sys.stdin).get('assistantSummaries', []) if a.get('name') == '${PROJECT_NAME}-assistant')
-print(count)
-" 2>/dev/null || echo "0")
-    echo "  🤖 Q in Connect Assistant: ${ASST_COUNT} found"
-
-    # Knowledge Base
-    KB_LIST=$(aws qconnect list-knowledge-bases --region "$REGION" --output json 2>/dev/null || echo '{"knowledgeBaseSummaries":[]}')
-    KB_EXISTS=$(echo "$KB_LIST" | python3 -c "
-import sys, json
-for kb in json.load(sys.stdin).get('knowledgeBaseSummaries', []):
-    if kb.get('name') == '${KB_NAME}':
-        print(kb.get('status','UNKNOWN')); break
-else: print('NOT_FOUND')
-" 2>/dev/null || echo "UNKNOWN")
-    echo "  📖 Knowledge Base ($KB_NAME): $KB_EXISTS"
-
-    # Gateway
-    if aws bedrock-agentcore-control help &>/dev/null 2>&1; then
-        GW_LIST=$(aws bedrock-agentcore-control list-gateways \
-            --region "$REGION" --output json 2>/dev/null || echo '{"gateways":[]}')
-        GW_STATUS=$(echo "$GW_LIST" | python3 -c "
-import sys, json
-for gw in json.load(sys.stdin).get('gateways', []):
-    if gw.get('name') == '${GATEWAY_NAME}':
-        print(gw.get('status','UNKNOWN')); break
-else: print('NOT_FOUND')
-" 2>/dev/null || echo "UNKNOWN")
-        echo "  🌐 AgentCore Gateway ($GATEWAY_NAME): $GW_STATUS"
-    else
-        echo "  🌐 AgentCore Gateway: CLI not available"
-    fi
-
-    # IAM Role
-    if aws iam get-role --role-name "$ROLE_NAME" &>/dev/null 2>&1; then
-        echo "  🔑 Gateway IAM Role ($ROLE_NAME): EXISTS"
-    else
-        echo "  🔑 Gateway IAM Role ($ROLE_NAME): NOT_FOUND"
-    fi
-
-    # Template bucket
-    if aws s3 ls "s3://$TEMPLATE_BUCKET" --region "$REGION" &>/dev/null 2>&1; then
-        echo "  🪣 CFN Template Bucket ($TEMPLATE_BUCKET): EXISTS"
-    else
-        echo "  🪣 CFN Template Bucket ($TEMPLATE_BUCKET): NOT_FOUND"
-    fi
-
-    echo ""
-    echo "============================================="
-}
-
-# #############################################################################
-#
-#  DEPLOY COMMAND
-#
-# #############################################################################
-do_deploy() {
-    if [ -z "$CFN_TEMPLATE" ]; then
-        echo "❌ CloudFormation template not found in cloudformation/"
-        exit 1
-    fi
-
-    echo "============================================="
-    echo "  AICC Builder - Full Automation Deployment"
-    echo "  Project: $PROJECT_NAME"
-    echo "  Region:  $REGION"
-    echo "  Account: $ACCOUNT_ID"
-    echo "  Profile: ${AWS_PROFILE:-<default>}"
-    echo "  Caller:  $(aws sts get-caller-identity --query Arn --output text 2>/dev/null || echo '?')"
-    echo "============================================="
-    if [ -t 0 ] && [ -z "${AUTO_CONFIRM:-}" ]; then
-        read -p "  Proceed with this account/region? [y/N]: " OK
-        OK=$(echo "$OK" | tr '[:upper:]' '[:lower:]')
-        case "$OK" in y|yes) ;; *) echo "  Aborted."; exit 0;; esac
-    fi
-
-    # =============================================================================
-    # Step 1: Deploy CloudFormation
-    # =============================================================================
-    echo ""
-    echo "📦 Step 1: Deploying CloudFormation stack..."
-
-    # Create S3 bucket for large templates (>51KB limit)
-    if ! aws s3 ls "s3://$TEMPLATE_BUCKET" --region "$REGION" 2>/dev/null; then
-        echo "   Creating S3 bucket for CloudFormation templates..."
+    if ! aws s3 ls "s3://$TEMPLATE_BUCKET" --region "$REGION" &>/dev/null; then
+        info "Creating S3 bucket for templates..."
         if [ "$REGION" = "us-east-1" ]; then
-            aws s3api create-bucket --bucket "$TEMPLATE_BUCKET" --region "$REGION"
+            aws s3api create-bucket --bucket "$TEMPLATE_BUCKET" --region "$REGION" >/dev/null
         else
             aws s3api create-bucket --bucket "$TEMPLATE_BUCKET" --region "$REGION" \
-                --create-bucket-configuration LocationConstraint="$REGION"
+                --create-bucket-configuration LocationConstraint="$REGION" >/dev/null
         fi
         aws s3api put-bucket-versioning --bucket "$TEMPLATE_BUCKET" \
             --versioning-configuration Status=Enabled --region "$REGION"
     fi
 
-    # Upload template to S3
     TEMPLATE_KEY="infrastructure-$(date +%Y%m%d-%H%M%S).yaml"
-    echo "   Uploading template to s3://$TEMPLATE_BUCKET/$TEMPLATE_KEY..."
-    aws s3 cp "$CFN_TEMPLATE" "s3://$TEMPLATE_BUCKET/$TEMPLATE_KEY" --region "$REGION"
+    info "Uploading template: s3://$TEMPLATE_BUCKET/$TEMPLATE_KEY"
+    aws s3 cp "$CFN_TEMPLATE" "s3://$TEMPLATE_BUCKET/$TEMPLATE_KEY" --region "$REGION" >/dev/null
     TEMPLATE_URL="https://s3.${REGION}.amazonaws.com/${TEMPLATE_BUCKET}/${TEMPLATE_KEY}"
 
+    # Un-updatable terminal states (failed first creation etc.) must be
+    # deleted before anything else can proceed.
+    CUR_STATUS=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" \
+        --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "")
+    if echo "$CUR_STATUS" | grep -qE '^(ROLLBACK_COMPLETE|ROLLBACK_FAILED|CREATE_FAILED)$'; then
+        warn "Existing stack is in $CUR_STATUS (failed creation) — deleting it first"
+        aws cloudformation delete-stack --stack-name "$STACK_NAME" --region "$REGION"
+        aws cloudformation wait stack-delete-complete --stack-name "$STACK_NAME" --region "$REGION" 2>/dev/null || true
+    fi
+
     if aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" &>/dev/null; then
-        echo "   Stack exists, updating..."
-        if aws cloudformation update-stack \
-            --stack-name "$STACK_NAME" \
-            --template-url "$TEMPLATE_URL" \
+        # If a previous run (or its crashed remains) left the stack mid-operation,
+        # wait for it to settle first — updating/reading an IN_PROGRESS stack
+        # races into missing outputs and NoSuchBucket errors downstream.
+        local CUR_STATUS
+        CUR_STATUS=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" \
+            --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "")
+        if echo "$CUR_STATUS" | grep -q "IN_PROGRESS"; then
+            info "Stack is $CUR_STATUS (probably from a previous run) — waiting for it to finish..."
+            case "$CUR_STATUS" in
+                CREATE_IN_PROGRESS)  aws cloudformation wait stack-create-complete --stack-name "$STACK_NAME" --region "$REGION" 2>/dev/null || true ;;
+                UPDATE_IN_PROGRESS|UPDATE_COMPLETE_CLEANUP_IN_PROGRESS) aws cloudformation wait stack-update-complete --stack-name "$STACK_NAME" --region "$REGION" 2>/dev/null || true ;;
+                DELETE_IN_PROGRESS)  aws cloudformation wait stack-delete-complete --stack-name "$STACK_NAME" --region "$REGION" 2>/dev/null || true ;;
+                *) sleep 30 ;;
+            esac
+        fi
+        # Unrecoverable states: a ROLLBACK_COMPLETE stack can never be updated,
+        # and DELETE_FAILED needs a retried delete. Clean up and fall through to
+        # fresh creation.
+        CUR_STATUS=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" \
+            --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "")
+        if echo "$CUR_STATUS" | grep -qE "ROLLBACK_COMPLETE|ROLLBACK_FAILED|DELETE_FAILED|CREATE_FAILED"; then
+            warn "Stack is in $CUR_STATUS — deleting it before re-creating"
+            aws cloudformation delete-stack --stack-name "$STACK_NAME" --region "$REGION" 2>/dev/null || true
+            aws cloudformation wait stack-delete-complete --stack-name "$STACK_NAME" --region "$REGION" 2>/dev/null || {
+                # DELETE_FAILED again — retain the blockers and force delete
+                aws cloudformation delete-stack --stack-name "$STACK_NAME" --region "$REGION" \
+                    --deletion-mode FORCE_DELETE_STACK 2>/dev/null || true
+                aws cloudformation wait stack-delete-complete --stack-name "$STACK_NAME" --region "$REGION" 2>/dev/null || true
+            }
+        fi
+    fi
+    if aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" &>/dev/null; then
+        # A same-named stack exists. It may be from an OLDER asset bundle
+        # (different resources / Environment) — blindly reusing it poisons
+        # every later phase with stale outputs. Check compatibility first.
+        local EXISTING_ENV
+        EXISTING_ENV=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" \
+            --query "Stacks[0].Parameters[?ParameterKey=='Environment'].ParameterValue" --output text 2>/dev/null || echo "")
+        [ -n "$EXISTING_ENV" ] && [ "$EXISTING_ENV" != "$ENVIRONMENT" ] && \
+            warn "Existing stack was deployed with Environment=$EXISTING_ENV (this bundle: $ENVIRONMENT) — likely from an older asset bundle"
+
+        info "Stack exists, updating..."
+        UPDATE_ERR=$(aws cloudformation update-stack \
+            --stack-name "$STACK_NAME" --template-url "$TEMPLATE_URL" \
             --parameters ParameterKey=ProjectName,ParameterValue="$PROJECT_NAME" \
                          ParameterKey=Environment,ParameterValue="$ENVIRONMENT" \
-            --capabilities CAPABILITY_NAMED_IAM \
-            --region "$REGION" 2>/dev/null; then
-            echo "   Waiting for stack update..."
-            aws cloudformation wait stack-update-complete --stack-name "$STACK_NAME" --region "$REGION"
-        else
-            echo "   No updates needed."
+            --capabilities CAPABILITY_NAMED_IAM --region "$REGION" 2>&1) || true
+        if echo "$UPDATE_ERR" | grep -q '"StackId"'; then
+            info "Waiting for stack update..."
+            if ! aws cloudformation wait stack-update-complete --stack-name "$STACK_NAME" --region "$REGION"; then
+                warn "Stack update FAILED (rolled back). The existing stack is incompatible with this bundle."
+                UPDATE_ERR="__ROLLBACK__"
+            fi
+        fi
+        if echo "$UPDATE_ERR" | grep -q "No updates are to be performed"; then
+            info "No updates needed."
+        elif echo "$UPDATE_ERR" | grep -qE "__ROLLBACK__|Update of resource type is not permitted|cannot be updated"; then
+            # Incompatible existing stack (e.g. created by a different asset bundle)
+            warn "Existing stack '$STACK_NAME' is incompatible with this bundle's template:"
+            echo "$UPDATE_ERR" | grep -v '^__' | head -2 | sed 's/^/        /'
+            choose "How do you want to handle the existing stack?" 1 \
+                "Delete and recreate it with this bundle's template  (recommended for workshops)" \
+                "Keep using the existing stack as-is  (outputs may not match this bundle!)" \
+                "Abort deployment"
+            case "$CHOICE" in
+                1)
+                    info "Deleting old stack..."
+                    OLD_KB_BUCKET=$(get_output "KnowledgeBaseBucketName")
+                    if [ -n "$OLD_KB_BUCKET" ]; then
+                        aws s3 rm "s3://$OLD_KB_BUCKET" --recursive --region "$REGION" >/dev/null 2>&1 || true
+                        purge_bucket_versions "$OLD_KB_BUCKET"
+                    fi
+                    aws cloudformation delete-stack --stack-name "$STACK_NAME" --region "$REGION"
+                    aws cloudformation wait stack-delete-complete --stack-name "$STACK_NAME" --region "$REGION"
+                    # S3 bucket names free up asynchronously after deletion; a
+                    # same-named bucket in the new stack can 409 for a while.
+                    # Retry creation up to 3 times.
+                    for create_try in 1 2 3; do
+                        info "Creating new stack... (attempt $create_try/3)"
+                        aws cloudformation create-stack \
+                            --stack-name "$STACK_NAME" --template-url "$TEMPLATE_URL" \
+                            --parameters ParameterKey=ProjectName,ParameterValue="$PROJECT_NAME" \
+                                         ParameterKey=Environment,ParameterValue="$ENVIRONMENT" \
+                            --capabilities CAPABILITY_NAMED_IAM --region "$REGION" >/dev/null
+                        info "Waiting for stack creation... (5-10 min)"
+                        if aws cloudformation wait stack-create-complete --stack-name "$STACK_NAME" --region "$REGION" 2>/dev/null; then
+                            break
+                        fi
+                        FAIL_REASON=$(aws cloudformation describe-stack-events --stack-name "$STACK_NAME" --region "$REGION" \
+                            --query "StackEvents[?ResourceStatus=='CREATE_FAILED'] | [0].ResourceStatusReason" --output text 2>/dev/null || echo "")
+                        warn "Stack creation failed: $(echo "$FAIL_REASON" | head -c 160)"
+                        aws cloudformation delete-stack --stack-name "$STACK_NAME" --region "$REGION"
+                        aws cloudformation wait stack-delete-complete --stack-name "$STACK_NAME" --region "$REGION" 2>/dev/null || true
+                        if [ "$create_try" = "3" ]; then
+                            echo "❌ Stack creation failed after 3 attempts. Aborting."
+                            exit 1
+                        fi
+                        if echo "$FAIL_REASON" | grep -q "conflicting conditional operation"; then
+                            info "S3 bucket name still releasing — waiting 60s before retry..."
+                            sleep 60
+                        else
+                            sleep 15
+                        fi
+                    done
+                    ;;
+                2)  warn "Continuing with the OLD stack — later phases may use stale outputs" ;;
+                3)  echo "  Aborted."; exit 1 ;;
+            esac
+        elif ! echo "$UPDATE_ERR" | grep -q '"StackId"'; then
+            warn "Stack update error: $(echo "$UPDATE_ERR" | head -2)"
         fi
     else
-        echo "   Creating new stack..."
+        info "Creating new stack..."
         aws cloudformation create-stack \
-            --stack-name "$STACK_NAME" \
-            --template-url "$TEMPLATE_URL" \
+            --stack-name "$STACK_NAME" --template-url "$TEMPLATE_URL" \
             --parameters ParameterKey=ProjectName,ParameterValue="$PROJECT_NAME" \
                          ParameterKey=Environment,ParameterValue="$ENVIRONMENT" \
-            --capabilities CAPABILITY_NAMED_IAM \
-            --region "$REGION"
-        echo "   Waiting for stack creation..."
+            --capabilities CAPABILITY_NAMED_IAM --region "$REGION" >/dev/null
+        info "Waiting for stack creation... (5-10 min)"
         aws cloudformation wait stack-create-complete --stack-name "$STACK_NAME" --region "$REGION"
     fi
-    echo "   ✅ CloudFormation stack ready!"
+    ok "CloudFormation stack ready"
 
-    # ─── Extract Outputs ─────────────────────────────────────────────────────
     API_ENDPOINT=$(get_output "ApiEndpoint")
     API_KEY=$(get_output "ApiKeyValue")
     KB_BUCKET=$(get_output "KnowledgeBaseBucketName")
     CUSTOMER_LOOKUP_ARN=$(get_output "CustomerLookupFunctionArn")
     UPDATE_Q_SESSION_ARN=$(get_output "UpdateQSessionFunctionArn")
+    if [ -n "${UPDATE_Q_SESSION_ARN:-}" ]; then
+        UPDATE_Q_FUNC="$(echo "$UPDATE_Q_SESSION_ARN" | awk -F: '{print $NF}')"
+    fi
+    info "API Endpoint: $API_ENDPOINT"
+}
 
+# =============================================================================
+# Phase 2: Lambda function code
+# =============================================================================
+phase_lambda_code() {
     echo ""
-    echo "   API Endpoint: $API_ENDPOINT"
-    echo "   API Key:      ${API_KEY:0:10}..."
+    echo "🔧 Phase 2: Updating Lambda function code..."
+    [ -d "$SCRIPT_DIR/lambda" ] || { info "No lambda/ directory, skipping"; return 0; }
 
-    # =============================================================================
-    # Step 2: Update Lambda Functions
-    # =============================================================================
-    echo ""
-    echo "🔧 Step 2: Updating Lambda functions..."
+    arn_to_func_name() { echo "$1" | awk -F: '{print $NF}'; }
 
-    if [ -d "$SCRIPT_DIR/lambda" ]; then
-        for func_dir in "$SCRIPT_DIR/lambda"/*/; do
-            [ -d "$func_dir" ] || continue
-            func_name=$(basename "$func_dir")
+    for func_dir in "$SCRIPT_DIR/lambda"/*/; do
+        [ -d "$func_dir" ] || continue
+        func_name=$(basename "$func_dir")
+        if [ -f "$func_dir/index.py" ]; then entry_file="index.py"
+        elif [ -f "$func_dir/index.js" ]; then entry_file="index.js"
+        else entry_file=$(ls "$func_dir" | head -1); fi
+        [ -z "$entry_file" ] && continue
 
-            # Find entry file: prefer index.py, then index.js, then first file
-            if [ -f "$func_dir/index.py" ]; then
-                entry_file="index.py"
-            elif [ -f "$func_dir/index.js" ]; then
-                entry_file="index.js"
+        case "$func_name" in
+            customer_lookup)
+                if [ -n "${CUSTOMER_LOOKUP_ARN:-}" ]; then aws_func="$(arn_to_func_name "$CUSTOMER_LOOKUP_ARN")"
+                else aws_func=$(resolve_stack_function "$func_name"); fi ;;
+            update_q_session)
+                if [ -n "${UPDATE_Q_SESSION_ARN:-}" ]; then aws_func="$(arn_to_func_name "$UPDATE_Q_SESSION_ARN")"
+                else aws_func=$(resolve_stack_function "$func_name"); fi ;;
+            *)  aws_func=$(resolve_stack_function "$func_name") ;;
+        esac
+
+        if [ -z "$aws_func" ]; then
+            warn "$func_name: no matching function in stack, skipping"
+            continue
+        fi
+
+        echo -n "   $aws_func <- $func_name/$entry_file ... "
+        (cd "$func_dir" && zip -qj /tmp/_deploy.zip "$entry_file")
+        retry=0
+        while [ $retry -lt 3 ]; do
+            if aws lambda update-function-code --function-name "$aws_func" \
+                --zip-file fileb:///tmp/_deploy.zip --region "$REGION" \
+                --output text --query 'FunctionName' &>/dev/null; then
+                aws lambda wait function-updated --function-name "$aws_func" --region "$REGION" 2>/dev/null || true
+                echo "✅"; break
             else
-                entry_file=$(ls "$func_dir" | head -1)
+                retry=$((retry+1))
+                [ $retry -lt 3 ] && { echo -n "⏳ "; sleep 5; } || echo "⚠️ failed"
             fi
-
-            [ -z "$entry_file" ] && continue
-
-            # Map function directory name to AWS Lambda function name
-            case "$func_name" in
-                customer_lookup)  aws_func="${PROJECT_NAME}-customer-lookup-${ENVIRONMENT}" ;;
-                update_q_session) aws_func="${PROJECT_NAME}-update-qsession-${ENVIRONMENT}" ;;
-                *)
-                    kebab=$(echo "$func_name" | sed 's/_/-/g' | sed 's/\([A-Z]\)/-\L\1/g' | sed 's/^-//')
-                    aws_func="${PROJECT_NAME}-${ENVIRONMENT}-${kebab}"
-                    ;;
-            esac
-
-            # update_q_session is optional — only declared in the CFn template when
-            # the interview captured a Q-in-Connect session-update requirement.
-            # If the function isn't in the deployed stack, skip quietly with a
-            # friendly message instead of failing Step 2 with ResourceNotFoundException.
-            if [ "$func_name" = "update_q_session" ] && [ -z "${UPDATE_Q_SESSION_ARN:-}" ]; then
-                echo "   ⏭️  $aws_func <- $func_name/$entry_file ... skipped (not declared in this stack's CloudFormation — Q session update is optional)"
-                continue
-            fi
-
-            echo -n "   $aws_func <- $func_name/$entry_file ... "
-            (cd "$func_dir" && zip -qj /tmp/_deploy.zip "$entry_file")
-
-            # Update with retry (handle ResourceConflictException)
-            retry_count=0
-            max_retries=3
-            while [ $retry_count -lt $max_retries ]; do
-                if aws lambda update-function-code --function-name "$aws_func" \
-                    --zip-file fileb:///tmp/_deploy.zip --region "$REGION" \
-                    --output text --query 'FunctionName' &>/dev/null; then
-                    aws lambda wait function-updated --function-name "$aws_func" --region "$REGION" 2>/dev/null || true
-                    echo "✅"
-                    break
-                else
-                    retry_count=$((retry_count + 1))
-                    if [ $retry_count -lt $max_retries ]; then
-                        echo -n "⏳(retry $retry_count) "
-                        sleep 5
-                    else
-                        echo "⚠️ failed after $max_retries attempts"
-                    fi
-                fi
-            done
-            rm -f /tmp/_deploy.zip
         done
-    fi
+        rm -f /tmp/_deploy.zip
 
-    # =============================================================================
-    # Step 3: Update OpenAPI spec & upload to S3
-    # =============================================================================
-    echo ""
-    echo "📝 Step 3: Updating OpenAPI spec..."
-
-    if [ -d "$SCRIPT_DIR/openapi" ]; then
-        # Normalize: strip scheme, strip trailing slash, strip a stray `/tools` suffix.
-        # `ApiEndpoint` should be the stage root (`.../dev`). A trailing `/tools` would
-        # collide with OpenAPI `paths: /tools/...` and produce `.../tools/tools/<op>` →
-        # API Gateway returns 403 "Missing Authentication Token". Guard against that here
-        # so a legacy/mis-generated CloudFormation Output doesn't silently break routing.
-        API_HOST=$(echo "$API_ENDPOINT" | sed -E 's|^https?://||; s|/+$||; s|/tools/?$||')
-        if [ "$API_HOST" != "$(echo "$API_ENDPOINT" | sed -E 's|^https?://||; s|/+$||')" ]; then
-            echo "   ⚠️  Stripped trailing '/tools' from ApiEndpoint (OpenAPI paths already carry '/tools/...')"
+        # ── Reconcile the Handler config with the code's actual entry point ──
+        #    The CFN placeholder may declare index.lambda_handler while the
+        #    generated code defines `def handler` (or vice versa) — that
+        #    mismatch surfaces only at call time as Runtime.HandlerNotFound
+        #    (found live: customer-lookup broke personalization mid-call).
+        local WANT_HANDLER=""
+        case "$entry_file" in
+            *.py)
+                if grep -qE '^def lambda_handler\b' "$func_dir/$entry_file"; then WANT_HANDLER="index.lambda_handler"
+                elif grep -qE '^def handler\b' "$func_dir/$entry_file"; then WANT_HANDLER="index.handler"; fi ;;
+            *.js|*.mjs)
+                if grep -qE 'exports\.handler|export const handler|export async function handler' "$func_dir/$entry_file"; then WANT_HANDLER="index.handler"; fi ;;
+        esac
+        if [ -n "$WANT_HANDLER" ]; then
+            local CUR_HANDLER
+            CUR_HANDLER=$(aws lambda get-function-configuration --function-name "$aws_func" \
+                --region "$REGION" --query 'Handler' --output text 2>/dev/null || echo "")
+            if [ -n "$CUR_HANDLER" ] && [ "$CUR_HANDLER" != "$WANT_HANDLER" ]; then
+                aws lambda update-function-configuration --function-name "$aws_func" \
+                    --handler "$WANT_HANDLER" --region "$REGION" >/dev/null 2>&1 \
+                    && aws lambda wait function-updated --function-name "$aws_func" --region "$REGION" 2>/dev/null \
+                    && info "$aws_func: handler fixed ($CUR_HANDLER -> $WANT_HANDLER)" \
+                    || warn "$aws_func: handler mismatch ($CUR_HANDLER vs code's $WANT_HANDLER) — fix manually"
+            fi
         fi
-        find "$SCRIPT_DIR/openapi" -name "openapi.yaml" | while read -r f; do
-            sed -i.bak "s|{API_ENDPOINT}|$API_HOST|g" "$f" && rm -f "${f}.bak"
-            echo "   ✅ Updated: $f"
-        done
-        # Upload to S3 for MCP Gateway
-        if [ -n "${KB_BUCKET:-}" ]; then
-            aws s3 sync "$SCRIPT_DIR/openapi" "s3://$KB_BUCKET/openapi/" \
-                --exclude "*.DS_Store" --exclude "*.bak" --region "$REGION"
-            echo "   ✅ Uploaded to s3://$KB_BUCKET/openapi/"
+    done
+}
+
+# =============================================================================
+# Phase 3: OpenAPI spec update & upload
+# =============================================================================
+phase_openapi() {
+    echo ""
+    echo "📝 Phase 3: Updating OpenAPI spec..."
+    [ -d "$SCRIPT_DIR/openapi" ] || { info "No openapi/ directory, skipping"; return 0; }
+
+    API_HOST=$(echo "$API_ENDPOINT" | sed -E 's|^https?://||; s|/+$||; s|/tools/?$||')
+    if [ -z "$API_HOST" ] || [ "$API_HOST" = "None" ]; then
+        warn "API endpoint unresolved — skipping OpenAPI host substitution (re-run after the stack is healthy)"
+        return 0
+    fi
+    find "$SCRIPT_DIR/openapi" -name "*.yaml" | while read -r f; do
+        # Substitute from a pristine copy so a failed earlier run (which may
+        # have baked in a stale/None host) can never poison later runs.
+        [ -f "${f}.orig" ] || cp "$f" "${f}.orig"
+        sed "s|{API_ENDPOINT}|$API_HOST|g" "${f}.orig" > "$f"
+        # If the pristine copy predates this fix and lacks the placeholder,
+        # also rewrite any literal host (incl. a broken https://None).
+        sed -i.bak -E "s|https://[A-Za-z0-9.-]+\.execute-api\.[a-z0-9-]+\.amazonaws\.com/[A-Za-z0-9]+|https://$API_HOST|g; s|https://None|https://$API_HOST|g" "$f" && rm -f "${f}.bak"
+        info "Updated: ${f#$SCRIPT_DIR/}"
+    done
+    if [ -n "${KB_BUCKET:-}" ]; then
+        if aws s3 sync "$SCRIPT_DIR/openapi" "s3://$KB_BUCKET/openapi/" \
+            --exclude "*.DS_Store" --exclude "*.bak" --region "$REGION" >/dev/null 2>&1; then
+            ok "Uploaded to s3://$KB_BUCKET/openapi/"
+        else
+            warn "OpenAPI upload failed (bucket missing?) — check the stack, then re-run"
         fi
     fi
+}
 
-    # =============================================================================
-    # Step 4: Upload FAQ documents
-    # =============================================================================
+# =============================================================================
+# Phase 4: FAQ upload
+# =============================================================================
+phase_faq() {
     echo ""
-    echo "📚 Step 4: Uploading FAQ documents..."
-
+    echo "📚 Phase 4: Uploading FAQ documents..."
     FAQ_DIR="$SCRIPT_DIR/faq/knowledge_base"
+    [ -d "$FAQ_DIR" ] || FAQ_DIR="$SCRIPT_DIR/faq"
     if [ -d "$FAQ_DIR" ] && [ -n "${KB_BUCKET:-}" ]; then
         count=$(find "$FAQ_DIR" -name "*.txt" | wc -l | tr -d ' ')
-        aws s3 sync "$FAQ_DIR" "s3://$KB_BUCKET/faq/" --exclude "*.DS_Store" --region "$REGION"
-        echo "   ✅ $count documents -> s3://$KB_BUCKET/faq/"
+        aws s3 sync "$FAQ_DIR" "s3://$KB_BUCKET/faq/" --exclude "*.DS_Store" --region "$REGION" >/dev/null
+        ok "$count documents -> s3://$KB_BUCKET/faq/"
     else
-        echo "   ⚠️ No FAQ directory or KB bucket, skipping."
+        info "No FAQ directory or KB bucket, skipping"
     fi
+}
 
-    # =============================================================================
-    # Step 5: Amazon Connect Instance - Create or Select
-    # =============================================================================
+# =============================================================================
+# Phase 5: Amazon Connect Instance — interactive create/select
+# =============================================================================
+phase_connect_instance() {
     echo ""
-    echo "📞 Step 5: Setting up Amazon Connect instance..."
+    echo "📞 Phase 5: Setting up Amazon Connect instance..."
 
     if [ -n "${CONNECT_INSTANCE_ID:-}" ]; then
-        echo "   Using pre-configured CONNECT_INSTANCE_ID: $CONNECT_INSTANCE_ID"
+        info "Using CONNECT_INSTANCE_ID from env: $CONNECT_INSTANCE_ID"
     else
-        # List existing Connect instances
+        local saved
+        saved=$(state_get CONNECT_INSTANCE_ID)
         INSTANCES_JSON=$(aws connect list-instances --region "$REGION" --output json 2>/dev/null || echo '{"InstanceSummaryList":[]}')
-        INSTANCE_COUNT=$(echo "$INSTANCES_JSON" | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('InstanceSummaryList',[])))" 2>/dev/null || echo "0")
+        INSTANCE_COUNT=$(jget "$INSTANCES_JSON" "InstanceSummaryList" | python3 -c "import sys,json; print(len(json.load(sys.stdin)))" 2>/dev/null || echo 0)
 
         if [ "$INSTANCE_COUNT" -eq 0 ]; then
-            # No instances — create one
-            echo "   No Connect instances found. Creating a new one..."
+            info "No Connect instance found. Creating a new one..."
+            # Instance aliases are GLOBALLY unique (like S3 buckets) — retry
+            # with a random suffix if the deterministic name is taken.
             ALIAS="aicc-workshop-${ACCOUNT_ID: -4}"
-            CREATE_RESULT=$(aws connect create-instance \
-                --identity-management-type "CONNECT_MANAGED" \
-                --instance-alias "$ALIAS" \
-                --inbound-calls-enabled \
-                --outbound-calls-enabled \
-                --region "$REGION" --output json 2>&1)
-
-            CONNECT_INSTANCE_ID=$(echo "$CREATE_RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin)['Id'])")
-            echo "   Created Connect instance: $CONNECT_INSTANCE_ID (alias: $ALIAS)"
-
-            # Wait for instance to become ACTIVE
-            echo -n "   Waiting for instance to become ACTIVE..."
+            CONNECT_INSTANCE_ID=""
+            for alias_try in 1 2 3; do
+                CREATE_RESULT=$(aws connect create-instance \
+                    --identity-management-type "CONNECT_MANAGED" \
+                    --instance-alias "$ALIAS" \
+                    --inbound-calls-enabled --outbound-calls-enabled \
+                    --region "$REGION" --output json 2>&1) || true
+                CONNECT_INSTANCE_ID=$(jget "$CREATE_RESULT" "Id")
+                [ -n "$CONNECT_INSTANCE_ID" ] && break
+                if echo "$CREATE_RESULT" | grep -q "alias is already used"; then
+                    ALIAS="aicc-workshop-${ACCOUNT_ID: -4}-$(openssl rand -hex 2 2>/dev/null || printf '%04x' $((RANDOM % 65536)))"
+                    warn "Instance alias taken (aliases are globally unique) — retrying as: $ALIAS"
+                else
+                    warn "create-instance failed: $(echo "$CREATE_RESULT" | head -2)"
+                    break
+                fi
+            done
+            [ -z "$CONNECT_INSTANCE_ID" ] && { echo "❌ Could not create a Connect instance."; exit 1; }
+            info "Created: $CONNECT_INSTANCE_ID (alias: $ALIAS)"
+            echo -n "   Waiting for ACTIVE..."
             for i in $(seq 1 60); do
                 STATUS=$(aws connect describe-instance --instance-id "$CONNECT_INSTANCE_ID" --region "$REGION" \
                     --query 'Instance.InstanceStatus' --output text 2>/dev/null || echo "UNKNOWN")
-                if [ "$STATUS" = "ACTIVE" ]; then
-                    echo " ✅"
-                    break
-                fi
-                echo -n "."
-                sleep 10
+                [ "$STATUS" = "ACTIVE" ] && { echo " ✅"; break; }
+                echo -n "."; sleep 10
             done
-
-        elif [ "$INSTANCE_COUNT" -eq 1 ]; then
-            # Exactly one instance — use it
-            CONNECT_INSTANCE_ID=$(echo "$INSTANCES_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['InstanceSummaryList'][0]['Id'])")
-            CONNECT_ALIAS=$(echo "$INSTANCES_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['InstanceSummaryList'][0].get('InstanceAlias','N/A'))")
-            echo "   Found 1 Connect instance: $CONNECT_ALIAS ($CONNECT_INSTANCE_ID)"
-
         else
-            # Multiple instances — interactive selection
-            echo "   Found $INSTANCE_COUNT Connect instances:"
-            echo "$INSTANCES_JSON" | python3 -c "
+            # Build menu from all instances (+ create-new option)
+            local menu=() ids=() default_idx=1 i=1
+            while IFS=$'\t' read -r id alias; do
+                menu+=("$alias ($id)")
+                ids+=("$id")
+                [ -n "$saved" ] && [ "$id" = "$saved" ] && default_idx=$i
+                i=$((i+1))
+            done < <(echo "$INSTANCES_JSON" | python3 -c "
 import sys, json
-instances = json.load(sys.stdin)['InstanceSummaryList']
-for i, inst in enumerate(instances):
-    print(f\"   [{i+1}] {inst.get('InstanceAlias','N/A')} ({inst['Id']})\")
-"
-            echo ""
-            read -p "   Select instance number [1-$INSTANCE_COUNT]: " SELECTION
-            CONNECT_INSTANCE_ID=$(echo "$INSTANCES_JSON" | python3 -c "
-import sys, json
-instances = json.load(sys.stdin)['InstanceSummaryList']
-idx = int('${SELECTION}') - 1
-if 0 <= idx < len(instances):
-    print(instances[idx]['Id'])
-else:
-    print('')
+for inst in json.load(sys.stdin)['InstanceSummaryList']:
+    print(inst['Id'] + '\t' + inst.get('InstanceAlias','N/A'))
 ")
-            if [ -z "$CONNECT_INSTANCE_ID" ]; then
-                echo "   ❌ Invalid selection."
-                exit 1
+            menu+=("Create a new instance")
+            choose "Which Connect instance do you want to deploy to?" "$default_idx" "${menu[@]}"
+            if [ "$CHOICE_VALUE" = "Create a new instance" ]; then
+                ask_text "New instance alias" "aicc-workshop-${ACCOUNT_ID: -4}"
+                ALIAS="$ANSWER"
+                CREATE_RESULT=$(aws connect create-instance \
+                    --identity-management-type "CONNECT_MANAGED" \
+                    --instance-alias "$ALIAS" \
+                    --inbound-calls-enabled --outbound-calls-enabled \
+                    --region "$REGION" --output json)
+                CONNECT_INSTANCE_ID=$(jget "$CREATE_RESULT" "Id")
+                echo -n "   Waiting for ACTIVE..."
+                for i in $(seq 1 60); do
+                    STATUS=$(aws connect describe-instance --instance-id "$CONNECT_INSTANCE_ID" --region "$REGION" \
+                        --query 'Instance.InstanceStatus' --output text 2>/dev/null || echo "UNKNOWN")
+                    [ "$STATUS" = "ACTIVE" ] && { echo " ✅"; break; }
+                    echo -n "."; sleep 10
+                done
+            else
+                CONNECT_INSTANCE_ID="${ids[$((CHOICE-1))]}"
             fi
         fi
-
     fi
+    state_set CONNECT_INSTANCE_ID "$CONNECT_INSTANCE_ID"
 
-    # Enable all required instance attributes (Lex, monitoring, transcription, etc.)
-    echo "   Enabling instance attributes..."
+    # Enable instance attributes.
+    #   BOT_MANAGEMENT + ENABLE_BOT_ANALYTICS_AND_TRANSCRIPTS unlock the Connect
+    #   console bot-building experience (Flows > Bots tab) so Lex bots can be
+    #   viewed/managed through Connect — without them the tab is hidden and the
+    #   bot appears "uncontrollable" from the Connect console.
+    #   MESSAGE_STREAMING reduces AI agent response latency.
+    info "Enabling instance attributes..."
     for attr in ENHANCED_CONTACT_MONITORING USE_CUSTOM_TTS_VOICES AUTO_RESOLVE_BEST_VOICES \
                  CONTACTFLOW_LOGS CONTACT_LENS MULTI_PARTY_CONFERENCE \
-                 HIGH_VOLUME_OUTBOUND EARLY_MEDIA; do
+                 BOT_MANAGEMENT ENABLE_BOT_ANALYTICS_AND_TRANSCRIPTS \
+                 HIGH_VOLUME_OUTBOUND EARLY_MEDIA MESSAGE_STREAMING; do
         aws connect update-instance-attribute \
-            --instance-id "$CONNECT_INSTANCE_ID" \
-            --attribute-type "$attr" \
-            --value "true" \
-            --region "$REGION" 2>/dev/null || true
+            --instance-id "$CONNECT_INSTANCE_ID" --attribute-type "$attr" \
+            --value "true" --region "$REGION" 2>/dev/null || true
     done
 
-    # Configure storage for call recordings and chat transcripts
-    echo "   Configuring storage for recordings and transcripts..."
+    # Storage config for recordings/transcripts
     CONNECT_STORAGE_BUCKET="${PROJECT_NAME}-connect-${ACCOUNT_ID}-${REGION}"
-    if ! aws s3 ls "s3://$CONNECT_STORAGE_BUCKET" --region "$REGION" 2>/dev/null; then
-        echo "   Creating storage bucket: $CONNECT_STORAGE_BUCKET"
+    if ! aws s3 ls "s3://$CONNECT_STORAGE_BUCKET" --region "$REGION" &>/dev/null; then
         if [ "$REGION" = "us-east-1" ]; then
-            aws s3api create-bucket --bucket "$CONNECT_STORAGE_BUCKET" --region "$REGION" 2>/dev/null || true
+            aws s3api create-bucket --bucket "$CONNECT_STORAGE_BUCKET" --region "$REGION" >/dev/null 2>&1 || true
         else
             aws s3api create-bucket --bucket "$CONNECT_STORAGE_BUCKET" --region "$REGION" \
-                --create-bucket-configuration LocationConstraint="$REGION" 2>/dev/null || true
+                --create-bucket-configuration LocationConstraint="$REGION" >/dev/null 2>&1 || true
         fi
     fi
     for STORAGE_TYPE in CALL_RECORDINGS CHAT_TRANSCRIPTS; do
         aws connect associate-instance-storage-config \
-            --instance-id "$CONNECT_INSTANCE_ID" \
-            --resource-type "$STORAGE_TYPE" \
-            --storage-config "{
-                \"StorageType\": \"S3\",
-                \"S3Config\": {
-                    \"BucketName\": \"${CONNECT_STORAGE_BUCKET}\",
-                    \"BucketPrefix\": \"${STORAGE_TYPE}\"
-                }
-            }" \
+            --instance-id "$CONNECT_INSTANCE_ID" --resource-type "$STORAGE_TYPE" \
+            --storage-config "{\"StorageType\":\"S3\",\"S3Config\":{\"BucketName\":\"${CONNECT_STORAGE_BUCKET}\",\"BucketPrefix\":\"${STORAGE_TYPE}\"}}" \
             --region "$REGION" 2>/dev/null || true
     done
-    echo "   ✅ Storage configured: s3://$CONNECT_STORAGE_BUCKET"
 
-    # Get instance alias for later use (discovery URL)
     CONNECT_ALIAS=$(aws connect describe-instance --instance-id "$CONNECT_INSTANCE_ID" --region "$REGION" \
         --query 'Instance.InstanceAlias' --output text 2>/dev/null || echo "")
     CONNECT_INSTANCE_ARN=$(aws connect describe-instance --instance-id "$CONNECT_INSTANCE_ID" --region "$REGION" \
         --query 'Instance.Arn' --output text 2>/dev/null || echo "")
+    ok "Connect instance: $CONNECT_INSTANCE_ID (alias: ${CONNECT_ALIAS:-N/A})"
+}
 
-    echo "   ✅ Connect Instance: $CONNECT_INSTANCE_ID (alias: ${CONNECT_ALIAS:-N/A})"
-
-    # =============================================================================
-    # Step 6: Q in Connect Assistant - Create or Select
-    # =============================================================================
+# =============================================================================
+# Phase 6: Q in Connect Assistant + Knowledge Base
+# =============================================================================
+phase_assistant() {
     echo ""
-    echo "🤖 Step 6: Setting up Q in Connect Assistant..."
+    echo "🤖 Phase 6: Setting up Q in Connect Assistant..."
 
     if [ -n "${AI_ASSISTANT_ID:-}" ]; then
-        echo "   Using pre-configured AI_ASSISTANT_ID: $AI_ASSISTANT_ID"
+        info "Using AI_ASSISTANT_ID from env: $AI_ASSISTANT_ID"
         ASSISTANT_ARN="arn:aws:wisdom:${REGION}:${ACCOUNT_ID}:assistant/${AI_ASSISTANT_ID}"
     else
-        # Check for existing assistant integration
         EXISTING_ASSOC=$(aws connect list-integration-associations \
-            --instance-id "$CONNECT_INSTANCE_ID" \
-            --integration-type WISDOM_ASSISTANT \
+            --instance-id "$CONNECT_INSTANCE_ID" --integration-type WISDOM_ASSISTANT \
             --region "$REGION" --output json 2>/dev/null || echo '{"IntegrationAssociationSummaryList":[]}')
-
-        ASSOC_COUNT=$(echo "$EXISTING_ASSOC" | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('IntegrationAssociationSummaryList',[])))" 2>/dev/null || echo "0")
+        ASSOC_COUNT=$(echo "$EXISTING_ASSOC" | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('IntegrationAssociationSummaryList',[])))" 2>/dev/null || echo 0)
 
         if [ "$ASSOC_COUNT" -gt 0 ]; then
-            # Use existing assistant
             ASSISTANT_ARN=$(echo "$EXISTING_ASSOC" | python3 -c "import sys,json; print(json.load(sys.stdin)['IntegrationAssociationSummaryList'][0]['IntegrationArn'])")
             AI_ASSISTANT_ID=$(echo "$ASSISTANT_ARN" | awk -F'/' '{print $NF}')
-            echo "   Found existing assistant: $AI_ASSISTANT_ID"
+            info "Using assistant already associated with instance: $AI_ASSISTANT_ID"
         else
-            # Create new assistant
-            echo "   Creating new Q in Connect assistant..."
+            info "Creating new Q in Connect assistant..."
             CREATE_ASSISTANT=$(aws qconnect create-assistant \
-                --name "${PROJECT_NAME}-assistant" \
-                --type AGENT \
+                --name "${PROJECT_NAME}-assistant" --type AGENT \
                 --description "AI assistant for ${PROJECT_NAME}" \
-                --region "$REGION" --output json 2>&1)
-
-            if echo "$CREATE_ASSISTANT" | python3 -c "import sys,json; json.load(sys.stdin)['assistant']" &>/dev/null; then
-                AI_ASSISTANT_ID=$(echo "$CREATE_ASSISTANT" | python3 -c "import sys,json; print(json.load(sys.stdin)['assistant']['assistantId'])")
-                ASSISTANT_ARN=$(echo "$CREATE_ASSISTANT" | python3 -c "import sys,json; print(json.load(sys.stdin)['assistant']['assistantArn'])")
-                echo "   Created assistant: $AI_ASSISTANT_ID"
-
-                # Wait for assistant to become ACTIVE
-                echo -n "   Waiting for assistant to become ACTIVE..."
-                for i in $(seq 1 30); do
-                    ASTATUS=$(aws qconnect get-assistant --assistant-id "$AI_ASSISTANT_ID" --region "$REGION" \
-                        --query 'assistant.status' --output text 2>/dev/null || echo "UNKNOWN")
-                    if [ "$ASTATUS" = "ACTIVE" ]; then
-                        echo " ✅"
-                        break
-                    fi
-                    echo -n "."
-                    sleep 5
-                done
-
-                # Create integration association with Connect
-                echo "   Connecting assistant to Connect instance..."
-                aws connect create-integration-association \
-                    --instance-id "$CONNECT_INSTANCE_ID" \
-                    --integration-type WISDOM_ASSISTANT \
-                    --integration-arn "$ASSISTANT_ARN" \
-                    --region "$REGION" 2>/dev/null || echo "   (Association may already exist)"
-            else
-                echo "   ⚠️ Failed to create assistant. Continuing without Q in Connect."
-                echo "   Error: $CREATE_ASSISTANT"
-                AI_ASSISTANT_ID=""
-            fi
+                --region "$REGION" --output json)
+            AI_ASSISTANT_ID=$(jget "$CREATE_ASSISTANT" "assistant.assistantId")
+            ASSISTANT_ARN=$(jget "$CREATE_ASSISTANT" "assistant.assistantArn")
+            echo -n "   Waiting for ACTIVE..."
+            for i in $(seq 1 30); do
+                ASTATUS=$(aws qconnect get-assistant --assistant-id "$AI_ASSISTANT_ID" --region "$REGION" \
+                    --query 'assistant.status' --output text 2>/dev/null || echo "UNKNOWN")
+                [ "$ASTATUS" = "ACTIVE" ] && { echo " ✅"; break; }
+                echo -n "."; sleep 5
+            done
+            info "Associating with Connect instance..."
+            aws connect create-integration-association \
+                --instance-id "$CONNECT_INSTANCE_ID" \
+                --integration-type WISDOM_ASSISTANT \
+                --integration-arn "$ASSISTANT_ARN" \
+                --region "$REGION" >/dev/null 2>&1 || info "(already associated)"
         fi
     fi
+    state_set AI_ASSISTANT_ID "$AI_ASSISTANT_ID"
+    ok "Assistant: $AI_ASSISTANT_ID"
 
-    echo "   ✅ AI Assistant ID: ${AI_ASSISTANT_ID:-N/A}"
-
-    # =============================================================================
-    # Step 6.5: Knowledge Base Connection (if FAQ exists)
-    # =============================================================================
+    # Knowledge Base (only when FAQ assets exist)
     if [ -d "$SCRIPT_DIR/faq" ] && [ -n "${AI_ASSISTANT_ID:-}" ]; then
-        echo ""
-        echo "📖 Step 6.5: Setting up Knowledge Base for FAQ..."
-
-        # Check if KB already exists
+        info "Setting up FAQ Knowledge Base..."
         EXISTING_KB=$(aws qconnect list-knowledge-bases --region "$REGION" --output json 2>/dev/null || echo '{"knowledgeBaseSummaries":[]}')
         KB_ID=$(echo "$EXISTING_KB" | python3 -c "
 import sys, json
-kbs = json.load(sys.stdin).get('knowledgeBaseSummaries', [])
-for kb in kbs:
-    if kb.get('name') == '${KB_NAME}':
-        print(kb['knowledgeBaseId'])
-        break
-else:
-    print('')
+for kb in json.load(sys.stdin).get('knowledgeBaseSummaries', []):
+    if kb.get('name') == '${KB_NAME}': print(kb['knowledgeBaseId']); break
 " 2>/dev/null || echo "")
-
         if [ -z "$KB_ID" ]; then
-            # Create knowledge base
-            echo "   Creating knowledge base: $KB_NAME"
             CREATE_KB=$(aws qconnect create-knowledge-base \
-                --name "$KB_NAME" \
-                --knowledge-base-type CUSTOM \
+                --name "$KB_NAME" --knowledge-base-type CUSTOM \
                 --description "FAQ knowledge base for ${PROJECT_NAME}" \
-                --region "$REGION" --output json 2>&1)
-
-            if echo "$CREATE_KB" | python3 -c "import sys,json; json.load(sys.stdin)['knowledgeBase']" &>/dev/null; then
-                KB_ID=$(echo "$CREATE_KB" | python3 -c "import sys,json; print(json.load(sys.stdin)['knowledgeBase']['knowledgeBaseId'])")
-                echo "   Created KB: $KB_ID"
-            else
-                echo "   ⚠️ Failed to create knowledge base: $CREATE_KB"
-            fi
+                --region "$REGION" --output json 2>&1) || true
+            KB_ID=$(jget "$CREATE_KB" "knowledgeBase.knowledgeBaseId")
+            [ -n "$KB_ID" ] && info "KB created: $KB_ID" || warn "KB creation failed"
         else
-            echo "   Found existing KB: $KB_ID"
+            info "Using existing KB: $KB_ID"
         fi
-
-        # Associate KB with assistant
         if [ -n "$KB_ID" ]; then
-            echo "   Associating KB with assistant..."
             aws qconnect create-assistant-association \
                 --assistant-id "$AI_ASSISTANT_ID" \
                 --association-type KNOWLEDGE_BASE \
                 --association "knowledgeBaseId=$KB_ID" \
-                --region "$REGION" 2>/dev/null || echo "   (Association may already exist)"
-            echo "   ✅ Knowledge Base connected to assistant"
-            echo "   ℹ️  FAQ sync: S3 data source 연결은 콘솔에서 진행하세요."
-            echo "        Bucket: s3://${KB_BUCKET:-N/A}/faq/"
+                --region "$REGION" >/dev/null 2>&1 || info "(KB already associated)"
+            ok "Knowledge Base associated"
         fi
     fi
+}
 
-    # =============================================================================
-    # Step 7: Lambda Environment Variable Injection
-    # =============================================================================
+# =============================================================================
+# Phase 7: Lambda environment variables
+# =============================================================================
+phase_env_vars() {
     echo ""
-    echo "🔑 Step 7: Injecting Lambda environment variables..."
-
+    echo "🔑 Phase 7: Injecting Lambda environment variables..."
+    # Prefer the exported ARN; fall back to fuzzy-matching the stack's Lambdas
+    # (many generated templates don't export UpdateQSessionFunctionArn)
     if [ -z "${UPDATE_Q_SESSION_ARN:-}" ]; then
-        echo "   ⏭️  Skipping — $UPDATE_Q_FUNC is not declared in this stack's CloudFormation"
-        echo "      (Q session update is optional; only needed when the interview captured a"
-        echo "      Q-in-Connect session-update requirement)."
-    elif [ -n "${CONNECT_INSTANCE_ID:-}" ] && [ -n "${AI_ASSISTANT_ID:-}" ]; then
-        echo "   Updating $UPDATE_Q_FUNC with CONNECT_INSTANCE_ID and AI_ASSISTANT_ID..."
-
-        # Get existing environment variables to merge
-        EXISTING_ENV=$(aws lambda get-function-configuration \
-            --function-name "$UPDATE_Q_FUNC" --region "$REGION" \
-            --query 'Environment.Variables' --output json 2>/dev/null || echo '{}')
-
-        # Merge new variables with existing ones
-        MERGED_ENV=$(echo "$EXISTING_ENV" | python3 -c "
+        resolved=$(resolve_stack_function "update_q_session")
+        [ -z "$resolved" ] && resolved=$(resolve_stack_function "update_qsession")
+        if [ -n "$resolved" ]; then
+            UPDATE_Q_FUNC="$resolved"
+            info "Resolved from stack resources: $UPDATE_Q_FUNC"
+        else
+            info "update_q_session Lambda not in stack, skipping"
+            return 0
+        fi
+    fi
+    EXISTING_ENV=$(aws lambda get-function-configuration \
+        --function-name "$UPDATE_Q_FUNC" --region "$REGION" \
+        --query 'Environment.Variables' --output json 2>/dev/null || echo '{}')
+    MERGED_ENV=$(echo "$EXISTING_ENV" | python3 -c "
 import sys, json
 raw = sys.stdin.read().strip()
-try:
-    env = json.loads(raw) if raw and raw != 'null' and raw != 'None' else {}
-except:
-    env = {}
-if not isinstance(env, dict):
-    env = {}
+try: env = json.loads(raw) if raw not in ('', 'null', 'None') else {}
+except Exception: env = {}
+if not isinstance(env, dict): env = {}
 env['CONNECT_INSTANCE_ID'] = '${CONNECT_INSTANCE_ID}'
 env['AI_ASSISTANT_ID'] = '${AI_ASSISTANT_ID}'
 print(json.dumps({'Variables': env}))
-" 2>/dev/null || echo "{\"Variables\":{\"CONNECT_INSTANCE_ID\":\"${CONNECT_INSTANCE_ID}\",\"AI_ASSISTANT_ID\":\"${AI_ASSISTANT_ID}\"}}")
+")
+    retry=0
+    while [ $retry -lt 3 ]; do
+        if aws lambda update-function-configuration \
+            --function-name "$UPDATE_Q_FUNC" --environment "$MERGED_ENV" \
+            --region "$REGION" --output text --query 'FunctionName' &>/dev/null; then
+            aws lambda wait function-updated --function-name "$UPDATE_Q_FUNC" --region "$REGION" 2>/dev/null || true
+            ok "Environment variables injected ($UPDATE_Q_FUNC)"
+            break
+        fi
+        retry=$((retry+1)); sleep 5
+    done
+    [ $retry -ge 3 ] && warn "Failed to inject environment variables"
 
-        # Retry loop for environment variable update
-        retry_count=0
-        max_retries=3
-        while [ $retry_count -lt $max_retries ]; do
-            if aws lambda update-function-configuration \
-                --function-name "$UPDATE_Q_FUNC" \
-                --environment "$MERGED_ENV" \
-                --region "$REGION" --output text --query 'FunctionName' &>/dev/null; then
-                aws lambda wait function-updated --function-name "$UPDATE_Q_FUNC" --region "$REGION" 2>/dev/null || true
-                echo "   ✅ Environment variables injected"
-                break
-            else
-                retry_count=$((retry_count + 1))
-                if [ $retry_count -lt $max_retries ]; then
-                    echo "   ⏳ Retry $retry_count..."
-                    sleep 5
-                else
-                    echo "   ⚠️ Failed to update environment variables after $max_retries attempts"
-                fi
-            fi
-        done
-    else
-        echo "   ⚠️ Skipping — CONNECT_INSTANCE_ID or AI_ASSISTANT_ID not set."
-    fi
-
-    # =============================================================================
-    # Step 8: AgentCore Gateway (MCP Server) Creation
-    # =============================================================================
-    echo ""
-    echo "🌐 Step 8: Setting up AgentCore Gateway (MCP Server)..."
-
-    # Check AWS CLI version for bedrock-agentcore-control support
-    if ! aws bedrock-agentcore-control help &>/dev/null 2>&1; then
-        echo "   ⚠️ bedrock-agentcore-control not available in this AWS CLI version."
-        echo "   Please upgrade AWS CLI: pip install --upgrade awscli"
-        echo "   Skipping Steps 8-10."
-        SKIP_GATEWAY=true
-    else
-        SKIP_GATEWAY=false
-    fi
-
-    if [ "$SKIP_GATEWAY" = "false" ] && [ -n "${CONNECT_ALIAS:-}" ]; then
-
-        # Step 8.1: Create or reuse Gateway IAM Role
-        echo "   Setting up IAM role: $ROLE_NAME"
-
-        TRUST_POLICY=$(cat <<'TRUSTEOF'
+    # ── Ensure the execution role can reach Connect + Q in Connect ──────────
+    #    Generated CFN templates often grant only AWSLambdaBasicExecutionRole,
+    #    but the handler calls connect:DescribeContact (to resolve the Wisdom
+    #    session ARN) and wisdom:UpdateSessionData/GetSession at runtime.
+    #    Without this the call fails with AccessDeniedException mid-call.
+    QSESSION_ROLE_ARN=$(aws lambda get-function-configuration \
+        --function-name "$UPDATE_Q_FUNC" --region "$REGION" \
+        --query 'Role' --output text 2>/dev/null || echo "")
+    if [ -n "$QSESSION_ROLE_ARN" ]; then
+        QSESSION_ROLE_NAME="${QSESSION_ROLE_ARN##*/}"
+        QSESSION_POLICY=$(cat <<QPEOF
 {
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "ConnectDescribeContact",
       "Effect": "Allow",
-      "Principal": {
-        "Service": "bedrock-agentcore.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
+      "Action": "connect:DescribeContact",
+      "Resource": "arn:aws:connect:${REGION}:${ACCOUNT_ID}:instance/${CONNECT_INSTANCE_ID}/contact/*"
+    },
+    {
+      "Sid": "QConnectSessionData",
+      "Effect": "Allow",
+      "Action": ["wisdom:UpdateSessionData", "wisdom:GetSession", "wisdom:GetAssistant"],
+      "Resource": [
+        "arn:aws:wisdom:${REGION}:${ACCOUNT_ID}:assistant/${AI_ASSISTANT_ID}",
+        "arn:aws:wisdom:${REGION}:${ACCOUNT_ID}:session/${AI_ASSISTANT_ID}/*"
+      ]
     }
   ]
 }
-TRUSTEOF
+QPEOF
 )
+        aws iam put-role-policy \
+            --role-name "$QSESSION_ROLE_NAME" \
+            --policy-name "aicc-qsession-runtime-access" \
+            --policy-document "$QSESSION_POLICY" 2>/dev/null \
+            && ok "Runtime permissions granted to $QSESSION_ROLE_NAME (connect:DescribeContact + wisdom session)" \
+            || warn "Could not attach runtime policy to $QSESSION_ROLE_NAME (check iam:PutRolePolicy permission)"
+    fi
+}
 
-        GATEWAY_ROLE_ARN=$(aws iam get-role --role-name "$ROLE_NAME" \
-            --query 'Role.Arn' --output text 2>/dev/null || echo "")
+# =============================================================================
+# Phase 8: AgentCore Gateway (MCP Server) + JWT audience + Target
+#   FIX: update-gateway now passes --role-arn/--protocol-type (required params
+#   whose omission made the old script's audience update always fail — the
+#   workshop's "Chapter 3 manual fix" is now automated correctly)
+# =============================================================================
+phase_gateway() {
+    echo ""
+    echo "🌐 Phase 8: Setting up AgentCore Gateway (MCP Server)..."
 
-        if [ -z "$GATEWAY_ROLE_ARN" ]; then
-            GATEWAY_ROLE_ARN=$(aws iam create-role \
-                --role-name "$ROLE_NAME" \
-                --assume-role-policy-document "$TRUST_POLICY" \
-                --description "IAM role for ${PROJECT_NAME} AgentCore Gateway" \
-                --query 'Role.Arn' --output text)
-            echo "   Created IAM role: $GATEWAY_ROLE_ARN"
+    SKIP_GATEWAY=false
+    if ! aws bedrock-agentcore-control help &>/dev/null; then
+        warn "bedrock-agentcore-control not available in this CLI. Skipping gateway phases"
+        SKIP_GATEWAY=true; return 0
+    fi
+    [ -z "${CONNECT_ALIAS:-}" ] && { warn "No Connect alias, skipping"; SKIP_GATEWAY=true; return 0; }
 
-            # Attach basic permissions
-            PERMISSION_POLICY=$(cat <<PERMEOF
+    # 8.1 IAM role
+    GATEWAY_ROLE_ARN=$(aws iam get-role --role-name "$ROLE_NAME" \
+        --query 'Role.Arn' --output text 2>/dev/null || echo "")
+    if [ -z "$GATEWAY_ROLE_ARN" ]; then
+        info "Creating Gateway IAM role: $ROLE_NAME"
+        TRUST_POLICY='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"bedrock-agentcore.amazonaws.com"},"Action":"sts:AssumeRole"}]}'
+        GATEWAY_ROLE_ARN=$(aws iam create-role \
+            --role-name "$ROLE_NAME" \
+            --assume-role-policy-document "$TRUST_POLICY" \
+            --description "IAM role for ${PROJECT_NAME} AgentCore Gateway" \
+            --query 'Role.Arn' --output text)
+        PERMISSION_POLICY=$(cat <<PERMEOF
 {
   "Version": "2012-10-17",
   "Statement": [
-    {
-      "Sid": "BedrockAgentCoreFullAccess",
-      "Effect": "Allow",
-      "Action": "bedrock-agentcore:*",
-      "Resource": "arn:aws:bedrock-agentcore:*:${ACCOUNT_ID}:*"
-    },
-    {
-      "Sid": "BedrockInvokeAccess",
-      "Effect": "Allow",
-      "Action": [
-        "bedrock:InvokeModel",
-        "bedrock:InvokeModelWithResponseStream"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Sid": "S3ReadAccess",
-      "Effect": "Allow",
-      "Action": [
-        "s3:GetObject",
-        "s3:GetObjectVersion",
-        "s3:ListBucket"
-      ],
-      "Resource": [
-        "arn:aws:s3:::${KB_BUCKET:-*}",
-        "arn:aws:s3:::${KB_BUCKET:-*}/*",
-        "arn:aws:s3:::bedrock-agentcore-gateway-*",
-        "arn:aws:s3:::bedrock-agentcore-runtime-*"
-      ]
-    },
-    {
-      "Sid": "LambdaAccess",
-      "Effect": "Allow",
-      "Action": [
-        "lambda:InvokeFunction",
-        "lambda:GetFunction"
-      ],
-      "Resource": "arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${PROJECT_NAME}-*"
-    },
-    {
-      "Sid": "SecretsManagerAccess",
-      "Effect": "Allow",
-      "Action": "secretsmanager:GetSecretValue",
-      "Resource": "arn:aws:secretsmanager:${REGION}:${ACCOUNT_ID}:secret:bedrock-agentcore*"
-    }
+    {"Sid": "BedrockAgentCore", "Effect": "Allow", "Action": "bedrock-agentcore:*", "Resource": "arn:aws:bedrock-agentcore:*:${ACCOUNT_ID}:*"},
+    {"Sid": "BedrockInvoke", "Effect": "Allow", "Action": ["bedrock:InvokeModel","bedrock:InvokeModelWithResponseStream"], "Resource": "*"},
+    {"Sid": "S3Read", "Effect": "Allow", "Action": ["s3:GetObject","s3:GetObjectVersion","s3:ListBucket"],
+     "Resource": ["arn:aws:s3:::${KB_BUCKET:-*}","arn:aws:s3:::${KB_BUCKET:-*}/*","arn:aws:s3:::bedrock-agentcore-gateway-*","arn:aws:s3:::bedrock-agentcore-runtime-*"]},
+    {"Sid": "Lambda", "Effect": "Allow", "Action": ["lambda:InvokeFunction","lambda:GetFunction"], "Resource": "arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${PROJECT_NAME}-*"},
+    {"Sid": "Secrets", "Effect": "Allow", "Action": "secretsmanager:GetSecretValue", "Resource": "arn:aws:secretsmanager:${REGION}:${ACCOUNT_ID}:secret:bedrock-agentcore*"}
   ]
 }
 PERMEOF
 )
-            aws iam put-role-policy \
-                --role-name "$ROLE_NAME" \
-                --policy-name "${PROJECT_NAME}-gateway-policy" \
-                --policy-document "$PERMISSION_POLICY"
-            echo "   Attached gateway permissions"
-
-            # Wait for IAM propagation
-            sleep 10
-        else
-            echo "   Reusing existing IAM role: $GATEWAY_ROLE_ARN"
-        fi
-
-        # Step 8.2: Create API Key Credential Provider
-        echo "   Creating API Key credential provider..."
-
-        # Check for existing credential provider
-        EXISTING_CRED=$(aws bedrock-agentcore-control list-api-key-credential-providers \
-            --region "$REGION" --output json 2>/dev/null || echo '{"credentialProviders":[]}')
-
-        CREDENTIAL_PROVIDER_ARN=$(echo "$EXISTING_CRED" | python3 -c "
-import sys, json
-providers = json.load(sys.stdin).get('credentialProviders', [])
-for p in providers:
-    if p.get('name') == '${CRED_PROVIDER_NAME}':
-        print(p['credentialProviderArn'])
-        break
-else:
-    print('')
-" 2>/dev/null || echo "")
-
-        if [ -z "$CREDENTIAL_PROVIDER_ARN" ]; then
-            CRED_RESULT=$(aws bedrock-agentcore-control create-api-key-credential-provider \
-                --name "$CRED_PROVIDER_NAME" \
-                --api-key "$API_KEY" \
-                --region "$REGION" --output json 2>&1)
-
-            CREDENTIAL_PROVIDER_ARN=$(echo "$CRED_RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('credentialProviderArn',''))" 2>/dev/null || echo "")
-
-            if [ -n "$CREDENTIAL_PROVIDER_ARN" ]; then
-                echo "   Created credential provider: $CREDENTIAL_PROVIDER_ARN"
-            else
-                echo "   ⚠️ Failed to create credential provider: $CRED_RESULT"
-                SKIP_GATEWAY=true
-            fi
-        else
-            echo "   Reusing existing credential provider: $CREDENTIAL_PROVIDER_ARN"
-        fi
+        aws iam put-role-policy --role-name "$ROLE_NAME" \
+            --policy-name "${PROJECT_NAME}-gateway-policy" \
+            --policy-document "$PERMISSION_POLICY"
+        info "Waiting for IAM propagation (10s)..."
+        sleep 10
+    else
+        info "Reusing existing IAM role: $GATEWAY_ROLE_ARN"
     fi
 
-    if [ "$SKIP_GATEWAY" = "false" ] && [ -n "${CONNECT_ALIAS:-}" ]; then
-
-        # Step 8.3: Construct Connect Discovery URL
-        DISCOVERY_URL="https://${CONNECT_ALIAS}.my.connect.aws/.well-known/openid-configuration"
-        echo "   Discovery URL: $DISCOVERY_URL"
-
-        # Step 8.4: Create Gateway (with placeholder audience)
-        echo "   Creating Gateway: $GATEWAY_NAME"
-
-        # Check for existing gateway
-        EXISTING_GW=$(aws bedrock-agentcore-control list-gateways \
-            --region "$REGION" --output json 2>/dev/null || echo '{"gateways":[]}')
-
-        GATEWAY_ID=$(echo "$EXISTING_GW" | python3 -c "
+    # 8.2 API Key credential provider
+    EXISTING_CRED=$(aws bedrock-agentcore-control list-api-key-credential-providers \
+        --region "$REGION" --output json 2>/dev/null || echo '{"credentialProviders":[]}')
+    CREDENTIAL_PROVIDER_ARN=$(echo "$EXISTING_CRED" | python3 -c "
 import sys, json
-gateways = json.load(sys.stdin).get('gateways', [])
-for gw in gateways:
-    if gw.get('name') == '${GATEWAY_NAME}':
-        print(gw['gatewayId'])
-        break
-else:
-    print('')
+for p in json.load(sys.stdin).get('credentialProviders', []):
+    if p.get('name') == '${CRED_PROVIDER_NAME}': print(p['credentialProviderArn']); break
+" 2>/dev/null || echo "")
+    if [ -z "$CREDENTIAL_PROVIDER_ARN" ]; then
+        CRED_RESULT=$(aws bedrock-agentcore-control create-api-key-credential-provider \
+            --name "$CRED_PROVIDER_NAME" --api-key "$API_KEY" \
+            --region "$REGION" --output json 2>&1) || true
+        CREDENTIAL_PROVIDER_ARN=$(jget "$CRED_RESULT" "credentialProviderArn")
+        [ -n "$CREDENTIAL_PROVIDER_ARN" ] && info "Credential provider created" || { warn "Credential provider creation failed: $CRED_RESULT"; SKIP_GATEWAY=true; return 0; }
+    else
+        # Refresh the stored key — the stack (and its API key) may have been
+        # recreated since the provider was made, which would break target auth
+        aws bedrock-agentcore-control update-api-key-credential-provider \
+            --name "$CRED_PROVIDER_NAME" --api-key "$API_KEY" \
+            --region "$REGION" >/dev/null 2>&1 \
+            && info "Reusing credential provider (API key refreshed to current stack)" \
+            || info "Reusing existing credential provider"
+    fi
+
+    # 8.3 Gateway
+    DISCOVERY_URL="https://${CONNECT_ALIAS}.my.connect.aws/.well-known/openid-configuration"
+    EXISTING_GW=$(aws bedrock-agentcore-control list-gateways \
+        --region "$REGION" --output json 2>/dev/null || echo '{}')
+    GATEWAY_ID=$(echo "$EXISTING_GW" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for gw in d.get('items', d.get('gateways', [])):
+    if gw.get('name') == '${GATEWAY_NAME}': print(gw['gatewayId']); break
 " 2>/dev/null || echo "")
 
-        if [ -z "$GATEWAY_ID" ]; then
+    if [ -z "$GATEWAY_ID" ]; then
+        info "Creating Gateway: $GATEWAY_NAME"
+        # Fresh IAM roles can take 10-60s to propagate; retry on assume-role /
+        # authorization errors (most common on brand-new accounts)
+        for gw_try in 1 2 3 4 5; do
             GW_RESULT=$(aws bedrock-agentcore-control create-gateway \
                 --name "$GATEWAY_NAME" \
                 --role-arn "$GATEWAY_ROLE_ARN" \
                 --protocol-type MCP \
                 --authorizer-type CUSTOM_JWT \
-                --authorizer-configuration "{
-                    \"customJWTAuthorizer\": {
-                        \"discoveryUrl\": \"${DISCOVERY_URL}\",
-                        \"allowedAudience\": [\"placeholder\"]
-                    }
-                }" \
-                --region "$REGION" --output json 2>&1)
-
-            GATEWAY_ID=$(echo "$GW_RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin).get('gatewayId',''))" 2>/dev/null || echo "")
-
-            if [ -n "$GATEWAY_ID" ]; then
-                echo "   Created Gateway: $GATEWAY_ID"
+                --authorizer-configuration "{\"customJWTAuthorizer\":{\"discoveryUrl\":\"${DISCOVERY_URL}\",\"allowedAudience\":[\"placeholder\"]}}" \
+                --region "$REGION" --output json 2>&1) || true
+            GATEWAY_ID=$(jget "$GW_RESULT" "gatewayId")
+            [ -n "$GATEWAY_ID" ] && break
+            if echo "$GW_RESULT" | grep -qiE 'assume|authoriz|denied|role'; then
+                info "IAM role still propagating (attempt $gw_try/5), waiting 20s..."
+                sleep 20
             else
-                echo "   ⚠️ Failed to create gateway: $GW_RESULT"
-                SKIP_GATEWAY=true
+                break
+            fi
+        done
+        [ -n "$GATEWAY_ID" ] && info "Gateway created: $GATEWAY_ID" || { warn "Gateway creation failed: $GW_RESULT"; SKIP_GATEWAY=true; return 0; }
+    else
+        info "Reusing existing Gateway: $GATEWAY_ID"
+    fi
+    state_set GATEWAY_ID "$GATEWAY_ID"
+
+    # 8.4 Wait READY
+    echo -n "   Waiting for Gateway READY..."
+    for i in $(seq 1 60); do
+        GW_STATUS=$(aws bedrock-agentcore-control get-gateway \
+            --gateway-identifier "$GATEWAY_ID" --region "$REGION" \
+            --query 'status' --output text 2>/dev/null || echo "UNKNOWN")
+        [ "$GW_STATUS" = "READY" ] && { echo " ✅"; break; }
+        [ "$GW_STATUS" = "FAILED" ] && { echo " ❌"; SKIP_GATEWAY=true; return 0; }
+        echo -n "."; sleep 10
+    done
+    GATEWAY_ARN=$(aws bedrock-agentcore-control get-gateway \
+        --gateway-identifier "$GATEWAY_ID" --region "$REGION" \
+        --query 'gatewayArn' --output text 2>/dev/null || echo "")
+    GATEWAY_URL="https://${GATEWAY_ID}.gateway.bedrock-agentcore.${REGION}.amazonaws.com/mcp"
+
+    # 8.5 JWT audience: placeholder -> gateway ID
+    #     now includes the required --role-arn/--protocol-type params whose omission broke it)
+    CURRENT_AUD=$(aws bedrock-agentcore-control get-gateway \
+        --gateway-identifier "$GATEWAY_ID" --region "$REGION" \
+        --query 'authorizerConfiguration.customJWTAuthorizer.allowedAudience[0]' --output text 2>/dev/null || echo "")
+    if [ "$CURRENT_AUD" != "$GATEWAY_ID" ]; then
+        info "Replacing JWT audience: '$CURRENT_AUD' -> '$GATEWAY_ID'"
+        AUD_OK=false
+        for aud_try in 1 2 3; do
+            UPDATE_RESULT=$(aws bedrock-agentcore-control update-gateway \
+                --gateway-identifier "$GATEWAY_ID" \
+                --name "$GATEWAY_NAME" \
+                --role-arn "$GATEWAY_ROLE_ARN" \
+                --protocol-type MCP \
+                --authorizer-type CUSTOM_JWT \
+                --authorizer-configuration "{\"customJWTAuthorizer\":{\"discoveryUrl\":\"${DISCOVERY_URL}\",\"allowedAudience\":[\"${GATEWAY_ID}\"]}}" \
+                --region "$REGION" --output json 2>&1) || true
+            if echo "$UPDATE_RESULT" | grep -q '"gatewayId"'; then
+                AUD_OK=true; break
+            fi
+            warn "Audience update attempt $aud_try/3 failed: $(echo "$UPDATE_RESULT" | head -2)"
+            sleep 15
+        done
+        if [ "$AUD_OK" = "true" ]; then
+            echo -n "   Waiting for READY after audience update..."
+            for i in $(seq 1 30); do
+                GW_STATUS=$(aws bedrock-agentcore-control get-gateway \
+                    --gateway-identifier "$GATEWAY_ID" --region "$REGION" \
+                    --query 'status' --output text 2>/dev/null || echo "UNKNOWN")
+                [ "$GW_STATUS" = "READY" ] && { echo " ✅"; break; }
+                echo -n "."; sleep 5
+            done
+            # verify — never trust the call alone
+            CURRENT_AUD=$(aws bedrock-agentcore-control get-gateway \
+                --gateway-identifier "$GATEWAY_ID" --region "$REGION" \
+                --query 'authorizerConfiguration.customJWTAuthorizer.allowedAudience[0]' --output text 2>/dev/null || echo "")
+            if [ "$CURRENT_AUD" = "$GATEWAY_ID" ]; then
+                ok "Audience = $GATEWAY_ID (verified)"
+            else
+                warn "Audience is still '$CURRENT_AUD' after update!"
+                warn "Manual fix required in console (Bedrock AgentCore > Gateways > Inbound Auth)"
             fi
         else
-            echo "   Reusing existing Gateway: $GATEWAY_ID"
+            warn "Audience update failed after 3 attempts."
+            warn "Manual fix required in console (Bedrock AgentCore > Gateways > Inbound Auth):"
+            warn "  Allowed audiences: replace 'placeholder' with '$GATEWAY_ID'"
         fi
+    else
+        ok "Audience already correct: $GATEWAY_ID"
     fi
 
-    if [ "$SKIP_GATEWAY" = "false" ] && [ -n "${GATEWAY_ID:-}" ]; then
-
-        # Step 8.5: Wait for Gateway to become READY
-        echo -n "   Waiting for Gateway to become READY..."
-        for i in $(seq 1 60); do
-            GW_STATUS=$(aws bedrock-agentcore-control get-gateway \
-                --gateway-identifier "$GATEWAY_ID" --region "$REGION" \
-                --query 'status' --output text 2>/dev/null || echo "UNKNOWN")
-            if [ "$GW_STATUS" = "READY" ] || [ "$GW_STATUS" = "ACTIVE" ]; then
-                echo " ✅"
-                break
-            fi
-            if [ "$GW_STATUS" = "FAILED" ]; then
-                echo " ❌ Gateway creation failed."
-                SKIP_GATEWAY=true
-                break
-            fi
-            echo -n "."
-            sleep 10
-        done
-
-        # Get Gateway ARN
-        GATEWAY_ARN=$(aws bedrock-agentcore-control get-gateway \
-            --gateway-identifier "$GATEWAY_ID" --region "$REGION" \
-            --query 'gatewayArn' --output text 2>/dev/null || echo "")
-    fi
-
-    # =============================================================================
-    # Step 9: Update Gateway Audience (placeholder -> actual gateway ID)
-    #   Always runs — ensures audience is set correctly even for reused gateways
-    # =============================================================================
-    if [ "$SKIP_GATEWAY" = "false" ] && [ -n "${GATEWAY_ID:-}" ]; then
-        echo ""
-        echo "🔄 Step 9: Updating Gateway JWT audience to gateway ID..."
-
-        aws bedrock-agentcore-control update-gateway \
-            --gateway-identifier "$GATEWAY_ID" \
-            --name "$GATEWAY_NAME" \
-            --authorizer-type CUSTOM_JWT \
-            --authorizer-configuration "{
-                \"customJWTAuthorizer\": {
-                    \"discoveryUrl\": \"${DISCOVERY_URL}\",
-                    \"allowedAudience\": [\"${GATEWAY_ID}\"]
-                }
-            }" \
-            --region "$REGION" --output text --query 'gatewayId' &>/dev/null || true
-
-        # Wait for gateway to return to READY after update
-        echo -n "   Waiting for Gateway to become READY after audience update..."
-        for i in $(seq 1 30); do
-            GW_STATUS=$(aws bedrock-agentcore-control get-gateway \
-                --gateway-identifier "$GATEWAY_ID" --region "$REGION" \
-                --query 'status' --output text 2>/dev/null || echo "UNKNOWN")
-            if [ "$GW_STATUS" = "READY" ] || [ "$GW_STATUS" = "ACTIVE" ]; then
-                echo " ✅"
-                break
-            fi
-            echo -n "."
-            sleep 5
-        done
-
-        echo "   ✅ Audience updated to: $GATEWAY_ID"
-
-        # Step 9.1: Create or reconcile Gateway Target (OpenAPI from S3)
-        echo "   Creating Gateway Target..."
-
-        EXPECTED_S3_URI="s3://${KB_BUCKET}/openapi/openapi.yaml"
-
-        TARGET_CONFIG=$(cat <<TCEOF
-{
-    "mcp": {
-        "openApiSchema": {
-            "s3": {
-                "uri": "${EXPECTED_S3_URI}"
-            }
-        }
-    }
-}
-TCEOF
-)
-
-        CRED_CONFIG=$(cat <<CCEOF
-[{
-    "credentialProviderType": "API_KEY",
-    "credentialProvider": {
-        "apiKeyCredentialProvider": {
-            "providerArn": "${CREDENTIAL_PROVIDER_ARN}",
-            "credentialParameterName": "x-api-key",
-            "credentialLocation": "HEADER"
-        }
-    }
-}]
-CCEOF
-)
-
-        # List existing targets and find one with our name.
-        EXISTING_TARGETS=$(aws bedrock-agentcore-control list-gateway-targets \
-            --gateway-identifier "$GATEWAY_ID" \
-            --region "$REGION" --output json 2>/dev/null || echo '{"targets":[]}')
-
-        # Resolve existing target's id + current S3 URI in one pass so we can
-        # reconcile rather than silently skip when the bucket name drifts
-        # (e.g., stack recreated in a different region/env → KnowledgeBaseBucketName
-        # changed from `${PROJECT}-dev-kb-...` to `${PROJECT}-ap-northeast-2-kb-...`
-        # but the old Gateway Target still points at the dead bucket → MCP reads
-        # a 404 for openapi.yaml until someone fixes it in the console).
-        TARGET_INFO=$(echo "$EXISTING_TARGETS" | TARGET_NAME="$TARGET_NAME" python3 -c "
+    # 8.6 Gateway Target (OpenAPI from S3) — create or reconcile stale S3 URI
+    EXPECTED_S3_URI="s3://${KB_BUCKET}/openapi/openapi.yaml"
+    TARGET_CONFIG="{\"mcp\":{\"openApiSchema\":{\"s3\":{\"uri\":\"${EXPECTED_S3_URI}\"}}}}"
+    CRED_CONFIG="[{\"credentialProviderType\":\"API_KEY\",\"credentialProvider\":{\"apiKeyCredentialProvider\":{\"providerArn\":\"${CREDENTIAL_PROVIDER_ARN}\",\"credentialParameterName\":\"x-api-key\",\"credentialLocation\":\"HEADER\"}}}]"
+    EXISTING_TARGETS=$(aws bedrock-agentcore-control list-gateway-targets \
+        --gateway-identifier "$GATEWAY_ID" --region "$REGION" --output json 2>/dev/null || echo '{}')
+    TARGET_INFO=$(echo "$EXISTING_TARGETS" | TARGET_NAME="$TARGET_NAME" python3 -c "
 import sys, json, os
 name = os.environ['TARGET_NAME']
-data = json.load(sys.stdin)
-for t in data.get('targets', []):
+d = json.load(sys.stdin)
+for t in d.get('items', d.get('targets', [])):
     if t.get('name') == name:
         tid = t.get('targetId') or t.get('id') or ''
         cfg = t.get('targetConfiguration') or {}
         uri = ((cfg.get('mcp') or {}).get('openApiSchema') or {}).get('s3', {}).get('uri') or ''
-        print(tid + '\t' + uri)
-        break
-else:
-    print('\t')
+        print(tid + '\t' + uri); break
+else: print('\t')
 " 2>/dev/null || echo $'\t')
+    EXISTING_TARGET_ID=$(echo "$TARGET_INFO" | cut -f1)
+    EXISTING_S3_URI=$(echo "$TARGET_INFO" | cut -f2)
 
-        EXISTING_TARGET_ID=$(echo "$TARGET_INFO" | cut -f1)
-        EXISTING_S3_URI=$(echo "$TARGET_INFO" | cut -f2)
-
-        if [ -z "$EXISTING_TARGET_ID" ]; then
+    if [ -z "$EXISTING_TARGET_ID" ]; then
+        # Fresh-account IAM propagation can make the first attempt fail or land
+        # in FAILED (gateway role can't read the S3 spec yet) — retry up to 3x
+        TGT_STATUS=""
+        for tgt_try in 1 2 3; do
+            info "Creating Gateway Target... (attempt $tgt_try/3)"
             TARGET_RESULT=$(aws bedrock-agentcore-control create-gateway-target \
-                --gateway-identifier "$GATEWAY_ID" \
-                --name "$TARGET_NAME" \
+                --gateway-identifier "$GATEWAY_ID" --name "$TARGET_NAME" \
                 --target-configuration "$TARGET_CONFIG" \
                 --credential-provider-configurations "$CRED_CONFIG" \
-                --region "$REGION" --output json 2>&1)
-
-            if echo "$TARGET_RESULT" | python3 -c "import sys,json; json.load(sys.stdin)" &>/dev/null; then
-                echo "   ✅ Gateway Target created -> $EXPECTED_S3_URI"
-            else
-                echo "   ⚠️ Failed to create target: $TARGET_RESULT"
+                --region "$REGION" --output json 2>&1) || true
+            NEW_TARGET_ID=$(jget "$TARGET_RESULT" "targetId")
+            if [ -z "$NEW_TARGET_ID" ]; then
+                warn "Target create call failed: $(echo "$TARGET_RESULT" | head -3)"
+                sleep 15
+                continue
             fi
-        elif [ "$EXISTING_S3_URI" != "$EXPECTED_S3_URI" ]; then
-            # Bucket name drifted — update in place so MCP reads the live OpenAPI.
-            echo "   ⚠️ Existing Gateway Target points to a stale S3 URI:"
-            echo "        was:  $EXISTING_S3_URI"
-            echo "        want: $EXPECTED_S3_URI"
-            echo "   Updating in place..."
-            UPDATE_RESULT=$(aws bedrock-agentcore-control update-gateway-target \
-                --gateway-identifier "$GATEWAY_ID" \
-                --target-id "$EXISTING_TARGET_ID" \
-                --name "$TARGET_NAME" \
-                --target-configuration "$TARGET_CONFIG" \
-                --credential-provider-configurations "$CRED_CONFIG" \
-                --region "$REGION" --output json 2>&1)
-
-            if echo "$UPDATE_RESULT" | python3 -c "import sys,json; json.load(sys.stdin)" &>/dev/null; then
-                echo "   ✅ Gateway Target updated -> $EXPECTED_S3_URI"
-            else
-                echo "   ⚠️ Failed to update target: $UPDATE_RESULT"
-                echo "      Fix by hand in the Bedrock AgentCore console, or delete"
-                echo "      the target (\"$TARGET_NAME\") and re-run deploy.sh."
+            # Wait for the target to finish validating the OpenAPI schema
+            echo -n "   Waiting for Target READY..."
+            TGT_STATUS=""
+            for i in $(seq 1 30); do
+                TGT=$(aws bedrock-agentcore-control get-gateway-target \
+                    --gateway-identifier "$GATEWAY_ID" --target-id "$NEW_TARGET_ID" \
+                    --region "$REGION" --output json 2>/dev/null || echo '{}')
+                TGT_STATUS=$(jget "$TGT" "status")
+                [ "$TGT_STATUS" = "READY" ] && { echo " ✅"; break; }
+                [ "$TGT_STATUS" = "FAILED" ] && { echo " ❌"; break; }
+                echo -n "."; sleep 5
+            done
+            if [ "$TGT_STATUS" = "READY" ]; then
+                ok "Target created -> $EXPECTED_S3_URI"
+                break
             fi
+            warn "Target status: ${TGT_STATUS:-TIMEOUT} — reason: $(jget "$TGT" "statusReasons")"
+            # delete the failed target before retrying
+            aws bedrock-agentcore-control delete-gateway-target \
+                --gateway-identifier "$GATEWAY_ID" --target-id "$NEW_TARGET_ID" \
+                --region "$REGION" >/dev/null 2>&1 || true
+            sleep 20
+        done
+        if [ "$TGT_STATUS" != "READY" ]; then
+            warn "Gateway Target could not reach READY after 3 attempts."
+            warn "Check that s3://${KB_BUCKET}/openapi/openapi.yaml exists, is valid OpenAPI 3.0,"
+            warn "and that role $ROLE_NAME has s3:GetObject on that bucket."
+        fi
+    elif [ "$EXISTING_S3_URI" != "$EXPECTED_S3_URI" ]; then
+        info "Updating Target S3 URI (stale bucket -> current bucket)..."
+        aws bedrock-agentcore-control update-gateway-target \
+            --gateway-identifier "$GATEWAY_ID" --target-id "$EXISTING_TARGET_ID" \
+            --name "$TARGET_NAME" --target-configuration "$TARGET_CONFIG" \
+            --credential-provider-configurations "$CRED_CONFIG" \
+            --region "$REGION" --output json >/dev/null 2>&1 \
+            && ok "Target updated" || warn "Target update failed"
+    else
+        ok "Gateway Target already up to date"
+    fi
+}
+
+# =============================================================================
+# Phase 9: Connect integrations — MCP server registration + Lambda associations
+#   (automates the console-only steps of workshop chapter 4)
+# =============================================================================
+phase_connect_integrations() {
+    echo ""
+    echo "🔗 Phase 9: Connect integrations (MCP server + Lambda associations)..."
+
+    # 9.1 MCP server registration: appintegrations MCP_SERVER app + Connect association
+    if [ "$SKIP_GATEWAY" = "false" ] && [ -n "${GATEWAY_ID:-}" ]; then
+        EXISTING_APPS=$(aws appintegrations list-applications --region "$REGION" --output json 2>/dev/null || echo '{"Applications":[]}')
+        MCP_APP_ARN=$(echo "$EXISTING_APPS" | python3 -c "
+import sys, json
+for a in json.load(sys.stdin).get('Applications', []):
+    if a.get('Namespace') == '${GATEWAY_ID}': print(a['Arn']); break
+" 2>/dev/null || echo "")
+        if [ -z "$MCP_APP_ARN" ]; then
+            # unique per gateway generation (avoids name conflicts with stale apps)
+            local APP_NAME="${MCP_APP_NAME}-${GATEWAY_ID##*-}"
+            info "Registering MCP server application: $APP_NAME"
+            APP_RESULT=$(aws appintegrations create-application \
+                --name "$APP_NAME" \
+                --namespace "$GATEWAY_ID" \
+                --description "MCP server for ${PROJECT_NAME}" \
+                --application-type MCP_SERVER \
+                --application-source-config "{\"ExternalUrlConfig\":{\"AccessUrl\":\"${GATEWAY_URL}\"}}" \
+                --region "$REGION" --output json 2>&1) || true
+            MCP_APP_ARN=$(jget "$APP_RESULT" "Arn")
+            [ -n "$MCP_APP_ARN" ] && info "Registered: $MCP_APP_ARN" || warn "MCP app registration failed: $APP_RESULT"
         else
-            echo "   Gateway Target already exists and points to the current bucket ✅"
+            info "Reusing existing MCP application"
+        fi
+        state_set MCP_APP_ARN "${MCP_APP_ARN:-}"
+
+        if [ -n "$MCP_APP_ARN" ]; then
+            APP_ASSOCS=$(aws connect list-integration-associations \
+                --instance-id "$CONNECT_INSTANCE_ID" --integration-type APPLICATION \
+                --region "$REGION" --output json 2>/dev/null || echo '{"IntegrationAssociationSummaryList":[]}')
+            if echo "$APP_ASSOCS" | grep -q "$MCP_APP_ARN"; then
+                ok "MCP server already integrated with Connect"
+            else
+                aws connect create-integration-association \
+                    --instance-id "$CONNECT_INSTANCE_ID" \
+                    --integration-type APPLICATION \
+                    --integration-arn "$MCP_APP_ARN" \
+                    --region "$REGION" >/dev/null 2>&1 \
+                    && ok "MCP server registered as Connect integration" \
+                    || warn "MCP integration association failed (check app-integrations:CreateApplication permission)"
+            fi
+        fi
+    else
+        info "No Gateway — skipping MCP registration"
+    fi
+
+    # 9.2 Lambda associations (register flow-invoked functions with Connect)
+    _load_stack_lambda_names
+    local flow_lambda_arns=""
+    if [ -n "$FLOW_JSON" ]; then
+        # functions referenced by the flow's {{X_LAMBDA_ARN}} placeholders
+        flow_lambda_arns=$(python3 - "$FLOW_JSON" <<'PYEOF' 2>/dev/null || true
+import sys, json, re
+tokens = set(re.findall(r'\{\{([A-Z_]+?)_LAMBDA(?:_ARN)?\}\}', open(sys.argv[1]).read()))
+for t in tokens: print(t.lower())
+PYEOF
+)
+    fi
+    ASSOCIATED=0
+    for stem in $flow_lambda_arns; do
+        fn=$(resolve_stack_function "$stem")
+        [ -z "$fn" ] && continue
+        fn_arn="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${fn}"
+        aws connect associate-lambda-function \
+            --instance-id "$CONNECT_INSTANCE_ID" \
+            --function-arn "$fn_arn" \
+            --region "$REGION" 2>/dev/null && info "Lambda associated: $fn" || info "Lambda already associated: $fn"
+        ASSOCIATED=$((ASSOCIATED+1))
+    done
+    [ "$ASSOCIATED" -gt 0 ] && ok "Associated $ASSOCIATED flow-referenced Lambda(s) with Connect" || info "No flow-referenced Lambdas"
+}
+
+# =============================================================================
+# Phase 10: Lex bot (automates workshop chapter 5 bot creation)
+#   - Language selection (auto-detected from assets + menu)
+#   - Speech model choice: Nova Sonic Speech-to-Speech (agentic voice) vs standard TTS
+#   - AMAZON.QInConnectIntent (AI agent intent) + build + Connect association
+# =============================================================================
+LOCALE_ID=""
+LEX_VOICE_ID=""
+LEX_VOICE_ENGINE=""
+SPEECH_MODE=""
+
+phase_lex_bot() {
+    echo ""
+    echo "🗣️  Phase 10: Creating Lex bot (voice entry point)..."
+
+    # ── Language selection (detected language first, deduplicated) ──────────
+    local langs=("$DETECTED_LANG  (detected from assets)")
+    for l in en-US ko-KR ja-JP es-US; do
+        [ "$l" != "$DETECTED_LANG" ] && langs+=("$l")
+    done
+    langs+=("Enter manually")
+    choose "Select the bot language" 1 "${langs[@]}"
+    case "$CHOICE_VALUE" in
+        "Enter manually") ask_text "Language code (e.g. fr-FR)" "en-US"; FLOW_LANG="$ANSWER" ;;
+        *) FLOW_LANG=$(echo "$CHOICE_VALUE" | awk '{print $1}') ;;
+    esac
+    LOCALE_ID=$(echo "$FLOW_LANG" | tr '-' '_')
+    info "Language: $FLOW_LANG (Lex locale: $LOCALE_ID)"
+
+    # ── Speech model choice (menu built after Nova Sonic availability check) ─
+    #    Three tiers of Connect bot speech models:
+    #    1. Nova Sonic Speech-to-Speech  (unifiedSpeechSettings; model-availability gated)
+    #    2. Amazon agentic voice / Advanced ASR (speechRecognitionSettings Neural; broadly available)
+    #    3. Standard ASR + Polly TTS
+    NOVA_SONIC_ARN=""
+    NOVA_MODEL=$(aws bedrock list-foundation-models --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+try:
+    for m in json.load(sys.stdin)['modelSummaries']:
+        if 'nova' in m['modelId'] and 'sonic' in m['modelId']: print(m['modelArn']); break
+except Exception: pass
+" 2>/dev/null || echo "")
+    local speech_opts=()
+    if [ -n "$NOVA_MODEL" ]; then
+        speech_opts+=("Amazon Nova Sonic Speech-to-Speech  (agentic voice S2S, most natural — recommended)")
+    fi
+    speech_opts+=("Amazon agentic voice — Advanced ASR  (low-latency turn taking + expressive TTS)")
+    speech_opts+=("Standard ASR + Polly TTS")
+    choose "Select the bot speech model" 1 "${speech_opts[@]}"
+    case "$CHOICE_VALUE" in
+        *"Nova Sonic"*)   SPEECH_MODE="nova-sonic"; NOVA_SONIC_ARN="$NOVA_MODEL"; info "Nova Sonic: $NOVA_SONIC_ARN" ;;
+        *"Advanced ASR"*) SPEECH_MODE="advanced-asr" ;;
+        *)                SPEECH_MODE="standard" ;;
+    esac
+
+    # ── Voice provider choice ───────────────────────────────────────────────
+    #    Amazon Connect agentic voice has NO public list/set API today: its voice
+    #    catalog is per-language (polyglot voices Katie/Blake/Brooke/Ronald/Gemma
+    #    cover En/De/Es/Fr/Hi/It/Ja/No/Pt/Ru; other locales have locale-specific
+    #    voices selectable only in the console) and its flow JSON representation
+    #    is undocumented. Either way the flow keeps a proper Set Voice block with
+    #    a working Polly voice; picking "agentic" adds a documented ~1-min console
+    #    step (switch the block's Voice Provider) printed in the deploy summary.
+    VOICE_PROVIDER="polly"
+    choose "Select the voice provider for the Contact Flow" 1 \
+        "Amazon Connect agentic voice  (expressive, 50+ languages — deployed with a Polly fallback; switch the Set voice block's provider in console after deploy, ~1 min)" \
+        "Amazon Polly                  (fully scripted here — voice/engine selected below)"
+    [ "$CHOICE" = "1" ] && VOICE_PROVIDER="agentic"
+    state_set VOICE_PROVIDER "$VOICE_PROVIDER"
+
+    # ── Polly voice selection (bot TTS fallback; flow set-voice when provider=polly)
+    local voices_json
+    voices_json=$(aws polly describe-voices --language-code "$FLOW_LANG" --region "$REGION" --output json 2>/dev/null || echo '{"Voices":[]}')
+    local voice_menu=() voice_ids=() voice_engines=()
+    while IFS=$'\t' read -r vid gender engines; do
+        voice_menu+=("$vid ($gender, engines: $engines)")
+        voice_ids+=("$vid")
+        # pick best engine: generative > neural > standard
+        local best="standard"
+        case "$engines" in *generative*) best="generative" ;; *neural*) best="neural" ;; esac
+        voice_engines+=("$best")
+    done < <(echo "$voices_json" | python3 -c "
+import sys, json
+for v in json.load(sys.stdin).get('Voices', []):
+    print(v['Id'] + '\t' + v['Gender'] + '\t' + '/'.join(v['SupportedEngines']))
+")
+    if [ ${#voice_ids[@]} -eq 0 ]; then
+        warn "No Polly voices for '$FLOW_LANG'. Falling back to Joanna/neural"
+        LEX_VOICE_ID="Joanna"; LEX_VOICE_ENGINE="neural"
+    elif [ "$VOICE_PROVIDER" = "agentic" ]; then
+        # keep a working Polly voice in the Set Voice block until the provider is
+        # switched in console — auto-pick the best one for the language
+        LEX_VOICE_ID="${voice_ids[0]}"
+        LEX_VOICE_ENGINE="${voice_engines[0]}"
+        info "Agentic voice selected — Set voice block keeps Polly fallback ($LEX_VOICE_ID/$LEX_VOICE_ENGINE) until you switch the provider in console"
+        case "$FLOW_LANG" in
+            en-*|de-*|es-*|fr-*|hi-*|it-*|ja-*|no-*|pt-*|ru-*)
+                info "Polyglot agentic voices available for this language: Katie, Blake, Brooke, Ronald, Gemma" ;;
+            *)
+                info "This language uses locale-specific agentic voices — preview & pick in console (Set voice block > Voice Provider: Amazon Connect agentic voice)" ;;
+        esac
+    else
+        choose "Select a TTS voice (also applied to the Contact Flow Set voice block)" 1 "${voice_menu[@]}"
+        LEX_VOICE_ID="${voice_ids[$((CHOICE-1))]}"
+        LEX_VOICE_ENGINE="${voice_engines[$((CHOICE-1))]}"
+        # offer engine choice when the voice supports multiple engines
+        local supported
+        supported=$(echo "$voices_json" | python3 -c "
+import sys, json
+for v in json.load(sys.stdin).get('Voices', []):
+    if v['Id'] == '$LEX_VOICE_ID': print('\n'.join(v['SupportedEngines'])); break
+")
+        local engine_count
+        engine_count=$(echo "$supported" | grep -c . || echo 1)
+        if [ "$engine_count" -gt 1 ]; then
+            local engine_opts=() default_engine_idx=1 i=1
+            while read -r eng; do
+                engine_opts+=("$eng")
+                [ "$eng" = "$LEX_VOICE_ENGINE" ] && default_engine_idx=$i
+                i=$((i+1))
+            done <<< "$supported"
+            choose "Select the TTS engine for voice $LEX_VOICE_ID" "$default_engine_idx" "${engine_opts[@]}"
+            LEX_VOICE_ENGINE="$CHOICE_VALUE"
+        fi
+    fi
+    ok "Voice: $LEX_VOICE_ID / $LEX_VOICE_ENGINE"
+    state_set FLOW_LANG "$FLOW_LANG"
+    state_set LEX_VOICE_ID "$LEX_VOICE_ID"
+    state_set LEX_VOICE_ENGINE "$LEX_VOICE_ENGINE"
+
+    # ── Speech detection sensitivity (VAD, agentic voice best practice) ─────
+    choose "Select speech detection sensitivity (VAD — match the caller's environment)" 1 \
+        "Default                (quiet environments — recommended)" \
+        "HighNoiseTolerance     (moderate background noise)" \
+        "MaximumNoiseTolerance  (very noisy environments, e.g. call from street/car)"
+    SPEECH_SENSITIVITY=$(echo "$CHOICE_VALUE" | awk '{print $1}')
+    info "Speech detection sensitivity: $SPEECH_SENSITIVITY"
+
+    # ── Lex bot runtime role (custom, NOT the SLR) ──────────────────────────
+    #    AMAZON.QInConnectIntent needs the bot role to carry wisdom:CreateSession/
+    #    GetAssistant/SendMessage/GetNextMessage on the assistant. The Connect
+    #    console injects that inline policy into a protected SLR — which the CLI
+    #    CANNOT modify (UnmodifiableEntity). Without it every Lex call fails with
+    #    "Invalid Bot Configuration: Amazon Lex could not access your Q In
+    #    Connect Assistant" (found live in a workshop). So we use a customer-
+    #    managed role with the same permissions instead.
+    local LEX_ROLE_NAME="${PROJECT_NAME}-lex-bot-role"
+    LEX_ROLE_ARN=$(aws iam get-role --role-name "$LEX_ROLE_NAME" \
+        --query 'Role.Arn' --output text 2>/dev/null || echo "")
+    if [ -z "$LEX_ROLE_ARN" ] || [ "$LEX_ROLE_ARN" = "None" ]; then
+        info "Creating Lex bot role: $LEX_ROLE_NAME"
+        LEX_ROLE_ARN=$(aws iam create-role --role-name "$LEX_ROLE_NAME" \
+            --assume-role-policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"lexv2.amazonaws.com"},"Action":"sts:AssumeRole"}]}' \
+            --query 'Role.Arn' --output text 2>/dev/null || echo "")
+        [ -n "$LEX_ROLE_ARN" ] && sleep 10   # IAM propagation
+    fi
+    [ -z "$LEX_ROLE_ARN" ] && { warn "Could not create Lex bot role — skipping bot creation"; return 0; }
+    aws iam put-role-policy --role-name "$LEX_ROLE_NAME" --policy-name polly \
+        --policy-document '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"polly:SynthesizeSpeech","Resource":"*"}]}' 2>/dev/null || true
+    aws iam put-role-policy --role-name "$LEX_ROLE_NAME" --policy-name qinconnect \
+        --policy-document "{
+  \"Version\": \"2012-10-17\",
+  \"Statement\": [
+    {\"Sid\": \"QInConnectAssistantPolicy\", \"Effect\": \"Allow\",
+     \"Action\": [\"wisdom:CreateSession\", \"wisdom:GetAssistant\"],
+     \"Resource\": [\"arn:aws:wisdom:*:${ACCOUNT_ID}:assistant/${AI_ASSISTANT_ID}\",
+                    \"arn:aws:wisdom:*:${ACCOUNT_ID}:assistant/${AI_ASSISTANT_ID}/*\"]},
+    {\"Sid\": \"QInConnectSessionsPolicy\", \"Effect\": \"Allow\",
+     \"Action\": [\"wisdom:SendMessage\", \"wisdom:GetNextMessage\"],
+     \"Resource\": [\"arn:aws:wisdom:*:${ACCOUNT_ID}:session/${AI_ASSISTANT_ID}/*\"]}
+  ]
+}" 2>/dev/null && info "Lex bot role has Q in Connect permissions" \
+        || warn "Could not attach Q in Connect policy to $LEX_ROLE_NAME"
+
+    # ── Create or reuse the bot ─────────────────────────────────────────────
+    BOT_ID=$(aws lexv2-models list-bots --region "$REGION" \
+        --filters "name=BotName,values=$BOT_NAME,operator=EQ" \
+        --query 'botSummaries[0].botId' --output text 2>/dev/null || echo "")
+    [ "$BOT_ID" = "None" ] && BOT_ID=""
+    if [ -z "$BOT_ID" ]; then
+        info "Creating bot: $BOT_NAME"
+        # AmazonConnectEnabled tag is REQUIRED for the Connect console's
+        # bot-management page (Flows > Bots) — without it the console shows
+        # "The Conversational AI bot does not have the required tag set".
+        BOT_RESULT=$(aws lexv2-models create-bot \
+            --bot-name "$BOT_NAME" \
+            --description "AI agent entry bot for ${PROJECT_NAME}" \
+            --role-arn "$LEX_ROLE_ARN" \
+            --data-privacy '{"childDirected":false}' \
+            --idle-session-ttl-in-seconds 600 \
+            --bot-tags "AmazonConnectEnabled=True,AssistantArn=${ASSISTANT_ARN}" \
+            --test-bot-alias-tags "AmazonConnectEnabled=True" \
+            --region "$REGION" --output json)
+        BOT_ID=$(jget "$BOT_RESULT" "botId")
+        echo -n "   Waiting for bot..."
+        for i in $(seq 1 30); do
+            BSTATUS=$(aws lexv2-models describe-bot --bot-id "$BOT_ID" --region "$REGION" \
+                --query 'botStatus' --output text 2>/dev/null || echo "UNKNOWN")
+            [ "$BSTATUS" = "Available" ] && { echo " ✅"; break; }
+            echo -n "."; sleep 3
+        done
+    else
+        info "Reusing existing bot: $BOT_NAME ($BOT_ID)"
+    fi
+    state_set BOT_ID "$BOT_ID"
+
+    # ── Create locale (Nova Sonic S2S or standard voice-settings) ───────────
+    LOCALE_EXISTS=$(aws lexv2-models describe-bot-locale --bot-id "$BOT_ID" \
+        --bot-version DRAFT --locale-id "$LOCALE_ID" --region "$REGION" \
+        --query 'botLocaleStatus' --output text 2>/dev/null || echo "")
+    if [ -z "$LOCALE_EXISTS" ]; then
+        info "Creating locale: $LOCALE_ID"
+        if [ "$SPEECH_MODE" = "nova-sonic" ]; then
+            aws lexv2-models create-bot-locale \
+                --bot-id "$BOT_ID" --bot-version DRAFT --locale-id "$LOCALE_ID" \
+                --nlu-intent-confidence-threshold 0.40 \
+                --unified-speech-settings "{\"speechFoundationModel\":{\"modelArn\":\"${NOVA_SONIC_ARN}\"}}" \
+                --speech-detection-sensitivity "$SPEECH_SENSITIVITY" \
+                --region "$REGION" >/dev/null
+        elif [ "$SPEECH_MODE" = "advanced-asr" ]; then
+            aws lexv2-models create-bot-locale \
+                --bot-id "$BOT_ID" --bot-version DRAFT --locale-id "$LOCALE_ID" \
+                --nlu-intent-confidence-threshold 0.40 \
+                --voice-settings "{\"voiceId\":\"${LEX_VOICE_ID}\",\"engine\":\"${LEX_VOICE_ENGINE}\"}" \
+                --speech-recognition-settings '{"speechModelPreference":"Neural"}' \
+                --speech-detection-sensitivity "$SPEECH_SENSITIVITY" \
+                --region "$REGION" >/dev/null
+        else
+            aws lexv2-models create-bot-locale \
+                --bot-id "$BOT_ID" --bot-version DRAFT --locale-id "$LOCALE_ID" \
+                --nlu-intent-confidence-threshold 0.40 \
+                --voice-settings "{\"voiceId\":\"${LEX_VOICE_ID}\",\"engine\":\"${LEX_VOICE_ENGINE}\"}" \
+                --speech-detection-sensitivity "$SPEECH_SENSITIVITY" \
+                --region "$REGION" >/dev/null
+        fi
+        echo -n "   Waiting for locale..."
+        for i in $(seq 1 30); do
+            LSTATUS=$(aws lexv2-models describe-bot-locale --bot-id "$BOT_ID" \
+                --bot-version DRAFT --locale-id "$LOCALE_ID" --region "$REGION" \
+                --query 'botLocaleStatus' --output text 2>/dev/null || echo "UNKNOWN")
+            case "$LSTATUS" in NotBuilt|Built|ReadyExpressTesting) echo " ✅"; break ;; esac
+            echo -n "."; sleep 3
+        done
+    else
+        info "Reusing existing locale: $LOCALE_ID ($LOCALE_EXISTS)"
+        # Apply the (possibly changed) speech model choice to the existing locale
+        if [ "$SPEECH_MODE" = "nova-sonic" ]; then
+            aws lexv2-models update-bot-locale \
+                --bot-id "$BOT_ID" --bot-version DRAFT --locale-id "$LOCALE_ID" \
+                --nlu-intent-confidence-threshold 0.40 \
+                --unified-speech-settings "{\"speechFoundationModel\":{\"modelArn\":\"${NOVA_SONIC_ARN}\"}}" \
+                --speech-detection-sensitivity "$SPEECH_SENSITIVITY" \
+                --region "$REGION" >/dev/null 2>&1 && info "Locale speech settings updated (Nova Sonic S2S)" || true
+        elif [ "$SPEECH_MODE" = "advanced-asr" ]; then
+            aws lexv2-models update-bot-locale \
+                --bot-id "$BOT_ID" --bot-version DRAFT --locale-id "$LOCALE_ID" \
+                --nlu-intent-confidence-threshold 0.40 \
+                --voice-settings "{\"voiceId\":\"${LEX_VOICE_ID}\",\"engine\":\"${LEX_VOICE_ENGINE}\"}" \
+                --speech-recognition-settings '{"speechModelPreference":"Neural"}' \
+                --speech-detection-sensitivity "$SPEECH_SENSITIVITY" \
+                --region "$REGION" >/dev/null 2>&1 && info "Locale speech settings updated (Advanced ASR)" || true
+        else
+            aws lexv2-models update-bot-locale \
+                --bot-id "$BOT_ID" --bot-version DRAFT --locale-id "$LOCALE_ID" \
+                --nlu-intent-confidence-threshold 0.40 \
+                --voice-settings "{\"voiceId\":\"${LEX_VOICE_ID}\",\"engine\":\"${LEX_VOICE_ENGINE}\"}" \
+                --speech-detection-sensitivity "$SPEECH_SENSITIVITY" \
+                --region "$REGION" >/dev/null 2>&1 && info "Locale speech settings updated (Standard)" || true
         fi
     fi
 
-    # =============================================================================
-    # Summary
-    # =============================================================================
+    # ── Ensure the bot uses the custom role (backfill for existing bots) ────
+    CUR_BOT_ROLE=$(aws lexv2-models describe-bot --bot-id "$BOT_ID" --region "$REGION" \
+        --query 'roleArn' --output text 2>/dev/null || echo "")
+    if [ -n "$CUR_BOT_ROLE" ] && [ "$CUR_BOT_ROLE" != "$LEX_ROLE_ARN" ]; then
+        info "Switching bot role to $LEX_ROLE_NAME (Q in Connect access)..."
+        aws lexv2-models update-bot --bot-id "$BOT_ID" --bot-name "$BOT_NAME" \
+            --role-arn "$LEX_ROLE_ARN" \
+            --data-privacy '{"childDirected":false}' --idle-session-ttl-in-seconds 600 \
+            --region "$REGION" >/dev/null 2>&1 \
+            && info "Bot role updated" || warn "Could not update bot role"
+        sleep 3
+    fi
+
+    # ── Console-manageability tags (backfill for existing bots) ─────────────
+    #    The Connect console bot page requires the AmazonConnectEnabled tag.
+    #    BOTH the bot AND its TestBotAlias need the tag — bot-only tagging still
+    #    shows "AI agent is not supported for bots created outside Connect console".
+    for TAG_ARN in "arn:aws:lex:${REGION}:${ACCOUNT_ID}:bot/${BOT_ID}" \
+                   "arn:aws:lex:${REGION}:${ACCOUNT_ID}:bot-alias/${BOT_ID}/TSTALIASID"; do
+        HAS_TAG=$(aws lexv2-models list-tags-for-resource --resource-arn "$TAG_ARN" \
+            --region "$REGION" --query 'tags.AmazonConnectEnabled' --output text 2>/dev/null || echo "")
+        if [ "$HAS_TAG" != "True" ]; then
+            aws lexv2-models tag-resource --resource-arn "$TAG_ARN" \
+                --tags "AmazonConnectEnabled=True,AssistantArn=${ASSISTANT_ARN}" \
+                --region "$REGION" 2>/dev/null \
+                && info "Tagged $(basename $TAG_ARN) for Connect console manageability" \
+                || warn "Could not tag $TAG_ARN — the Connect console bot page may show 'required tag' error"
+        fi
+    done
+
+    # ── AI agent intent (AMAZON.QInConnectIntent) ───────────────────────────
+    QIC_INTENT=$(aws lexv2-models list-intents --bot-id "$BOT_ID" --bot-version DRAFT \
+        --locale-id "$LOCALE_ID" --region "$REGION" \
+        --query "intentSummaries[?parentIntentSignature=='AMAZON.QInConnectIntent'].intentId" \
+        --output text 2>/dev/null || echo "")
+    if [ -z "$QIC_INTENT" ] || [ "$QIC_INTENT" = "None" ]; then
+        info "Adding AI agent intent (AMAZON.QInConnectIntent)..."
+        aws lexv2-models create-intent \
+            --bot-id "$BOT_ID" --bot-version DRAFT --locale-id "$LOCALE_ID" \
+            --intent-name "AIAgentIntent" \
+            --parent-intent-signature "AMAZON.QInConnectIntent" \
+            --q-in-connect-intent-configuration "{\"qInConnectAssistantConfiguration\":{\"assistantArn\":\"${ASSISTANT_ARN}\"}}" \
+            --region "$REGION" >/dev/null \
+            && ok "AI agent intent enabled (assistant linked)" \
+            || warn "QInConnect intent creation failed"
+    else
+        # Backfill: intents created by earlier versions (or by hand) may lack the
+        # assistant linkage — without qInConnectIntentConfiguration the bot is not
+        # actually connected to the Connect assistant and self-service silently
+        # fails. Verify and repair.
+        local QIC_ASST_ARN
+        QIC_ASST_ARN=$(aws lexv2-models describe-intent \
+            --bot-id "$BOT_ID" --bot-version DRAFT --locale-id "$LOCALE_ID" \
+            --intent-id "$QIC_INTENT" --region "$REGION" \
+            --query 'qInConnectIntentConfiguration.qInConnectAssistantConfiguration.assistantArn' \
+            --output text 2>/dev/null || echo "")
+        if [ "$QIC_ASST_ARN" = "$ASSISTANT_ARN" ]; then
+            info "AI agent intent already linked to assistant"
+        else
+            info "AI agent intent exists but assistant link is missing/stale — repairing..."
+            local QIC_NAME
+            QIC_NAME=$(aws lexv2-models describe-intent \
+                --bot-id "$BOT_ID" --bot-version DRAFT --locale-id "$LOCALE_ID" \
+                --intent-id "$QIC_INTENT" --region "$REGION" \
+                --query 'intentName' --output text 2>/dev/null || echo "AIAgentIntent")
+            aws lexv2-models update-intent \
+                --bot-id "$BOT_ID" --bot-version DRAFT --locale-id "$LOCALE_ID" \
+                --intent-id "$QIC_INTENT" --intent-name "$QIC_NAME" \
+                --parent-intent-signature "AMAZON.QInConnectIntent" \
+                --q-in-connect-intent-configuration "{\"qInConnectAssistantConfiguration\":{\"assistantArn\":\"${ASSISTANT_ARN}\"}}" \
+                --region "$REGION" >/dev/null 2>&1 \
+                && ok "AI agent intent relinked to assistant" \
+                || warn "Failed to relink AI agent intent to assistant (check bot in console)"
+        fi
+    fi
+
+    # ── Build ───────────────────────────────────────────────────────────────
+    info "Building bot locale... (1-2 min)"
+    aws lexv2-models build-bot-locale --bot-id "$BOT_ID" --bot-version DRAFT \
+        --locale-id "$LOCALE_ID" --region "$REGION" >/dev/null 2>&1 || true
+    echo -n "   Waiting for build..."
+    for i in $(seq 1 60); do
+        LSTATUS=$(aws lexv2-models describe-bot-locale --bot-id "$BOT_ID" \
+            --bot-version DRAFT --locale-id "$LOCALE_ID" --region "$REGION" \
+            --query 'botLocaleStatus' --output text 2>/dev/null || echo "UNKNOWN")
+        case "$LSTATUS" in
+            Built) echo " ✅"; break ;;
+            Failed) echo " ❌ build failed"; aws lexv2-models describe-bot-locale --bot-id "$BOT_ID" --bot-version DRAFT --locale-id "$LOCALE_ID" --region "$REGION" --query 'failureReasons' --output json 2>/dev/null; break ;;
+        esac
+        echo -n "."; sleep 5
+    done
+
+    # ── TestBotAlias ARN + Connect association (CLI equivalent of Lex toggle) ─
+    LEX_BOT_ALIAS_ARN="arn:aws:lex:${REGION}:${ACCOUNT_ID}:bot-alias/${BOT_ID}/TSTALIASID"
+    EXISTING_BOTS=$(aws connect list-bots --instance-id "$CONNECT_INSTANCE_ID" \
+        --lex-version V2 --region "$REGION" --output json 2>/dev/null || echo '{"LexBots":[]}')
+    if echo "$EXISTING_BOTS" | grep -q "$BOT_ID"; then
+        info "Bot already associated with Connect"
+    else
+        aws connect associate-bot \
+            --instance-id "$CONNECT_INSTANCE_ID" \
+            --lex-v2-bot "AliasArn=$LEX_BOT_ALIAS_ARN" \
+            --region "$REGION" 2>/dev/null \
+            && ok "Bot associated with Connect: $LEX_BOT_ALIAS_ARN" \
+            || warn "Bot association failed (associate-bot)"
+    fi
+    state_set LEX_BOT_ALIAS_ARN "$LEX_BOT_ALIAS_ARN"
+}
+
+# =============================================================================
+# Phase 11: Contact Flow import (automates chapter 5 import + placeholders)
+#   - Auto-resolves {{...}} placeholders from deployed resources (menus for the rest)
+#   - Applies the selected voice/engine to set-voice blocks
+#   - Automates "Set language attribute": injects UpdateContactData(LanguageCode)
+#   - Auto-fixes known import errors (RealTime analytics etc.) and retries
+# =============================================================================
+CONTACT_FLOW_ID=""
+CONTACT_FLOW_ARN=""
+
+phase_contact_flow() {
     echo ""
-    echo "============================================="
+    echo "📋 Phase 11: Preparing & importing Contact Flow..."
+    [ -z "$FLOW_JSON" ] && { info "No contact-flow/ directory, skipping"; return 0; }
+
+    local WORK_FLOW="/tmp/${PROJECT_NAME}_flow_resolved.json"
+    cp "$FLOW_JSON" "$WORK_FLOW"
+
+    # ── Collect placeholders ────────────────────────────────────────────────
+    local placeholders
+    placeholders=$(grep -o '{{[A-Z_]*}}' "$WORK_FLOW" | sort -u | tr -d '{}')
+    info "Placeholders found: $(echo $placeholders | tr '\n' ' ')"
+
+    # helper: substitution
+    replace_ph() { # token value
+        python3 - "$WORK_FLOW" "$1" "$2" <<'PYEOF'
+import sys
+path, token, value = sys.argv[1], sys.argv[2], sys.argv[3]
+s = open(path).read()
+open(path, 'w').write(s.replace('{{%s}}' % token, value))
+PYEOF
+    }
+
+    # queue / hours menus (lazy-loaded once)
+    local QUEUES_JSON="" HOURS_JSON=""
+
+    for token in $placeholders; do
+        local value=""
+        case "$token" in
+            *_LAMBDA_ARN|*_LAMBDA)
+                local stem
+                stem=$(echo "$token" | sed 's/_LAMBDA_ARN$//; s/_LAMBDA$//' | tr '[:upper:]' '[:lower:]')
+                local fn
+                fn=$(resolve_stack_function "$stem")
+                if [ -n "$fn" ]; then
+                    value="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:${fn}"
+                    info "$token -> $fn (auto-resolved from stack)"
+                else
+                    # multiple choice: pick from stack Lambdas
+                    _load_stack_lambda_names
+                    local menu=() arns=()
+                    for f in $STACK_LAMBDA_NAMES; do
+                        menu+=("$f"); arns+=("arn:aws:lambda:${REGION}:${ACCOUNT_ID}:function:$f")
+                    done
+                    menu+=("Skip (configure manually in console)")
+                    choose "Select the Lambda to map to placeholder {{$token}}" 1 "${menu[@]}"
+                    if [ "$CHOICE_VALUE" != "Skip (configure manually in console)" ]; then
+                        value="${arns[$((CHOICE-1))]}"
+                    fi
+                fi
+                ;;
+            WISDOM_ASSISTANT_ARN)
+                value="$ASSISTANT_ARN"
+                info "$token -> Assistant ARN (auto)"
+                ;;
+            LEX_BOT_ALIAS_ARN)
+                value="${LEX_BOT_ALIAS_ARN:-}"
+                [ -n "$value" ] && info "$token -> $BOT_NAME TestBotAlias (auto)"
+                ;;
+            QUEUE_ARN|*_QUEUE_ARN)
+                [ -z "$QUEUES_JSON" ] && QUEUES_JSON=$(aws connect list-queues \
+                    --instance-id "$CONNECT_INSTANCE_ID" --queue-types STANDARD \
+                    --region "$REGION" --output json 2>/dev/null || echo '{"QueueSummaryList":[]}')
+                local qmenu=() qarns=() qdefault=1 qi=1
+                while IFS=$'\t' read -r qname qarn; do
+                    qmenu+=("$qname"); qarns+=("$qarn")
+                    [ "$qname" = "BasicQueue" ] && qdefault=$qi
+                    qi=$((qi+1))
+                done < <(echo "$QUEUES_JSON" | python3 -c "
+import sys, json
+for q in json.load(sys.stdin).get('QueueSummaryList', []):
+    print((q.get('Name') or 'N/A') + '\t' + q['Arn'])
+")
+                if [ ${#qarns[@]} -gt 0 ]; then
+                    choose "Select the queue for placeholder {{$token}}" "$qdefault" "${qmenu[@]}"
+                    value="${qarns[$((CHOICE-1))]}"
+                fi
+                ;;
+            HOURS_ARN|*_HOURS_ARN|*HOURS_OF_OPERATION*ARN)
+                [ -z "$HOURS_JSON" ] && HOURS_JSON=$(aws connect list-hours-of-operations \
+                    --instance-id "$CONNECT_INSTANCE_ID" \
+                    --region "$REGION" --output json 2>/dev/null || echo '{"HoursOfOperationSummaryList":[]}')
+                local hmenu=() harns=()
+                while IFS=$'\t' read -r hname harn; do
+                    hmenu+=("$hname"); harns+=("$harn")
+                done < <(echo "$HOURS_JSON" | python3 -c "
+import sys, json
+for h in json.load(sys.stdin).get('HoursOfOperationSummaryList', []):
+    print((h.get('Name') or 'N/A') + '\t' + h['Arn'])
+")
+                if [ ${#harns[@]} -gt 0 ]; then
+                    choose "Select the hours of operation for placeholder {{$token}}" 1 "${hmenu[@]}"
+                    value="${harns[$((CHOICE-1))]}"
+                fi
+                ;;
+            *)
+                ask_text "Enter a value for placeholder {{$token}} (empty = skip)" ""
+                value="$ANSWER"
+                ;;
+        esac
+        [ -n "$value" ] && replace_ph "$token" "$value"
+    done
+
+    # ── Agentic voice (ASR) tuning presets ──────────────────────────────────
+    #    Based on the agentic-voice best practices guide: barge-in + end-of-turn
+    #    controls are Lex session attributes on the Get customer input block.
+    #    https://docs.aws.amazon.com/connect/latest/adminguide/agentic-voice-best-practices.html
+    local ASR_CONFIDENCE="" ASR_TIMEOUT="" ALLOW_INTERRUPT=""
+    choose "Select a conversation tuning preset (ASR turn-taking & barge-in, applied to the Get customer input block)" 1 \
+        "Natural conversation      (defaults: confidence 0.7 / 640ms, barge-in ON — recommended)" \
+        "Pause-tolerant            (confidence 0.9 / 3000ms — for dictated digits, noisy or slow speakers)" \
+        "Snappy short exchanges    (confidence 0.5 / 500ms — fast yes/no menus)" \
+        "Compliance-first          (barge-in OFF — disclaimers must be heard in full)" \
+        "Keep asset's original session attributes"
+    case "$CHOICE" in
+        1) ASR_CONFIDENCE="0.7"; ASR_TIMEOUT="640";  ALLOW_INTERRUPT="true"  ;;
+        2) ASR_CONFIDENCE="0.9"; ASR_TIMEOUT="3000"; ALLOW_INTERRUPT="true"  ;;
+        3) ASR_CONFIDENCE="0.5"; ASR_TIMEOUT="500";  ALLOW_INTERRUPT="true"  ;;
+        4) ASR_CONFIDENCE="0.7"; ASR_TIMEOUT="640";  ALLOW_INTERRUPT="false" ;;
+        5) ;; # keep as-is
+    esac
+    [ -n "$ASR_CONFIDENCE" ] && info "ASR preset: confidence=$ASR_CONFIDENCE timeout=${ASR_TIMEOUT}ms barge-in=$ALLOW_INTERRUPT"
+
+    # ── Apply voice + Set language attribute + fix known import bugs ────────
+    python3 - "$WORK_FLOW" "$LEX_VOICE_ID" "$LEX_VOICE_ENGINE" "$FLOW_LANG" "$ASR_CONFIDENCE" "$ASR_TIMEOUT" "$ALLOW_INTERRUPT" "${VOICE_PROVIDER:-polly}" <<'PYEOF'
+import sys, json
+path, voice, engine, lang = sys.argv[1:5]
+asr_conf, asr_timeout, allow_interrupt = sys.argv[5:8]
+provider = sys.argv[8] if len(sys.argv) > 8 else 'polly'
+d = json.load(open(path))
+actions = d.get('Actions', [])
+meta = d.setdefault('Metadata', {}).setdefault('ActionMetadata', {})
+
+# 1) Apply the selected voice/engine to set-voice blocks.
+#    NOTE: even when the user picked "Amazon Connect agentic voice", the Set
+#    Voice block is kept INTACT with a working Polly voice — the agentic
+#    provider has no public API/flow-JSON representation, so switching the
+#    block's Voice Provider is a documented ~1-min console step after deploy
+#    (printed in the summary). Converting/removing the block here would leave
+#    the flow without a proper voice configuration block, which is worse UX.
+for a in actions:
+    if a.get('Type') == 'UpdateContactTextToSpeechVoice':
+        a['Parameters']['TextToSpeechVoice'] = voice
+        a['Parameters']['TextToSpeechEngine'] = engine.capitalize()
+        # also refresh the display language code in metadata
+        m = meta.get(a['Identifier'], {})
+        if isinstance(m.get('parameters', {}).get('TextToSpeechVoice'), dict):
+            m['parameters']['TextToSpeechVoice']['languageCode'] = lang
+
+# 2) Automate "Set language attribute":
+#    inject an UpdateContactData(LanguageCode) action right after set-voice
+#    (without it, Lex fails with BotId/BotLocale 404 — the #1 workshop pitfall)
+has_lang = any(a.get('Type') == 'UpdateContactData' and 'LanguageCode' in a.get('Parameters', {}) for a in actions)
+if not has_lang:
+    for a in list(actions):
+        if a.get('Type') == 'UpdateContactTextToSpeechVoice':
+            nxt = a['Transitions'].get('NextAction')
+            lang_id = 'aicc-set-language'
+            actions.append({
+                "Identifier": lang_id,
+                "Type": "UpdateContactData",
+                "Parameters": {"LanguageCode": lang},
+                "Transitions": {"NextAction": nxt,
+                                "Errors": [{"ErrorType": "NoMatchingError", "NextAction": nxt}]}
+            })
+            a['Transitions']['NextAction'] = lang_id
+            # keep the error transition on set-voice pointing at its original target
+            pos = meta.get(a['Identifier'], {}).get('position', {'x': 0, 'y': 0})
+            meta[lang_id] = {"position": {"x": pos.get('x', 0) + 140, "y": pos.get('y', 0) + 120},
+                             "isFriendlyName": True, "dynamicParams": []}
+            break
+
+# 3) Upgrade legacy recording blocks to the current console block type.
+#    UpdateContactRecordingBehavior is the OUTDATED block — the console now
+#    uses UpdateContactRecordingAndAnalyticsBehavior (VoiceBehavior shape),
+#    which supports RealTime + AutomatedInteraction analytics. API-verified:
+#    the new type requires NoMatchingError + ChannelMismatch error branches.
+for a in actions:
+    if a.get('Type') != 'UpdateContactRecordingBehavior':
+        continue
+    p = a.get('Parameters', {})
+    rb = p.get('RecordingBehavior', {}) or {}
+    ab = p.get('AnalyticsBehavior', {}) or {}
+    vab = {
+        "Enabled": ab.get('Enabled', 'True'),
+        "AnalyticsLanguage": ab.get('AnalyticsLanguage', lang),
+        "AnalyticsModes": ["RealTime", "AutomatedInteraction"],
+        "ConversationalAnalyticsRedactionConfiguration": {"Enabled": "False"},
+        "SentimentConfiguration": ab.get('SentimentConfiguration', {"Enabled": "True"}),
+        "SummaryConfiguration": {"SummaryModes": ["PostContact", "AutomatedInteraction"]},
+    }
+    a['Type'] = 'UpdateContactRecordingAndAnalyticsBehavior'
+    a['Parameters'] = {"VoiceBehavior": {
+        "VoiceRecordingBehavior": {
+            "RecordedParticipants": rb.get('RecordedParticipants', ["Agent", "Customer"]),
+            "IVRRecordingBehavior": rb.get('IVRRecordingBehavior', 'Enabled'),
+        },
+        "VoiceAnalyticsBehavior": vab,
+    }}
+    # required error branches for the new block type
+    tr = a.setdefault('Transitions', {})
+    nxt = tr.get('NextAction')
+    have = {e.get('ErrorType') for e in tr.get('Errors', [])}
+    tr.setdefault('Errors', [])
+    for et in ('NoMatchingError', 'ChannelMismatch'):
+        if et not in have and nxt:
+            tr['Errors'].append({"ErrorType": et, "NextAction": nxt})
+
+# 4) Agentic voice ASR tuning: set Lex session attributes on the
+#    Get customer input (ConnectParticipantWithLexBot) block per best practices
+if asr_conf:
+    for a in actions:
+        if a.get('Type') == 'ConnectParticipantWithLexBot':
+            attrs = a['Parameters'].setdefault('LexSessionAttributes', {})
+            attrs['x-amz-lex:audio:end-confidence-threshold:*:*'] = asr_conf
+            attrs['x-amz-lex:audio:end-timeout-ms:*:*'] = asr_timeout
+            attrs['x-amz-lex:allow-interrupt:*:*'] = allow_interrupt
+
+json.dump(d, open(path, 'w'), ensure_ascii=False, indent=1)
+print("   Flow JSON post-processing done (voice=%s/%s, lang=%s)" % (voice, engine, lang))
+PYEOF
+
+    # check for unresolved placeholders
+    local remaining
+    remaining=$(grep -o '{{[A-Z_]*}}' "$WORK_FLOW" | sort -u || true)
+    if [ -n "$remaining" ]; then
+        warn "Unresolved placeholders remain (configure in console after import):"
+        echo "$remaining" | sed 's/^/        /'
+        # leftover placeholders may fail ARN validation on import,
+        # so confirm with the user before attempting
+        if ! ask_yn "Attempt the import anyway?" "y"; then
+            info "Contact Flow import skipped. File: $WORK_FLOW"
+            return 0
+        fi
+    fi
+
+    # ── Import (create or update content); auto-fix problems and retry ──────
+    local EXISTING_FLOW_ID
+    EXISTING_FLOW_ID=$(aws connect list-contact-flows --instance-id "$CONNECT_INSTANCE_ID" \
+        --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+for f in json.load(sys.stdin).get('ContactFlowSummaryList', []):
+    if f.get('Name') == '${FLOW_NAME}': print(f['Id']); break
+" 2>/dev/null || echo "")
+
+    local attempt=1 RESULT=""
+    while [ $attempt -le 3 ]; do
+        if [ -n "$EXISTING_FLOW_ID" ]; then
+            RESULT=$(aws connect update-contact-flow-content \
+                --instance-id "$CONNECT_INSTANCE_ID" --contact-flow-id "$EXISTING_FLOW_ID" \
+                --content "file://$WORK_FLOW" --region "$REGION" \
+                --cli-error-format json --output json 2>&1) && {
+                CONTACT_FLOW_ID="$EXISTING_FLOW_ID"
+                ok "Updated existing Contact Flow content: $FLOW_NAME"
+                break
+            }
+        else
+            RESULT=$(aws connect create-contact-flow \
+                --instance-id "$CONNECT_INSTANCE_ID" --name "$FLOW_NAME" \
+                --type CONTACT_FLOW --status PUBLISHED \
+                --content "file://$WORK_FLOW" --region "$REGION" \
+                --cli-error-format json --output json 2>&1) && {
+                CONTACT_FLOW_ID=$(jget "$RESULT" "ContactFlowId")
+                CONTACT_FLOW_ARN=$(jget "$RESULT" "ContactFlowArn")
+                ok "Contact Flow created & published: $FLOW_NAME ($CONTACT_FLOW_ID)"
+                break
+            }
+        fi
+        # failed -> parse problems and attempt auto-fix
+        warn "Import failed (attempt $attempt/3). Analyzing problems..."
+        echo "$RESULT" | python3 -c "
+import sys, json
+try:
+    d = json.loads(sys.stdin.read())
+    for p in d.get('problems', []): print('        -', p.get('message'))
+except Exception: pass
+" 2>/dev/null || true
+        # generic auto-fix: remove invalid parameters named in problem messages
+        python3 - "$WORK_FLOW" <<PYEOF 2>/dev/null || true
+import sys, json, re
+problems = '''$RESULT'''
+path = sys.argv[1]
+d = json.load(open(path))
+
+# Redaction/language conflict. Contact Lens real-time redaction is only offered
+# for some languages; requesting it with any other AnalyticsLanguage is rejected
+# with a message that blames AnalyticsLanguage, not the redaction block. Deleting
+# the language then yields "missing required property" (it IS required), so the
+# generic rules below can never converge — handle it explicitly, first.
+# Verified against CreateContactFlow (2026-08-06): en-US + redaction passes,
+# ko-KR + redaction fails, ko-KR without redaction passes.
+REDACTION_OK = {'en-US','en-GB','en-AU','en-IN','es-US','fr-CA','fr-FR','de-DE','it-IT','pt-BR'}
+if 'AnalyticsLanguage' in problems:
+    for a in d.get('Actions', []):
+        vab = ((a.get('Parameters') or {}).get('VoiceBehavior') or {}).get('VoiceAnalyticsBehavior')
+        if not isinstance(vab, dict):
+            continue
+        red = vab.get('ConversationalAnalyticsRedactionConfiguration')
+        if isinstance(red, dict) and str(red.get('Enabled','')).lower() == 'true' \
+           and str(vab.get('AnalyticsLanguage','')) not in REDACTION_OK:
+            vab['ConversationalAnalyticsRedactionConfiguration'] = {'Enabled': 'False'}
+
+# Generic: drop the property the API called invalid. Two things matter here.
+#  1. Delete the LEAF named in the path, not the top-level branch. The old code
+#     matched only the first path segment, so a complaint about
+#     Parameters.VoiceBehavior.VoiceAnalyticsBehavior.AnalyticsLanguage deleted
+#     the whole VoiceBehavior and left Parameters {} — itself invalid, turning a
+#     fixable flow into an unfixable one.
+#  2. Only act on "Invalid ..." problems. For "missing required property",
+#     deleting things is exactly backwards.
+for pm in re.finditer(r'(Invalid Action property (?:value|name)|Action is missing required property)\.\s*Path:\s*Actions\[(\d+)\]\.Parameters((?:\.[A-Za-z0-9_]+)*)', problems):
+    kind, idx, rest = pm.group(1), int(pm.group(2)), pm.group(3)
+    if kind.startswith('Action is missing') or idx >= len(d.get('Actions', [])):
+        continue
+    segs = [s for s in rest.split('.') if s]
+    if not segs:
+        continue  # "Parameters" itself — nothing safe to delete generically
+    node = d['Actions'][idx].get('Parameters')
+    for s in segs[:-1]:
+        if not isinstance(node, dict):
+            node = None
+            break
+        node = node.get(s)
+    if isinstance(node, dict):
+        node.pop(segs[-1], None)
+
+json.dump(d, open(path, 'w'), ensure_ascii=False, indent=1)
+PYEOF
+        attempt=$((attempt+1))
+    done
+
+    if [ -z "$CONTACT_FLOW_ID" ]; then
+        warn "Contact Flow import failed. Import manually in the console: $WORK_FLOW"
+        return 0
+    fi
+    if [ -z "$CONTACT_FLOW_ARN" ]; then
+        CONTACT_FLOW_ARN=$(aws connect describe-contact-flow \
+            --instance-id "$CONNECT_INSTANCE_ID" --contact-flow-id "$CONTACT_FLOW_ID" \
+            --region "$REGION" --query 'ContactFlow.Arn' --output text 2>/dev/null || echo "")
+    fi
+    state_set CONTACT_FLOW_ID "$CONTACT_FLOW_ID"
+}
+
+# =============================================================================
+# Phase 12: AI Prompt + AI Agent + Security Profile (automates chapter 6)
+#   - AI Prompt: creates ORCHESTRATION prompt from asset yaml (model is a choice)
+#   - AI Agent: copies the system SelfServiceOrchestratorVoice/Chat config and
+#               auto-configures MCP tools from openapi operationIds (confirmation policy is a choice)
+#   - Security Profile: grants MCP tool access + attaches to the AI Agent
+#   - Sets the default self-service agent (orchestratorUseCase=Connect.SelfService)
+# =============================================================================
+phase_ai_agent() {
+    echo ""
+    echo "🧠 Phase 12: AI Prompt + AI Agent + Security Profile..."
+    [ -z "${AI_ASSISTANT_ID:-}" ] && { warn "No assistant, skipping"; return 0; }
+    [ -z "$PROMPT_FILE" ] && { warn "No prompts/ asset, skipping"; return 0; }
+
+    # ── Model selection ─────────────────────────────────────────────────────
+    choose "Select the model for the AI Prompt" 1 \
+        "Claude Haiku 4.5   (fast/low-cost — recommended)" \
+        "Claude Sonnet 4.5  (accurate/complex scenarios)"
+    case "$CHOICE" in
+        1) MODEL_ID="global.anthropic.claude-haiku-4-5-20251001-v1:0" ;;
+        2) MODEL_ID="global.anthropic.claude-sonnet-4-5-20250929-v1:0" ;;
+    esac
+    info "Model: $MODEL_ID"
+
+    # ── Create AI Prompt (asset yaml verbatim) ──────────────────────────────
+    AI_PROMPT_ID=$(aws qconnect list-ai-prompts --assistant-id "$AI_ASSISTANT_ID" \
+        --origin CUSTOMER --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+for p in json.load(sys.stdin).get('aiPromptSummaries', []):
+    if p.get('name') == '${PROMPT_NAME}': print(p['aiPromptId'].split(':')[0]); break
+" 2>/dev/null || echo "")
+    if [ -z "$AI_PROMPT_ID" ]; then
+        info "Creating AI Prompt: $PROMPT_NAME"
+        python3 - "$PROMPT_FILE" <<PYEOF
+import json, sys
+text = open(sys.argv[1]).read()
+req = {
+  "assistantId": "${AI_ASSISTANT_ID}",
+  "name": "${PROMPT_NAME}",
+  "type": "ORCHESTRATION",
+  "templateType": "TEXT",
+  "modelId": "${MODEL_ID}",
+  "apiFormat": "MESSAGES",
+  "visibilityStatus": "PUBLISHED",
+  "templateConfiguration": {"textFullAIPromptEditTemplateConfiguration": {"text": text}}
+}
+json.dump(req, open('/tmp/_ai_prompt_req.json', 'w'), ensure_ascii=False)
+PYEOF
+        PROMPT_RESULT=$(aws qconnect create-ai-prompt \
+            --cli-input-json file:///tmp/_ai_prompt_req.json \
+            --region "$REGION" --output json 2>&1) || true
+        rm -f /tmp/_ai_prompt_req.json
+        AI_PROMPT_ID=$(jget "$PROMPT_RESULT" "aiPrompt.aiPromptId" | cut -d: -f1)
+        if [ -z "$AI_PROMPT_ID" ]; then
+            warn "AI Prompt creation failed: $(echo "$PROMPT_RESULT" | head -3)"
+            return 0
+        fi
+    else
+        info "Reusing existing AI Prompt: $PROMPT_NAME"
+    fi
+    # publish a version
+    PROMPT_VERSION=$(aws qconnect create-ai-prompt-version \
+        --assistant-id "$AI_ASSISTANT_ID" --ai-prompt-id "$AI_PROMPT_ID" \
+        --region "$REGION" --query 'versionNumber' --output text 2>/dev/null || echo "1")
+    AI_PROMPT_VERSIONED="${AI_PROMPT_ID}:${PROMPT_VERSION}"
+    ok "AI Prompt: $AI_PROMPT_VERSIONED"
+    state_set AI_PROMPT_ID "$AI_PROMPT_ID"
+
+    # ── Channel selection (system agent to copy from) ───────────────────────
+    choose "Select the AI Agent base channel (source of default tool config)" 1 \
+        "Voice (phone-first — copy SelfServiceOrchestratorVoice)" \
+        "Chat  (chat-first — copy SelfServiceOrchestratorChat)"
+    local SYS_AGENT_NAME="SelfServiceOrchestratorVoice"
+    [ "$CHOICE" = "2" ] && SYS_AGENT_NAME="SelfServiceOrchestratorChat"
+
+    # ── MCP tool preview + user-confirmation policy ─────────────────────────
+    #    toolId = gateway_{GATEWAY_ID}__{targetName}___{operationId}
+    #    read-only ops (get/check/track/list/search/find/query/lookup) -> no confirmation
+    local TOOL_PREVIEW=""
+    if [ -n "$OPENAPI_FILE" ] && [ -n "${GATEWAY_ID:-}" ]; then
+        TOOL_PREVIEW=$(python3 - "$OPENAPI_FILE" "$TARGET_NAME" <<'PYEOF'
+import sys, re
+ops = re.findall(r'operationId:\s*([A-Za-z0-9_\-]+)', open(sys.argv[1]).read())
+target = sys.argv[2]
+readonly_prefix = ('get','check','track','list','search','find','query','lookup','describe','read','retrieve')
+for op in ops:
+    confirm = 'false' if op.lower().startswith(readonly_prefix) else 'true'
+    print(f"{target}___{op}\t{confirm}")
+PYEOF
+)
+        echo ""
+        info "Auto-configured MCP tools (whether customer confirmation is required):"
+        echo "$TOOL_PREVIEW" | while IFS=$'\t' read -r t c; do
+            [ "$c" = "true" ] && echo "        🔒 $t  (confirmation required — mutating operation)" \
+                              || echo "        👁  $t  (no confirmation — read-only operation)"
+        done
+        choose "How should per-tool user confirmation be set?" 1 \
+            "Use the classification above (read-only=run, mutating=confirm — recommended)" \
+            "Require confirmation for ALL tools" \
+            "No confirmation for any tool"
+        TOOL_CONFIRM_POLICY="$CHOICE"
+    fi
+
+    # ── Create AI Agent: copy system agent config + add MCP tools ───────────
+    AI_AGENT_ID=$(aws qconnect list-ai-agents --assistant-id "$AI_ASSISTANT_ID" \
+        --origin CUSTOMER --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+for a in json.load(sys.stdin).get('aiAgentSummaries', []):
+    if a.get('name') == '${AGENT_NAME}': print(a['aiAgentId'].split(':')[0]); break
+" 2>/dev/null || echo "")
+
+    if [ -z "$AI_AGENT_ID" ]; then
+        info "Creating AI Agent: $AGENT_NAME (base: $SYS_AGENT_NAME)"
+        aws qconnect list-ai-agents --assistant-id "$AI_ASSISTANT_ID" \
+            --origin SYSTEM --region "$REGION" --output json > /tmp/_sys_agents.json
+        python3 - <<PYEOF
+import json, re
+sys_agents = json.load(open('/tmp/_sys_agents.json'))['aiAgentSummaries']
+base = next(a for a in sys_agents if a['name'] == '${SYS_AGENT_NAME}')
+cfg = base['configuration']['orchestrationAIAgentConfiguration']
+
+# swap the system prompt for ours
+cfg['orchestrationAIPromptId'] = '${AI_PROMPT_VERSIONED}'
+cfg['connectInstanceArn'] = '${CONNECT_INSTANCE_ARN}'
+cfg['locale'] = '${LOCALE_ID:-en_US}'
+
+# AWS-managed MCP tools (e.g. Retrieve) reject overriding description/schema
+# on create; keep only the identifying fields copied from the system config
+cfg['toolConfigurations'] = [
+    ({k: v for k, v in t.items() if k in ('toolName', 'toolType', 'toolId')}
+     if (t.get('toolId') or '').startswith('aws_service__') else t)
+    for t in cfg.get('toolConfigurations', [])
+]
+
+# add MCP tools (Complete/Escalate/Retrieve are copied from system config)
+policy = '${TOOL_CONFIRM_POLICY:-1}'
+preview = '''${TOOL_PREVIEW:-}'''
+for line in preview.strip().splitlines():
+    if not line.strip(): continue
+    perm, auto_confirm = line.split('\t')
+    op = perm.split('___', 1)[1]
+    tool_name = perm.replace('-', '_')
+    confirm = {'1': auto_confirm == 'true', '2': True, '3': False}[policy]
+    cfg['toolConfigurations'].append({
+        "toolName": tool_name,
+        "toolType": "MODEL_CONTEXT_PROTOCOL",
+        "toolId": "gateway_${GATEWAY_ID}__" + perm,
+        "userInteractionConfiguration": {"isUserConfirmationRequired": confirm}
+    })
+
+req = {
+  "assistantId": "${AI_ASSISTANT_ID}",
+  "name": "${AGENT_NAME}",
+  "type": "ORCHESTRATION",
+  "visibilityStatus": "PUBLISHED",
+  "configuration": {"orchestrationAIAgentConfiguration": cfg}
+}
+json.dump(req, open('/tmp/_ai_agent_req.json', 'w'), ensure_ascii=False)
+PYEOF
+        AGENT_RESULT=""
+        # MCP tools may take a moment to propagate after integration registration
+        for attempt in 1 2 3 4; do
+            AGENT_RESULT=$(aws qconnect create-ai-agent \
+                --cli-input-json file:///tmp/_ai_agent_req.json \
+                --region "$REGION" --output json 2>&1) || true
+            if echo "$AGENT_RESULT" | grep -q '"aiAgentId"'; then
+                break
+            elif echo "$AGENT_RESULT" | grep -q 'not found in MCP tools'; then
+                info "MCP tools not visible yet (attempt $attempt/4), waiting 15s..."
+                sleep 15
+            else
+                break
+            fi
+        done
+        rm -f /tmp/_ai_agent_req.json /tmp/_sys_agents.json
+        AI_AGENT_ID=$(jget "$AGENT_RESULT" "aiAgent.aiAgentId" | cut -d: -f1)
+        AI_AGENT_ARN=$(jget "$AGENT_RESULT" "aiAgent.aiAgentArn")
+        if [ -z "$AI_AGENT_ID" ]; then
+            warn "AI Agent creation failed: $(echo "$AGENT_RESULT" | head -5)"
+            return 0
+        fi
+    else
+        info "Reusing existing AI Agent: $AGENT_NAME"
+        AI_AGENT_ARN=$(aws qconnect get-ai-agent --assistant-id "$AI_ASSISTANT_ID" \
+            --ai-agent-id "$AI_AGENT_ID" --region "$REGION" \
+            --query 'aiAgent.aiAgentArn' --output text 2>/dev/null || echo "")
+        if [ -z "$AI_AGENT_ARN" ] || [ "$AI_AGENT_ARN" = "None" ]; then
+            AI_AGENT_ARN=$(aws qconnect list-ai-agents --assistant-id "$AI_ASSISTANT_ID" \
+                --origin CUSTOMER --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+for a in json.load(sys.stdin).get('aiAgentSummaries', []):
+    if a.get('name') == '${AGENT_NAME}':
+        print(a.get('aiAgentArn','').split(':\$LATEST')[0]); break
+" 2>/dev/null || echo "")
+        fi
+    fi
+    state_set AI_AGENT_ID "$AI_AGENT_ID"
+
+    # publish a version
+    AGENT_VERSION=$(aws qconnect create-ai-agent-version \
+        --assistant-id "$AI_ASSISTANT_ID" --ai-agent-id "$AI_AGENT_ID" \
+        --region "$REGION" --query 'versionNumber' --output text 2>/dev/null || echo "1")
+    ok "AI Agent: ${AI_AGENT_ID}:${AGENT_VERSION}"
+
+    # ── Set as default self-service agent ───────────────────────────────────
+    info "Setting as default self-service AI agent..."
+    aws qconnect update-assistant-ai-agent \
+        --assistant-id "$AI_ASSISTANT_ID" \
+        --ai-agent-type ORCHESTRATION \
+        --configuration "aiAgentId=${AI_AGENT_ID}:${AGENT_VERSION}" \
+        --orchestrator-use-case "Connect.SelfService" \
+        --region "$REGION" >/dev/null 2>&1 \
+        && ok "Default self-service agent = $AGENT_NAME" \
+        || warn "Failed to set default agent (check console)"
+
+    # ── Security Profile: MCP tool access + attach to AI Agent ──────────────
+    #    Without this profile attached to the AI Agent, every MCP tool call is
+    #    rejected with "Tool is not allowed" (MCP -32001) and the AI escalates.
+    if [ -n "${GATEWAY_ID:-}" ] && [ -z "${TOOL_PREVIEW:-}" ]; then
+        warn "MCP tool list unavailable (missing OpenAPI spec) — security profile will grant base permissions only. Grant per-tool Access in console: Users > Security profiles > ${SP_NAME} > Tools"
+    fi
+    if [ -n "${GATEWAY_ID:-}" ]; then
+        info "Configuring security profile (MCP tool access)..."
+        local PERMS_JSON
+        PERMS_JSON=$(echo "${TOOL_PREVIEW:-}" | python3 -c "
+import sys, json
+perms = [l.split('\t')[0] for l in sys.stdin.read().strip().splitlines() if l.strip()]
+apps = [{'Namespace': '${GATEWAY_ID}', 'ApplicationPermissions': perms, 'Type': 'MCP'}] if perms else []
+print(json.dumps(apps))
+")
+        SP_ID=$(aws connect list-security-profiles --instance-id "$CONNECT_INSTANCE_ID" \
+            --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+for s in json.load(sys.stdin).get('SecurityProfileSummaryList', []):
+    if s.get('Name') == '${SP_NAME}': print(s['Id']); break
+" 2>/dev/null || echo "")
+        local APPS_ARGS=()
+        [ "$PERMS_JSON" != "[]" ] && APPS_ARGS=(--applications "$PERMS_JSON")
+        if [ -z "$SP_ID" ]; then
+            SP_RESULT=$(aws connect create-security-profile \
+                --security-profile-name "$SP_NAME" \
+                --description "AI agent tool permissions for ${PROJECT_NAME}" \
+                --permissions '["BasicAgentAccess","Wisdom.View"]' \
+                ${APPS_ARGS[@]+"${APPS_ARGS[@]}"} \
+                --instance-id "$CONNECT_INSTANCE_ID" \
+                --region "$REGION" --output json 2>&1) || true
+            SP_ID=$(jget "$SP_RESULT" "SecurityProfileId")
+            [ -n "$SP_ID" ] && info "Security profile created: $SP_NAME" || warn "Security profile creation failed: $(echo "$SP_RESULT" | head -3)"
+        elif [ "$PERMS_JSON" != "[]" ]; then
+            aws connect update-security-profile \
+                --security-profile-id "$SP_ID" --instance-id "$CONNECT_INSTANCE_ID" \
+                --applications "$PERMS_JSON" --region "$REGION" 2>/dev/null \
+                && info "Updated tool permissions on existing security profile" || warn "Security profile update failed"
+        fi
+        state_set SP_ID "${SP_ID:-}"
+
+        if [ -z "${AI_AGENT_ARN:-}" ]; then
+            warn "AI Agent ARN could not be resolved — security profile NOT attached."
+            warn "Attach manually: Connect console > AI agents > ${AGENT_NAME} > Security Profiles > ${SP_NAME}"
+        elif [ -n "$SP_ID" ]; then
+            # The entity ARN must carry a version qualifier, and the profile
+            # must be attached to BOTH :$LATEST (what the console editor shows
+            # as the draft) AND the PUBLISHED version (what the default
+            # self-service assignment actually runs). Attaching only $LATEST
+            # passes a naive check while runtime tool calls still fail with
+            # "Tool is not allowed" — found in live workshop QA.
+            local BASE_ARN="${AI_AGENT_ARN%:\$LATEST}"
+            local PUBLISHED_OK="" LATEST_OK=""
+            # Resolve the ACTUAL published version list — never assume ":1".
+            # (On re-runs create-ai-agent-version mints v2, v3, ... and the
+            # default self-service assignment points at the newest one; if the
+            # version probe failed we'd otherwise attach to the wrong version.)
+            local VERSION_QUALS
+            VERSION_QUALS=$(aws qconnect list-ai-agent-versions \
+                --assistant-id "$AI_ASSISTANT_ID" --ai-agent-id "$AI_AGENT_ID" \
+                --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+try:
+    vs = sorted(v.get('versionNumber') for v in json.load(sys.stdin).get('aiAgentVersionSummaries', []) if v.get('versionNumber'))
+    print(' '.join(str(v) for v in vs[-3:]))  # newest 3 is plenty
+except Exception: pass
+" 2>/dev/null || echo "")
+            [ -z "$VERSION_QUALS" ] && VERSION_QUALS="${AGENT_VERSION:-1}"
+            for QUAL in "\$LATEST" $VERSION_QUALS; do
+                local ENTITY_ARN="${BASE_ARN}:${QUAL}"
+                aws connect associate-security-profiles \
+                    --instance-id "$CONNECT_INSTANCE_ID" \
+                    --security-profiles "[{\"Id\":\"$SP_ID\"}]" \
+                    --entity-type AI_AGENT \
+                    --entity-arn "$ENTITY_ARN" \
+                    --region "$REGION" >/dev/null 2>&1 || true
+                # verify — never trust the call alone
+                local VERIFIED
+                VERIFIED=$(aws connect list-entity-security-profiles \
+                    --instance-id "$CONNECT_INSTANCE_ID" \
+                    --entity-type AI_AGENT --entity-arn "$ENTITY_ARN" \
+                    --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+try:
+    for p in json.load(sys.stdin).get('SecurityProfiles', []):
+        if p.get('Id') == '${SP_ID}': print('yes'); break
+except Exception: pass
+" 2>/dev/null || echo "")
+                if [ -z "$VERIFIED" ]; then
+                    # eventual consistency — retry once after a short wait
+                    sleep 5
+                    aws connect associate-security-profiles \
+                        --instance-id "$CONNECT_INSTANCE_ID" \
+                        --security-profiles "[{\"Id\":\"$SP_ID\"}]" \
+                        --entity-type AI_AGENT \
+                        --entity-arn "$ENTITY_ARN" \
+                        --region "$REGION" >/dev/null 2>&1 || true
+                    VERIFIED=$(aws connect list-entity-security-profiles \
+                        --instance-id "$CONNECT_INSTANCE_ID" \
+                        --entity-type AI_AGENT --entity-arn "$ENTITY_ARN" \
+                        --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+try:
+    for p in json.load(sys.stdin).get('SecurityProfiles', []):
+        if p.get('Id') == '${SP_ID}': print('yes'); break
+except Exception: pass
+" 2>/dev/null || echo "")
+                fi
+                if [ "$QUAL" = "\$LATEST" ]; then LATEST_OK="$VERIFIED"; else [ "$VERIFIED" = "yes" ] && PUBLISHED_OK="yes"; fi
+            done
+            if [ "$PUBLISHED_OK" = "yes" ]; then
+                ok "Security profile attached to AI Agent v${AGENT_VERSION:-1} + \$LATEST — verified (tool access granted)"
+            else
+                warn "Security profile attachment to the PUBLISHED agent version could NOT be verified (\$LATEST: ${LATEST_OK:-no})."
+                warn "Without it, tool calls fail with 'Tool is not allowed' (MCP -32001)."
+                warn "Attach manually: Connect console > AI agents > ${AGENT_NAME} > Security Profiles > select '${SP_NAME}' > Publish"
+            fi
+        fi
+    fi
+}
+
+# =============================================================================
+# Phase 13: Phone number claim + flow association (optional, chapter 6 finale)
+# =============================================================================
+CLAIMED_PHONE=""
+
+phase_phone_number() {
+    echo ""
+    echo "☎️  Phase 13: Phone number claim (optional)..."
+    [ -z "${CONTACT_FLOW_ID:-}" ] && { info "No Contact Flow, skipping"; return 0; }
+
+    # skip when a number was already claimed for this project
+    local EXISTING_NUM
+    EXISTING_NUM=$(aws connect list-phone-numbers-v2 --instance-id "$CONNECT_INSTANCE_ID" \
+        --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+for p in json.load(sys.stdin).get('ListPhoneNumbersSummaryList', []):
+    if p.get('PhoneNumberDescription') == '${PROJECT_NAME}-workshop':
+        print(p['PhoneNumber']); break
+" 2>/dev/null || echo "")
+    if [ -n "$EXISTING_NUM" ]; then
+        CLAIMED_PHONE="$EXISTING_NUM"
+        ok "Reusing previously claimed number: $CLAIMED_PHONE"
+        return 0
+    fi
+
+    if [ -n "$AUTO" ]; then
+        info "AUTO_CONFIRM mode — skipping phone claim (avoids charges)"
+        return 0
+    fi
+    if ! ask_yn "Claim a US phone number now and attach it to the flow? (incurs charges)" "n"; then
+        info "Phone claim skipped. You can do it later in console (Channels > Phone numbers)"
+        return 0
+    fi
+
+    choose "Select the number type" 1 \
+        "DID (direct-dial local number)" \
+        "TOLL_FREE (toll-free)"
+    local NUM_TYPE="DID"
+    [ "$CHOICE" = "2" ] && NUM_TYPE="TOLL_FREE"
+
+    local AVAIL
+    AVAIL=$(aws connect search-available-phone-numbers \
+        --target-arn "$CONNECT_INSTANCE_ARN" \
+        --phone-number-country-code US \
+        --phone-number-type "$NUM_TYPE" \
+        --max-results 8 --region "$REGION" --output json 2>&1) || true
+    local nums=()
+    while read -r n; do [ -n "$n" ] && nums+=("$n"); done < <(echo "$AVAIL" | python3 -c "
+import sys, json
+try:
+    for p in json.load(sys.stdin).get('AvailableNumbersList', []):
+        print(p['PhoneNumber'])
+except Exception: pass
+" 2>/dev/null)
+    if [ ${#nums[@]} -eq 0 ]; then
+        warn "Failed to search available numbers: $(echo "$AVAIL" | head -2)"
+        return 0
+    fi
+
+    choose "Select the number to claim" 1 "${nums[@]}" "Cancel"
+    [ "$CHOICE_VALUE" = "Cancel" ] && { info "Claim cancelled"; return 0; }
+    local PICKED="$CHOICE_VALUE"
+
+    local CLAIM_RESULT
+    CLAIM_RESULT=$(aws connect claim-phone-number \
+        --instance-id "$CONNECT_INSTANCE_ID" \
+        --phone-number "$PICKED" \
+        --phone-number-description "${PROJECT_NAME}-workshop" \
+        --region "$REGION" --output json 2>&1) || true
+    local PHONE_ID
+    PHONE_ID=$(jget "$CLAIM_RESULT" "PhoneNumberId")
+    if [ -z "$PHONE_ID" ]; then
+        warn "Phone claim failed: $(echo "$CLAIM_RESULT" | head -2)"
+        return 0
+    fi
+    CLAIMED_PHONE="$PICKED"
+    state_set PHONE_NUMBER_ID "$PHONE_ID"
+    ok "Number claimed: $PICKED"
+
+    # attach number -> contact flow
+    sleep 3  # brief propagation wait after claim
+    aws connect associate-phone-number-contact-flow \
+        --phone-number-id "$PHONE_ID" \
+        --instance-id "$CONNECT_INSTANCE_ID" \
+        --contact-flow-id "$CONTACT_FLOW_ID" \
+        --region "$REGION" 2>/dev/null \
+        && ok "Number attached to Contact Flow ($FLOW_NAME) — call it now!" \
+        || warn "Number-flow association failed (attach manually in console)"
+}
+
+# =============================================================================
+# Summary
+# =============================================================================
+do_summary() {
+    echo ""
+    hr
     echo "  ✅ Deployment Complete!"
-    echo "============================================="
+    hr
     echo ""
     echo "  Project:           $PROJECT_NAME"
     echo "  Region:            $REGION"
-    echo "  API Endpoint:      $API_ENDPOINT"
+    echo "  API Endpoint:      ${API_ENDPOINT:-N/A}"
     echo "  API Key:           ${API_KEY:0:10}..."
     echo ""
-    echo "  Connect Instance:  ${CONNECT_INSTANCE_ID:-N/A}"
-    echo "  Connect Alias:     ${CONNECT_ALIAS:-N/A}"
-    echo "  AI Assistant ID:   ${AI_ASSISTANT_ID:-N/A}"
-    if [ -n "${GATEWAY_ID:-}" ]; then
-    echo "  Gateway ID:        $GATEWAY_ID"
-    echo "  Gateway ARN:       ${GATEWAY_ARN:-N/A}"
+    echo "  Connect Instance:  ${CONNECT_INSTANCE_ID:-N/A} (${CONNECT_ALIAS:-})"
+    echo "  Assistant:         ${AI_ASSISTANT_ID:-N/A}"
+    echo "  Gateway:           ${GATEWAY_ID:-N/A}"
+    echo "  Lex Bot:           ${BOT_ID:-N/A} ($BOT_NAME, ${LOCALE_ID:-})"
+    echo "  Contact Flow:      ${CONTACT_FLOW_ID:-N/A} ($FLOW_NAME)"
+    echo "  AI Agent:          ${AI_AGENT_ID:-N/A} ($AGENT_NAME)"
+    if [ "${VOICE_PROVIDER:-polly}" = "agentic" ]; then
+        echo "  Voice:             Polly ${LEX_VOICE_ID:-N/A} (temporary) -> switch to Amazon Connect agentic voice in console (see below)"
+    else
+        echo "  Voice:             ${LEX_VOICE_ID:-N/A}/${LEX_VOICE_ENGINE:-} (${FLOW_LANG:-})"
     fi
+    echo "  Speech Mode:       ${SPEECH_MODE:-N/A}"
+    [ -n "${CLAIMED_PHONE:-}" ] && echo "  📞 Phone number:    $CLAIMED_PHONE  <- call it now!"
     echo ""
-
-    # Contact Flow placeholders
-    if [ -d "$SCRIPT_DIR/contact-flow" ]; then
-        echo "  ─── Contact Flow 설정 ───"
-        echo ""
-        echo "  Contact Flow JSON을 Import한 후 아래 placeholder를 교체하세요:"
-        echo ""
-        [ -n "${CUSTOMER_LOOKUP_ARN:-}" ] && echo "  {{CUSTOMER_LOOKUP_LAMBDA_ARN}}"
-        [ -n "${CUSTOMER_LOOKUP_ARN:-}" ] && echo "    -> $CUSTOMER_LOOKUP_ARN"
-        [ -n "${CUSTOMER_LOOKUP_ARN:-}" ] && echo ""
-        [ -n "${UPDATE_Q_SESSION_ARN:-}" ] && echo "  {{UPDATE_Q_SESSION_LAMBDA_ARN}}"
-        [ -n "${UPDATE_Q_SESSION_ARN:-}" ] && echo "    -> $UPDATE_Q_SESSION_ARN"
-        [ -n "${UPDATE_Q_SESSION_ARN:-}" ] && echo ""
-        echo "  {{LEX_BOT_ALIAS_ARN}}  -> Connect > Bot 연결 후 ARN"
-        echo "  {{QUEUE_ARN}}          -> Connect > Routing > Queues > ARN"
-        if [ -n "${AI_ASSISTANT_ID:-}" ] && [ -n "${CONNECT_INSTANCE_ARN:-}" ]; then
-            echo ""
-            echo "  {{WISDOM_ASSISTANT_ARN}}"
-            echo "    -> arn:aws:wisdom:${REGION}:${ACCOUNT_ID}:assistant/${AI_ASSISTANT_ID}"
-        fi
+    echo "  ─── How to test ───"
+    echo ""
+    if [ -n "${CLAIMED_PHONE:-}" ]; then
+        echo "  1. Call $CLAIMED_PHONE and talk to the AI agent"
+    fi
+    echo "  · Test chat: https://${CONNECT_ALIAS}.my.connect.aws/test-chat"
+    echo "    (pick flow '$FLOW_NAME' in Test Settings, then chat)"
+    echo "  · Trace AI agent reasoning & tool calls:"
+    echo "    aws qconnect list-spans --assistant-id ${AI_ASSISTANT_ID:-<ID>} \\"
+    echo "      --session-id <last UUID of WisdomSessionArn> --region $REGION"
+    echo ""
+    if [ "${VOICE_PROVIDER:-polly}" = "agentic" ]; then
+        echo "  ─── ⚠️  REQUIRED console step — switch to agentic voice (~1 min) ───"
+        echo "  The flow currently speaks with Polly ${LEX_VOICE_ID:-} (a working fallback)."
+        echo "  To use Amazon Connect agentic voice as selected:"
+        echo "    Flows > $FLOW_NAME > open the 'Set voice' block >"
+        echo "    Voice Provider: Amazon Connect agentic voice > Language: ${FLOW_LANG:-} >"
+        echo "    pick a voice (Listen to voice sample) > keep 'Set language attribute' ON >"
+        echo "    Save > Publish"
+        echo "  (AWS exposes no API to list/set agentic voices yet — console only)"
         echo ""
     fi
-
-    echo "  ─── 남은 수동 작업 ───"
+    echo "  ─── ✅ Post-deploy console checklist (~2 min, do before testing voice) ───"
     echo ""
-    echo "  1. Connect > Third-party applications에서 MCP Server 연결"
-    echo "  2. AI Agent 프롬프트 설정 (prompts/ai_agent_prompt.yaml 내용 붙여넣기)"
-    echo "  3. Contact Flow Import + Lex Bot 연결 + 전화번호 할당"
-    if [ -d "$SCRIPT_DIR/faq" ]; then
-        echo "  4. Knowledge Base S3 Data Source 연결 (콘솔에서 진행)"
-    fi
+    echo "  1. Lex bot speech model  (deploy sets the API's Neural ASR; verify the"
+    echo "     console shows the intended speech-to-text model — some tiers are"
+    echo "     console-only today):"
+    echo "       Connect console > Flows > Bots (Amazon Lex) > ${BOT_NAME:-$PROJECT_NAME-bot} >"
+    echo "       Language: ${FLOW_LANG:-} > Speech to text >"
+    echo "       select 'Amazon Connect agentic voice - advanced' > Save > Build"
+    echo "  2. Security profile on the AI Agent (script verifies this, but if any"
+    echo "     ⚠️ appeared above, re-attach by hand):"
+    echo "       Connect console > Q in Connect (AI Agents) > $AGENT_NAME >"
+    echo "       confirm security profile '${SP_NAME:-$PROJECT_NAME-mcp-tools}' is attached"
+    echo "       to the PUBLISHED agent version (not just \$LATEST)"
+    echo "     Symptom if missing: MCP tool calls fail with 'Tool is not allowed' (-32001)"
     echo ""
-    echo "  ※ 리소스 정리: ./deploy.sh cleanup"
+    echo "  ─── Cleanup ───"
+    echo "  ./deploy.sh cleanup"
     echo ""
-    echo "============================================="
+    hr
 }
 
-# #############################################################################
-#  Main: Route to command
-# #############################################################################
+# =============================================================================
+# DEPLOY: phase runner
+# =============================================================================
+do_deploy() {
+    if [ -z "$CFN_TEMPLATE" ]; then
+        echo "❌ No CloudFormation template found under cloudformation/."
+        exit 1
+    fi
+    do_preflight
+
+    # ── Deployment scope ─────────────────────────────────────────────────────
+    #    full: everything through AI agent + phone number (chapters 2-6)
+    #    core: infrastructure/gateway only (chapters 5-6 done by hand in the
+    #          console — the workshop learning path)
+    #    Env override: DEPLOY_SCOPE=full|core
+    local SCOPE="${DEPLOY_SCOPE:-}"
+    if [ -z "$SCOPE" ]; then
+        choose "Select the deployment scope" 1 \
+            "Full automation      — everything incl. Lex bot, Contact Flow, AI Agent, security profile (workshop chapters 2-6)" \
+            "Core infrastructure  — stack/Lambda/Connect/Assistant/Gateway/MCP only; do Lex/Flow/AI Agent yourself in the console (learning path)"
+        [ "$CHOICE" = "2" ] && SCOPE="core" || SCOPE="full"
+    fi
+    state_set DEPLOY_SCOPE "$SCOPE"
+
+    phase_cloudformation
+    phase_lambda_code
+    phase_openapi
+    phase_faq
+    phase_connect_instance
+    phase_assistant
+    phase_env_vars
+    phase_gateway
+    phase_connect_integrations
+    if [ "$SCOPE" = "core" ]; then
+        echo ""
+        info "Core scope selected — stopping after MCP registration."
+        info "Continue in the console with workshop chapters 5-6 (Lex bot, Contact Flow, AI Agent),"
+        info "or re-run './deploy.sh' and pick Full automation at any time (idempotent)."
+        do_summary
+        return 0
+    fi
+    phase_lex_bot
+    phase_contact_flow
+    phase_ai_agent
+    phase_phone_number
+    do_summary
+}
+
+# =============================================================================
+# CLEANUP (reverse order — phone/flow/AI agent/bot/MCP/Gateway/Assistant/CFN)
+# =============================================================================
+do_cleanup() {
+    hr
+    echo "  AICC Builder - Resource Cleanup"
+    echo "  Project: $PROJECT_NAME | Region: $REGION | Account: $ACCOUNT_ID"
+    hr
+    echo ""
+    echo "  ⚠️  This will delete ALL of the following resources:"
+    echo "     Phone numbers, Contact Flow, AI Agent/Prompt, security profile, Lex bot,"
+    echo "     MCP integration, all AgentCore Gateway resources, Assistant + KB, CloudFormation stack"
+    echo "     * The Connect instance itself is NOT deleted."
+    echo ""
+    if [ -z "$AUTO" ]; then
+        read -r -p "  Are you sure you want to delete everything? (yes/no): " CONFIRM
+        [ "$CONFIRM" != "yes" ] && { echo "  Cancelled."; exit 0; }
+    fi
+    echo ""
+
+    local INSTANCE_ID="${CONNECT_INSTANCE_ID:-$(state_get CONNECT_INSTANCE_ID)}"
+    if [ -z "$INSTANCE_ID" ]; then
+        INSTANCES_JSON=$(aws connect list-instances --region "$REGION" --output json 2>/dev/null || echo '{"InstanceSummaryList":[]}')
+        N=$(echo "$INSTANCES_JSON" | python3 -c "import sys,json; print(len(json.load(sys.stdin).get('InstanceSummaryList',[])))" 2>/dev/null || echo 0)
+        [ "$N" = "1" ] && INSTANCE_ID=$(echo "$INSTANCES_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin)['InstanceSummaryList'][0]['Id'])")
+    fi
+
+    # ── Release phone numbers ───────────────────────────────────────────────
+    echo "☎️  Releasing phone numbers..."
+    if [ -n "$INSTANCE_ID" ]; then
+        aws connect list-phone-numbers-v2 --instance-id "$INSTANCE_ID" \
+            --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+for p in json.load(sys.stdin).get('ListPhoneNumbersSummaryList', []):
+    if p.get('PhoneNumberDescription') == '${PROJECT_NAME}-workshop':
+        print(p['PhoneNumberId'])
+" 2>/dev/null | while read -r pid; do
+            [ -z "$pid" ] && continue
+            info "Releasing number: $pid"
+            aws connect release-phone-number --phone-number-id "$pid" --region "$REGION" 2>/dev/null || true
+        done
+    fi
+
+    # ── Contact Flow ─────────────────────────────────────────────────────────
+    echo "📋 Deleting Contact Flow..."
+    if [ -n "$INSTANCE_ID" ]; then
+        FLOW_ID=$(aws connect list-contact-flows --instance-id "$INSTANCE_ID" \
+            --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+for f in json.load(sys.stdin).get('ContactFlowSummaryList', []):
+    if f.get('Name') == '${FLOW_NAME}': print(f['Id']); break
+" 2>/dev/null || echo "")
+        [ -n "$FLOW_ID" ] && aws connect delete-contact-flow --instance-id "$INSTANCE_ID" \
+            --contact-flow-id "$FLOW_ID" --region "$REGION" 2>/dev/null && info "Deleted: $FLOW_NAME" || true
+    fi
+
+    # ── AI Agent / Prompt / Security Profile ────────────────────────────────
+    echo "🧠 Deleting AI Agent / Prompt / security profile..."
+    ASST_ID="${AI_ASSISTANT_ID:-$(state_get AI_ASSISTANT_ID)}"
+    if [ -z "$ASST_ID" ]; then
+        ASST_ID=$(aws qconnect list-assistants --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+for a in json.load(sys.stdin).get('assistantSummaries', []):
+    if a.get('name') == '${PROJECT_NAME}-assistant': print(a['assistantId']); break
+" 2>/dev/null || echo "")
+    fi
+    if [ -n "$ASST_ID" ]; then
+        aws qconnect remove-assistant-ai-agent --assistant-id "$ASST_ID" \
+            --ai-agent-type ORCHESTRATION --region "$REGION" 2>/dev/null || true
+        AGENT_ID=$(aws qconnect list-ai-agents --assistant-id "$ASST_ID" --origin CUSTOMER \
+            --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+for a in json.load(sys.stdin).get('aiAgentSummaries', []):
+    if a.get('name') == '${AGENT_NAME}': print(a['aiAgentId'].split(':')[0]); break
+" 2>/dev/null || echo "")
+        if [ -n "$AGENT_ID" ]; then
+            for v in $(aws qconnect list-ai-agent-versions --assistant-id "$ASST_ID" \
+                --ai-agent-id "$AGENT_ID" --region "$REGION" \
+                --query 'aiAgentVersionSummaries[].versionNumber' --output text 2>/dev/null); do
+                aws qconnect delete-ai-agent-version --assistant-id "$ASST_ID" \
+                    --ai-agent-id "$AGENT_ID" --version-number "$v" --region "$REGION" 2>/dev/null || true
+            done
+            aws qconnect delete-ai-agent --assistant-id "$ASST_ID" \
+                --ai-agent-id "$AGENT_ID" --region "$REGION" 2>/dev/null && info "AI Agent deleted: $AGENT_NAME" || true
+        fi
+        PROMPT_ID=$(aws qconnect list-ai-prompts --assistant-id "$ASST_ID" --origin CUSTOMER \
+            --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+for p in json.load(sys.stdin).get('aiPromptSummaries', []):
+    if p.get('name') == '${PROMPT_NAME}': print(p['aiPromptId'].split(':')[0]); break
+" 2>/dev/null || echo "")
+        if [ -n "$PROMPT_ID" ]; then
+            for v in $(aws qconnect list-ai-prompt-versions --assistant-id "$ASST_ID" \
+                --ai-prompt-id "$PROMPT_ID" --region "$REGION" \
+                --query 'aiPromptVersionSummaries[].versionNumber' --output text 2>/dev/null); do
+                aws qconnect delete-ai-prompt-version --assistant-id "$ASST_ID" \
+                    --ai-prompt-id "$PROMPT_ID" --version-number "$v" --region "$REGION" 2>/dev/null || true
+            done
+            aws qconnect delete-ai-prompt --assistant-id "$ASST_ID" \
+                --ai-prompt-id "$PROMPT_ID" --region "$REGION" 2>/dev/null && info "AI Prompt deleted: $PROMPT_NAME" || true
+        fi
+    fi
+    if [ -n "$INSTANCE_ID" ]; then
+        SP_ID=$(aws connect list-security-profiles --instance-id "$INSTANCE_ID" \
+            --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+for s in json.load(sys.stdin).get('SecurityProfileSummaryList', []):
+    if s.get('Name') == '${SP_NAME}': print(s['Id']); break
+" 2>/dev/null || echo "")
+        if [ -n "$SP_ID" ]; then
+            # An SP attached to an AI agent entity can't be deleted; parse the
+            # associated entity ARNs from the error and disassociate them first.
+            SP_DEL_ERR=$(aws connect delete-security-profile --instance-id "$INSTANCE_ID" \
+                --security-profile-id "$SP_ID" --region "$REGION" 2>&1) || true
+            if echo "$SP_DEL_ERR" | grep -q ResourceInUseException; then
+                echo "$SP_DEL_ERR" | grep -oE 'arn:aws:wisdom:[^],[:space:]]+' | while read -r earn; do
+                    aws connect disassociate-security-profiles --instance-id "$INSTANCE_ID" \
+                        --security-profiles "[{\"Id\":\"$SP_ID\"}]" \
+                        --entity-type AI_AGENT --entity-arn "$earn" \
+                        --region "$REGION" 2>/dev/null || true
+                done
+                aws connect delete-security-profile --instance-id "$INSTANCE_ID" \
+                    --security-profile-id "$SP_ID" --region "$REGION" 2>/dev/null || true
+            fi
+            aws connect describe-security-profile --security-profile-id "$SP_ID" \
+                --instance-id "$INSTANCE_ID" --region "$REGION" &>/dev/null \
+                && warn "Security profile could not be deleted: $SP_NAME" \
+                || info "Security profile deleted: $SP_NAME"
+        fi
+    fi
+
+    # ── Lex bot ─────────────────────────────────────────────────────────────
+    echo "🗣️  Deleting Lex bot..."
+    LEX_BOT_ID=$(aws lexv2-models list-bots --region "$REGION" \
+        --filters "name=BotName,values=$BOT_NAME,operator=EQ" \
+        --query 'botSummaries[0].botId' --output text 2>/dev/null || echo "")
+    [ "$LEX_BOT_ID" = "None" ] && LEX_BOT_ID=""
+    if [ -n "$LEX_BOT_ID" ]; then
+        if [ -n "$INSTANCE_ID" ]; then
+            aws connect disassociate-bot --instance-id "$INSTANCE_ID" \
+                --lex-v2-bot "AliasArn=arn:aws:lex:${REGION}:${ACCOUNT_ID}:bot-alias/${LEX_BOT_ID}/TSTALIASID" \
+                --region "$REGION" 2>/dev/null || true
+        fi
+        aws lexv2-models delete-bot --bot-id "$LEX_BOT_ID" \
+            --skip-resource-in-use-check --region "$REGION" >/dev/null 2>&1 && info "Bot deleted: $BOT_NAME" || true
+    fi
+    # bot runtime role
+    for POL in polly qinconnect; do
+        aws iam delete-role-policy --role-name "${PROJECT_NAME}-lex-bot-role" --policy-name "$POL" 2>/dev/null || true
+    done
+    aws iam delete-role --role-name "${PROJECT_NAME}-lex-bot-role" 2>/dev/null && info "Lex bot role deleted" || true
+
+    # ── MCP integration ─────────────────────────────────────────────────────
+    echo "🔗 Removing MCP integration..."
+    # find ALL project MCP apps (by name prefix OR namespace prefix) — a stale
+    # app from an earlier gateway generation must be removed too
+    aws appintegrations list-applications --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+for a in json.load(sys.stdin).get('Applications', []):
+    if a.get('Name','').startswith('${MCP_APP_NAME}') or a.get('Namespace','').startswith('${GATEWAY_NAME}'):
+        print(a['Arn'])
+" 2>/dev/null | while read -r app_arn; do
+        [ -z "$app_arn" ] && continue
+        if [ -n "$INSTANCE_ID" ]; then
+            aws connect list-integration-associations --instance-id "$INSTANCE_ID" \
+                --integration-type APPLICATION --region "$REGION" --output json 2>/dev/null | \
+                APP_ARN="$app_arn" python3 -c "
+import sys, json, os
+for a in json.load(sys.stdin).get('IntegrationAssociationSummaryList', []):
+    if a.get('IntegrationArn') == os.environ['APP_ARN']: print(a['IntegrationAssociationId'])
+" 2>/dev/null | while read -r aid; do
+                [ -z "$aid" ] && continue
+                aws connect delete-integration-association --instance-id "$INSTANCE_ID" \
+                    --integration-association-id "$aid" --region "$REGION" 2>/dev/null || true
+            done
+        fi
+        sleep 2
+        aws appintegrations delete-application --arn "$app_arn" \
+            --region "$REGION" 2>/dev/null && info "MCP app deleted: $app_arn" || warn "MCP app not deleted (check associations): $app_arn"
+    done
+
+    # ── WISDOM integration + Assistant + KB ─────────────────────────────────
+    echo "🤖 Deleting Assistant / KB..."
+    # Ownership guard: only touch the assistant (and its Connect association)
+    # when it was created by this project (name match).
+    ASST_OWNED=false
+    if [ -n "$ASST_ID" ]; then
+        ASST_NAME=$(aws qconnect get-assistant --assistant-id "$ASST_ID" --region "$REGION" \
+            --query 'assistant.name' --output text 2>/dev/null || echo "")
+        [ "$ASST_NAME" = "${PROJECT_NAME}-assistant" ] && ASST_OWNED=true
+    fi
+    if [ -n "$INSTANCE_ID" ] && [ "$ASST_OWNED" = "true" ]; then
+        aws connect list-integration-associations --instance-id "$INSTANCE_ID" \
+            --integration-type WISDOM_ASSISTANT --region "$REGION" --output json 2>/dev/null | \
+            python3 -c "
+import sys, json
+for a in json.load(sys.stdin).get('IntegrationAssociationSummaryList', []):
+    if a.get('IntegrationArn','').endswith('$ASST_ID'): print(a['IntegrationAssociationId'])
+" 2>/dev/null | while read -r aid; do
+            [ -z "$aid" ] && continue
+            aws connect delete-integration-association --instance-id "$INSTANCE_ID" \
+                --integration-association-id "$aid" --region "$REGION" 2>/dev/null || true
+        done
+    fi
+    KB_ID=$(aws qconnect list-knowledge-bases --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+for kb in json.load(sys.stdin).get('knowledgeBaseSummaries', []):
+    if kb.get('name') == '${KB_NAME}': print(kb['knowledgeBaseId']); break
+" 2>/dev/null || echo "")
+    if [ "$ASST_OWNED" = "true" ]; then
+        aws qconnect list-assistant-associations --assistant-id "$ASST_ID" \
+            --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+for a in json.load(sys.stdin).get('assistantAssociationSummaries', []):
+    print(a['assistantAssociationId'])
+" 2>/dev/null | while read -r aaid; do
+            [ -z "$aaid" ] && continue
+            aws qconnect delete-assistant-association --assistant-id "$ASST_ID" \
+                --assistant-association-id "$aaid" --region "$REGION" 2>/dev/null || true
+        done
+        aws qconnect delete-assistant --assistant-id "$ASST_ID" --region "$REGION" 2>/dev/null \
+            && info "Assistant deleted" || true
+    elif [ -n "$ASST_ID" ]; then
+        info "Assistant ($ASST_NAME) is not owned by this project — keeping it and its associations"
+    fi
+    [ -n "$KB_ID" ] && aws qconnect delete-knowledge-base --knowledge-base-id "$KB_ID" \
+        --region "$REGION" 2>/dev/null && info "KB deleted" || true
+
+    # ── Gateway resources ───────────────────────────────────────────────────
+    echo "🌐 Deleting AgentCore Gateway..."
+    if aws bedrock-agentcore-control help &>/dev/null; then
+        GW_ID=$(aws bedrock-agentcore-control list-gateways --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for gw in d.get('items', d.get('gateways', [])):
+    if gw.get('name') == '${GATEWAY_NAME}': print(gw['gatewayId']); break
+" 2>/dev/null || echo "")
+        if [ -n "$GW_ID" ]; then
+            aws bedrock-agentcore-control list-gateway-targets --gateway-identifier "$GW_ID" \
+                --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for t in d.get('items', d.get('targets', [])):
+    print(t.get('targetId',''))
+" 2>/dev/null | while read -r tid; do
+                [ -z "$tid" ] && continue
+                aws bedrock-agentcore-control delete-gateway-target \
+                    --gateway-identifier "$GW_ID" --target-id "$tid" \
+                    --region "$REGION" >/dev/null 2>&1 || true
+            done
+            # wait until all targets are actually gone
+            for i in $(seq 1 24); do
+                TCOUNT=$(aws bedrock-agentcore-control list-gateway-targets \
+                    --gateway-identifier "$GW_ID" --region "$REGION" --output json 2>/dev/null | \
+                    python3 -c "import sys,json; d=json.load(sys.stdin); print(len(d.get('items', d.get('targets', []))))" 2>/dev/null || echo 0)
+                [ "$TCOUNT" = "0" ] && break
+                sleep 5
+            done
+            aws bedrock-agentcore-control delete-gateway --gateway-identifier "$GW_ID" \
+                --region "$REGION" >/dev/null 2>&1 || true
+            echo -n "   Waiting for gateway deletion..."
+            for i in $(seq 1 30); do
+                aws bedrock-agentcore-control get-gateway --gateway-identifier "$GW_ID" \
+                    --region "$REGION" &>/dev/null || { echo " ✅"; break; }
+                echo -n "."; sleep 5
+            done
+        fi
+        CRED_ARN=$(aws bedrock-agentcore-control list-api-key-credential-providers \
+            --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+for p in json.load(sys.stdin).get('credentialProviders', []):
+    if p.get('name') == '${CRED_PROVIDER_NAME}': print(p['credentialProviderArn']); break
+" 2>/dev/null || echo "")
+        [ -n "$CRED_ARN" ] && aws bedrock-agentcore-control delete-api-key-credential-provider \
+            --name "$CRED_PROVIDER_NAME" --region "$REGION" 2>/dev/null || true
+    fi
+
+    # ── Gateway IAM Role ────────────────────────────────────────────────────
+    echo "🔑 Deleting Gateway IAM role..."
+    if aws iam get-role --role-name "$ROLE_NAME" &>/dev/null; then
+        for pname in $(aws iam list-role-policies --role-name "$ROLE_NAME" \
+            --query 'PolicyNames' --output text 2>/dev/null); do
+            aws iam delete-role-policy --role-name "$ROLE_NAME" --policy-name "$pname" 2>/dev/null || true
+        done
+        for parn in $(aws iam list-attached-role-policies --role-name "$ROLE_NAME" \
+            --query 'AttachedPolicies[].PolicyArn' --output text 2>/dev/null); do
+            aws iam detach-role-policy --role-name "$ROLE_NAME" --policy-arn "$parn" 2>/dev/null || true
+        done
+        aws iam delete-role --role-name "$ROLE_NAME" 2>/dev/null && info "IAM role deleted" || true
+    fi
+
+    # ── S3 assets + CFN stack + template bucket ─────────────────────────────
+    echo "📦 Deleting CloudFormation stack..."
+    KB_BUCKET=$(get_output "KnowledgeBaseBucketName")
+    if [ -n "$KB_BUCKET" ]; then
+        aws s3 rm "s3://$KB_BUCKET" --recursive --region "$REGION" >/dev/null 2>&1 || true
+        purge_bucket_versions "$KB_BUCKET"
+    fi
+    if aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" &>/dev/null; then
+        aws cloudformation delete-stack --stack-name "$STACK_NAME" --region "$REGION"
+        info "Waiting for stack deletion..."
+        aws cloudformation wait stack-delete-complete --stack-name "$STACK_NAME" --region "$REGION" || true
+    fi
+    if aws s3 ls "s3://$TEMPLATE_BUCKET" --region "$REGION" &>/dev/null; then
+        aws s3 rm "s3://$TEMPLATE_BUCKET" --recursive --region "$REGION" >/dev/null 2>&1 || true
+        purge_bucket_versions "$TEMPLATE_BUCKET"
+        aws s3api delete-bucket --bucket "$TEMPLATE_BUCKET" --region "$REGION" 2>/dev/null || true
+    fi
+
+    rm -f "$STATE_FILE"
+    echo ""
+    hr
+    echo "  ✅ Cleanup complete! (Connect instance preserved)"
+    echo "     Delete instance: aws connect delete-instance --instance-id <ID>"
+    hr
+}
+
+# =============================================================================
+# STATUS
+# =============================================================================
+do_status() {
+    hr
+    echo "  AICC Builder - Deployment Status"
+    echo "  Project: $PROJECT_NAME | Region: $REGION"
+    hr
+    echo ""
+    STACK_STATUS=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" \
+        --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "NOT_FOUND")
+    echo "  📦 CloudFormation:   $STACK_STATUS"
+    [ "$STACK_STATUS" != "NOT_FOUND" ] && echo "     API Endpoint:     $(get_output ApiEndpoint)"
+
+    N=$(aws connect list-instances --region "$REGION" --output json 2>/dev/null | \
+        python3 -c "import sys,json; print(len(json.load(sys.stdin).get('InstanceSummaryList',[])))" 2>/dev/null || echo 0)
+    echo "  📞 Connect instances:  ${N}"
+
+    for kv in CONNECT_INSTANCE_ID AI_ASSISTANT_ID GATEWAY_ID BOT_ID CONTACT_FLOW_ID AI_AGENT_ID SP_ID PHONE_NUMBER_ID; do
+        v=$(state_get $kv)
+        [ -n "$v" ] && echo "  🔹 $kv: $v"
+    done
+
+    if aws bedrock-agentcore-control help &>/dev/null; then
+        GW_STATUS=$(aws bedrock-agentcore-control list-gateways --region "$REGION" --output json 2>/dev/null | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+for gw in d.get('items', d.get('gateways', [])):
+    if gw.get('name') == '${GATEWAY_NAME}': print(gw.get('status','?')); break
+else: print('NOT_FOUND')
+" 2>/dev/null || echo "?")
+        echo "  🌐 Gateway ($GATEWAY_NAME): $GW_STATUS"
+    fi
+    echo ""
+    hr
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+# Record a full transcript for diagnostics (share this file when reporting issues)
+DEPLOY_LOG="$SCRIPT_DIR/aicc_deploy_$(date +%Y%m%d_%H%M%S).log"
+exec > >(tee "$DEPLOY_LOG") 2>&1
+echo "(transcript: $DEPLOY_LOG)"
+
 case "$COMMAND" in
-    deploy)
-        do_deploy
-        ;;
-    cleanup|clean|destroy|delete)
-        do_cleanup
-        ;;
-    status)
-        do_status
-        ;;
+    deploy)                     do_deploy ;;
+    cleanup|clean|destroy|delete) do_cleanup ;;
+    status)                     do_status ;;
     *)
         echo "Usage: $0 {deploy|cleanup|status}"
-        echo ""
-        echo "  deploy   Deploy all workshop assets (default)"
-        echo "  cleanup  Tear down ALL deployed resources"
-        echo "  status   Show current deployment status"
         exit 1
         ;;
 esac

--- a/skills/aicc-builder-skill/scripts/_extract_prompts.py
+++ b/skills/aicc-builder-skill/scripts/_extract_prompts.py
@@ -11,11 +11,14 @@ Args:
 """
 from __future__ import annotations
 
+import ast
 import json
 import re
 import sys
 import types
 from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
 
 
 def extract_prompts(repo_root: Path, skill_root: Path) -> int:
@@ -26,7 +29,8 @@ def extract_prompts(repo_root: Path, skill_root: Path) -> int:
     out_sub = skill_root / "resources/sub-agents"
     out_orch = skill_root / "resources/orchestrator"
     out_schemas = skill_root / "resources/schemas"
-    for d in (out_sub, out_orch, out_schemas):
+    out_scripts = skill_root / "resources/scripts"
+    for d in (out_sub, out_orch, out_schemas, out_scripts):
         d.mkdir(parents=True, exist_ok=True)
 
     # ---------------- 1) shared consistency rules ----------------
@@ -228,6 +232,9 @@ def extract_prompts(repo_root: Path, skill_root: Path) -> int:
         p.write_text(json.dumps(schema, indent=2))
         print(f"[ok] {cls}.schema.json ({p.stat().st_size} bytes)")
 
+    # ---------------- 5b) deterministic asset linters ----------------
+    _extract_linters(src, out_scripts)
+
     # ---------------- 6) COVERAGE ASSERTION (drift-gate blind-spot guard) ----------------
     # The --check drift gate diffs the extractor's output against itself, so it can
     # ONLY catch edits to sections/models the extractor already enumerates. A NEWLY
@@ -237,6 +244,56 @@ def extract_prompts(repo_root: Path, skill_root: Path) -> int:
     # and warns about any the extractor's lists don't cover, so future additions
     # surface instead of rotting.
     return _report_coverage(sp_ns, spec_ns, phases, standalone_orch, schema_models)
+
+
+_LINT_HEADER = '''#!/usr/bin/env python3
+# AUTO-GENERATED — DO NOT EDIT.
+#
+# Mechanically extracted from backend/ecs/src/tools/asset_linters.py by
+# skills/aicc-builder-skill/scripts/_extract_prompts.py: the `strands` import and
+# every @tool-decorated wrapper (they need the S3/session runtime) are stripped,
+# and scripts/_lint_assets_cli.py is appended as the CLI driver.
+#
+# To change a lint rule, edit the backend module and re-run
+# skills/aicc-builder-skill/scripts/extract_prompts.sh.
+'''
+
+
+def _extract_linters(src: Path, out_scripts: Path) -> None:
+    """Generate resources/scripts/lint_assets.py from tools/asset_linters.py.
+
+    The library-tier linters (lint_and_autofix_cfn / lint_and_autofix_openapi /
+    lint_python_source / lint_lambda_status_codes / lint_contact_flow /
+    lint_ai_prompt) are pure str→dict and depend only on the stdlib + PyYAML, so
+    they port verbatim. The @tool wrappers around them read assets from S3 and
+    cannot, so they are dropped along with the `from strands import tool` line.
+
+    Extracting rather than hand-copying is deliberate: the API-verified block
+    schemas and error-branch tables in that module change often, and a stale copy
+    in the skill would fail Contact Flow imports the webapp accepts.
+    """
+    lint_src = src / "tools/asset_linters.py"
+    text = lint_src.read_text()
+    lines = text.splitlines(keepends=True)
+    drop: set[int] = set()
+    dropped_tools: list[str] = []
+    for node in ast.parse(text).body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if any(isinstance(d, ast.Name) and d.id == "tool" for d in node.decorator_list):
+                start = min([node.lineno] + [d.lineno for d in node.decorator_list])
+                drop.update(range(start, (node.end_lineno or start) + 1))
+                dropped_tools.append(node.name)
+        elif isinstance(node, ast.ImportFrom) and node.module == "strands":
+            drop.update(range(node.lineno, (node.end_lineno or node.lineno) + 1))
+
+    body = "".join(l for i, l in enumerate(lines, 1) if i not in drop)
+    body = re.sub(r"\n{4,}", "\n\n\n", body)
+    cli = (HERE / "_lint_assets_cli.py").read_text()
+    out = out_scripts / "lint_assets.py"
+    out.write_text(f"{_LINT_HEADER}\n{body.rstrip()}\n\n\n{cli}")
+    out.chmod(0o755)
+    print(f"[ok] lint_assets.py <- tools/asset_linters.py "
+          f"({out.stat().st_size} bytes; dropped @tool: {', '.join(dropped_tools)})")
 
 
 # Backend prompt strings that are intentionally NOT extracted as standalone skill

--- a/skills/aicc-builder-skill/scripts/_lint_assets_cli.py
+++ b/skills/aicc-builder-skill/scripts/_lint_assets_cli.py
@@ -1,0 +1,161 @@
+# ---------------------------------------------------------------------------
+# CLI driver (appended by scripts/_extract_prompts.py — not part of the backend
+# module). Runs every library-tier linter above over an <output_dir> bundle.
+# ---------------------------------------------------------------------------
+
+import json as _cli_json
+import re as _cli_re
+import sys as _cli_sys
+from pathlib import Path as _CliPath
+
+
+def _cli_assets_root(output_dir):
+    """Newest ``assets/vN`` directory, falling back to a flat ``assets/``."""
+    base = output_dir / "assets"
+    versioned = sorted(
+        (d for d in base.glob("v*") if d.is_dir() and _cli_re.fullmatch(r"v\d+", d.name)),
+        key=lambda d: int(d.name[1:]),
+    )
+    return versioned[-1] if versioned else base
+
+
+def _cli_run(output_dir, apply_fixes):
+    """Return (report, error_count, pending_fix_count)."""
+    assets = _cli_assets_root(output_dir)
+    report = []
+    errors = 0
+    pending = 0
+
+    def add(path, kind, errs, warns, fixes, fixed_text=None, target=None):
+        nonlocal errors, pending
+        errs = [str(e) for e in (errs or [])]
+        warns = [str(w) for w in (warns or [])]
+        fixes = [str(f) for f in (fixes or [])]
+        if not (errs or warns or fixes):
+            return          # clean file: stay quiet rather than print a bare header
+        errors += len(errs)
+        if fixes:
+            if apply_fixes and fixed_text is not None:
+                (target or path).write_text(fixed_text)
+            else:
+                pending += len(fixes)
+        report.append({"file": str(path), "linter": kind, "errors": errs,
+                       "warnings": warns, "fixes_applied": fixes,
+                       "written": bool(fixes and apply_fixes and fixed_text is not None)})
+
+    # ---- Lambda handlers: Python syntax + BUSINESS_OUTCOME_200 status codes ----
+    lam_dir = assets / "lambda"
+    if lam_dir.is_dir():
+        for p in sorted(lam_dir.rglob("*.py")):
+            code = p.read_text()
+            syn = lint_python_source(code)
+            if not syn["ok"]:
+                add(p, "python_syntax",
+                    [f"line {e.get('line')}: {e.get('message')}" for e in syn["errors"]],
+                    [], [])
+                continue    # a file that doesn't compile can't be status-linted
+            status = lint_lambda_status_codes(code)
+            if status["fixes_applied"] or status["warnings"]:
+                add(p, "lambda_status_codes", [], status["warnings"],
+                    status["fixes_applied"], status["fixed_code"])
+
+    # ---- CloudFormation ----
+    infra_dir = assets / "infrastructure"
+    if infra_dir.is_dir():
+        for p in sorted(infra_dir.glob("*.y*ml")):
+            res = lint_and_autofix_cfn(p.read_text())
+            if not res["available"]:
+                report.append({"file": str(p), "linter": "cloudformation",
+                               "errors": [], "warnings": [
+                                   "cfn-lint not installed — autofixes applied but the "
+                                   "template was NOT validated (pip install cfn-lint)"],
+                               "fixes_applied": res["fixes_applied"], "written": False})
+                continue
+            add(p, "cloudformation",
+                [f"{e.get('id')}@L{e.get('line')}: {e.get('message')}" for e in res["errors"]],
+                [f"{w.get('id')}@L{w.get('line')}: {w.get('message')}" for w in res["warnings"]],
+                res["fixes_applied"], res["fixed_yaml"])
+
+    # ---- OpenAPI ----
+    oapi_dir = assets / "openapi"
+    if oapi_dir.is_dir():
+        for p in sorted(oapi_dir.glob("*.y*ml")):
+            res = lint_and_autofix_openapi(p.read_text())
+            warns = [] if res["available"] else [
+                "openapi-spec-validator not installed — autofixes applied but the "
+                "document was NOT validated (pip install openapi-spec-validator)"]
+            add(p, "openapi", res["errors"], warns,
+                res["fixes_applied"], res["fixed_yaml"])
+
+    # ---- Contact Flow ----
+    cf_dir = assets / "contact_flow"
+    if cf_dir.is_dir():
+        for p in sorted(cf_dir.rglob("*.json")):
+            res = lint_contact_flow(p.read_text())
+            add(p, "contact_flow", res["errors"], res["warnings"],
+                res["fixes_applied"], res.get("fixed_json"))
+
+    # ---- AI prompt (qconnect variable-once rule) ----
+    pr_dir = assets / "prompt"
+    if pr_dir.is_dir():
+        for p in sorted(pr_dir.rglob("*")):
+            if p.suffix.lower() not in (".yaml", ".yml", ".md", ".txt") or not p.is_file():
+                continue
+            res = lint_ai_prompt(p.read_text())
+            if res["errors"] or res["fixes_applied"] or res["warnings"]:
+                add(p, "ai_prompt", res["errors"], res["warnings"],
+                    res["fixes_applied"], res.get("fixed_text"))
+
+    return report, errors, pending
+
+
+def _cli_main():
+    argv = _cli_sys.argv[1:]
+    flags = {a for a in argv if a.startswith("-")}
+    args = [a for a in argv if not a.startswith("-")]
+    unknown = flags - {"--fix", "--json"}
+    if len(args) != 1 or unknown:
+        print(f"Usage: {_cli_sys.argv[0]} <output_dir> [--fix] [--json]\n"
+              f"  --fix   write the deterministic auto-fixes back to the files\n"
+              f"  --json  machine-readable report on stdout",
+              file=_cli_sys.stderr)
+        return 2
+    out_dir = _CliPath(args[0]).resolve()
+    if not out_dir.is_dir():
+        print(f"ERROR: not a directory: {out_dir}", file=_cli_sys.stderr)
+        return 2
+
+    apply_fixes = "--fix" in flags
+    report, errors, pending = _cli_run(out_dir, apply_fixes)
+
+    if "--json" in flags:
+        print(_cli_json.dumps({"success": errors == 0 and pending == 0,
+                               "errors": errors, "pending_fixes": pending,
+                               "results": report}, indent=2, ensure_ascii=False))
+        return 0 if (errors == 0 and pending == 0) else 1
+
+    if not report:
+        print(f"OK — nothing to lint under {_cli_assets_root(out_dir)}")
+        return 0
+    for r in report:
+        head = f"{r['linter']}: {r['file']}"
+        print(head)
+        for e in r["errors"]:
+            print(f"  ERROR   {e}")
+        for w in r["warnings"]:
+            print(f"  WARN    {w}")
+        for f in r["fixes_applied"]:
+            print(f"  {'FIXED  ' if r['written'] else 'NEEDS FIX'} {f}")
+    print("")
+    if errors == 0 and pending == 0:
+        print("OK — no blocking lint findings"
+              + (" (auto-fixes written)" if apply_fixes else ""))
+        return 0
+    print(f"FAIL — {errors} error(s), {pending} pending auto-fix(es).")
+    if pending and not apply_fixes:
+        print("Re-run with --fix to apply the deterministic fixes, then re-lint.")
+    return 1
+
+
+if __name__ == "__main__":
+    _cli_sys.exit(_cli_main())

--- a/skills/aicc-builder-skill/scripts/extract_prompts.sh
+++ b/skills/aicc-builder-skill/scripts/extract_prompts.sh
@@ -33,6 +33,7 @@ case "${MODE}" in
     echo "✓ resources/orchestrator/*.md"
     echo "✓ resources/sub-agents/*.md"
     echo "✓ resources/schemas/*.json"
+    echo "✓ resources/scripts/lint_assets.py"
     echo ""
     echo "Next: review 'git diff skills/aicc-builder-skill/resources/' and commit."
     ;;
@@ -44,6 +45,7 @@ case "${MODE}" in
     mkdir -p "${TMP_ROOT}/resources/orchestrator"
     mkdir -p "${TMP_ROOT}/resources/sub-agents"
     mkdir -p "${TMP_ROOT}/resources/schemas"
+    mkdir -p "${TMP_ROOT}/resources/scripts"
 
     # --strict: a coverage gap (a new backend prompt section / spec model the
     # extractor doesn't enumerate) is a hard failure here, not just a warning —
@@ -69,6 +71,18 @@ case "${MODE}" in
         echo ""
       fi
     done
+
+    # resources/scripts/ also holds hand-authored CLI scripts the extractor never
+    # writes, so diff only the generated file rather than the whole directory.
+    if ! diff -q \
+        "${SKILL_ROOT}/resources/scripts/lint_assets.py" \
+        "${TMP_ROOT}/resources/scripts/lint_assets.py" >/dev/null 2>&1; then
+      DRIFT=1
+      echo "DRIFT in resources/scripts/lint_assets.py:"
+      diff "${SKILL_ROOT}/resources/scripts/lint_assets.py" \
+           "${TMP_ROOT}/resources/scripts/lint_assets.py" || true
+      echo ""
+    fi
 
     if [[ "${DRIFT}" -ne 0 ]]; then
       echo "Skill prompts are out of sync with backend/ecs/src/." >&2


### PR DESCRIPTION
Two changes, one commit each.

## 1. `fix(backend)`: the driver path was unreachable

`introspect_database()` picks its connection method per target — the RDS Data API
on Aurora with the HTTP endpoint enabled, a real engine driver everywhere else —
and reports it as `access_method`. `convert_to_infrastructure_schema()` then
threw that away and hardcoded `"rds-data-api"`, along with the Data-API-only
`connection`, `environment_variables` and `iam_requirements`.

So every driver-only database — plain RDS PostgreSQL/MySQL/MariaDB, SQL Server,
Oracle, Db2, or Aurora with the endpoint off — presented downstream as Data API.
`lambda_generator`'s driver branch keys on `access_method == "<engine>-driver"`,
so that whole branch could never run: the generated handler called
`rds-data:ExecuteStatement` against a cluster that has no Data API, read a
`DB_CLUSTER_ARN` that was never set, and failed on its first query. The template
also asked for `rds-data:*` the function cannot use and omitted the `VpcConfig` a
driver connection needs.

The converter now branches on the scanned verdict:

| `access_method` | `connection` | env vars | IAM |
|---|---|---|---|
| `rds-data-api` | `{cluster_arn, secret_arn, database_name}` | `DB_CLUSTER_ARN`, `DB_SECRET_ARN`, `DB_NAME` | `rds-data:*` + `secretsmanager:GetSecretValue` |
| `<engine>-driver` | `{host, port, secret_arn, database_name}` | `DB_SECRET_ARN`, `DB_HOST`, `DB_PORT`, `DB_NAME` | `secretsmanager:GetSecretValue` only |

Payloads that predate the field (schema-as-document, cached scans) infer it from
the coordinates present rather than defaulting to a fixed value. The orchestrator
prompt documented only the Data API shape, so it describes both now, and the
module docstring no longer claims plain RDS is unreachable.

The Data API env/usage gate in `validate_consistency.py` is keyed on `rds-data`
appearing in the handler source rather than on `access_method`, so a driver
Lambda skips it instead of failing it — no new false positives.

`tests/test_db_access_method.py` covers both contracts across the six
driver-only engines, Aurora with the endpoint off, and the inference fallback.

## 2. `chore(skill)`: re-sync `skills/aicc-builder-skill` with the webapp

The auto-extracted tier had drifted and several authored files described
behaviour the webapp no longer has.

- **New `resources/scripts/lint_assets.py`** — generated from
  `tools/asset_linters.py` with the `strands` import and the four `@tool`
  wrappers stripped. That module carries ~1600 lines of API-verified Contact Flow
  block and error tables; a hand-copy would go stale and reject flows the webapp
  accepts.
- **New `resources/scripts/shape_parity.py`** — the reviewer's spec ↔ OpenAPI
  HARD GATE, which the skill had no equivalent of.
- `validate_consistency.py` — ported the checks added since the last sync: IAM
  permissions, the RDS Data API env/usage contract, and the four SQL checks
  against the scanned schema (18 total).
- The extractor gained a `--strict` coverage gate, so a new backend prompt
  section or spec model that nothing extracts fails `--check` instead of silently
  going missing.
- `contact_flow_block_schemas.md` rewritten from the linter's own tables (51
  verified Types + console names, the invalid-Type list, per-block params and
  error branches, the qconnect variable-once rule); `vision_import.md` now runs
  the linter with `--fix` and prints the authoritative Type list instead of
  trusting a copy.
- `deploy_workshop.sh` re-synced with the 13-phase script; both `SKILL.md`s and
  `README.md` updated (PHASE 0 existing-database with the table above, the
  three-gate validation section, the 17 golden rules, the auto-extracted vs
  authored split).

### Verification

- `extract_prompts.sh --check`: no drift, full coverage.
- Both `SKILL.md` bodies byte-identical; every script compiles.
- Differential smoke test: a deliberately-broken bundle produced 9 consistency
  mismatches, 2 shape violations and 5 lint fixes; the corrected bundle produced
  nothing from all three gates.
- `python -m pytest tests/` → 231 passed. The 4 `test_session_isolation.py`
  failures on my machine are a missing local `pytest-asyncio`, not a code
  failure, and are unrelated to this change.