### PR TITLE
fix: Segment chat bubbles at tool boundaries; fix session-restore ordering

### DIFF
--- a/backend/ecs/app.py
+++ b/backend/ecs/app.py
@@ -48,6 +48,7 @@ from prompts.system_prompt import SYSTEM_PROMPT, get_document_analysis_prompt, g
 from context import format_history_for_injection
 from context.modification_tracking import (
     format_modification_state_block,
+    record_modification_outcome,
     record_modification_request,
     suggest_placeholder,
 )
@@ -1879,7 +1880,7 @@ async def _rehydrate_assets_for_display(websocket: WebSocket, session_id: str) -
     raises into the connect path.
     """
     try:
-        from tools.s3_asset_storage import list_session_assets, get_asset_from_s3
+        from tools.s3_asset_storage import list_session_assets, get_asset_from_s3, get_asset_mtime_ms
         keys = list_session_assets(session_id) or []
         emitted = 0
         seen: set = set()
@@ -1906,18 +1907,28 @@ async def _rehydrate_assets_for_display(websocket: WebSocket, session_id: str) -
                 continue
             ext = os.path.splitext(file_name)[1].lower()
             language = _REHYDRATE_EXT_TO_LANG.get(ext, "text")
+            # File mtime (NFS) / LastModified (S3) in epoch ms — lets the
+            # frontend place the replayed preview at its true chronological
+            # position instead of defaulting to "now" (= bottom of the chat).
+            try:
+                created_at = get_asset_mtime_ms(key)
+            except Exception:
+                created_at = None
+            preview_payload = {
+                "assetType": c_type,
+                "fileName": file_name,
+                "operationId": op_id,
+                "content": content,
+                "language": language,
+                "isComplete": True,
+                "rehydrated": True,
+            }
+            if created_at:
+                preview_payload["createdAt"] = created_at
             await safe_send_json(websocket, {
                 "type": "asset_preview",
                 "sessionId": session_id,
-                "assetPreview": {
-                    "assetType": c_type,
-                    "fileName": file_name,
-                    "operationId": op_id,
-                    "content": content,
-                    "language": language,
-                    "isComplete": True,
-                    "rehydrated": True,
-                },
+                "assetPreview": preview_payload,
             })
             emitted += 1
         if emitted:
@@ -2332,10 +2343,12 @@ async def handle_send_message_ws(websocket: WebSocket, session_id: str, message:
     # then inject a <modification_state> block so the orchestrator can route
     # edits to the right asset and detect repeated corrections.
     modification_state_block = ""
+    modification_request_recorded = False
     try:
         raw_user_text = user_message if isinstance(user_message, str) else ""
         if raw_user_text:
             record_modification_request(effective_session_id, raw_user_text)
+            modification_request_recorded = True
         mod_state = format_modification_state_block(effective_session_id, raw_user_text)
         if mod_state:
             modification_state_block = (
@@ -2524,10 +2537,14 @@ async def handle_send_message_ws(websocket: WebSocket, session_id: str, message:
                                         "status": "completed",
                                     })
 
-                                # Record tool completion to NFS (real-time, inline)
+                                # Record tool completion to NFS (real-time, inline).
+                                # tool_use_id lets the end-of-turn fallback scan
+                                # (update_from_new_messages) skip this completion
+                                # instead of double-recording it.
                                 try:
                                     _record_tool_completion(
-                                        effective_session_id, tr_tool_name, status
+                                        effective_session_id, tr_tool_name, status,
+                                        tool_use_id=tr_tool_use_id,
                                     )
                                 except Exception:
                                     pass  # non-critical
@@ -2623,6 +2640,16 @@ async def handle_send_message_ws(websocket: WebSocket, session_id: str, message:
             )
             _context_store.save_conversation_history(session_id, session["conversation_history"])
 
+            # Modification tracking: the turn finished without an error, so the
+            # agent's edit (if this was one) stands as claimed. Without this the
+            # outcome stayed null forever and the "same keyword ≥2× after a
+            # claimed success → ask, don't re-patch" rule could never fire.
+            if modification_request_recorded:
+                try:
+                    record_modification_outcome(effective_session_id, "claimed_success")
+                except Exception:
+                    pass  # non-critical
+
         except asyncio.CancelledError:
             # User cancelled generation (cancelGeneration action). Preserve any
             # partial work, notify the client, then re-raise so the task is
@@ -2642,6 +2669,14 @@ async def handle_send_message_ws(websocket: WebSocket, session_id: str, message:
                     _context_store.save_conversation_history(session_id, session["conversation_history"])
             except Exception as save_err:
                 logger.warning(f"[BG] partial save on cancel failed for {session_id}: {save_err}")
+            # Modification tracking: a cancelled turn made no verified change —
+            # mark it 'skipped' so the repeat-detection rule treats the next
+            # identical request as a fresh attempt, not a failed re-patch.
+            if modification_request_recorded:
+                try:
+                    record_modification_outcome(effective_session_id, "skipped")
+                except Exception:
+                    pass  # non-critical
             await safe_send_or_log({
                 "type": "generation_cancelled",
                 "sessionId": session_id,
@@ -2698,10 +2733,24 @@ async def handle_send_message_ws(websocket: WebSocket, session_id: str, message:
                     _context_store.save_conversation_history(session_id, session["conversation_history"])
             except Exception as save_err:
                 logger.error(f"[BG] Failed to save history after max_tokens for {session_id}: {save_err}")
+            # Modification tracking: the truncated tool calls never ran, so no
+            # edit was applied this turn.
+            if modification_request_recorded:
+                try:
+                    record_modification_outcome(effective_session_id, "error")
+                except Exception:
+                    pass  # non-critical
             await safe_send_or_log({"type": "stream_end"})
         except Exception as e:
             logger.error(f"[BG] Streaming error for {session_id}: {e}\n{traceback.format_exc()}")
             await safe_send_or_log({"type": "error", "content": str(e)})
+            # Modification tracking: the turn errored — the requested edit is not
+            # a claimed success.
+            if modification_request_recorded:
+                try:
+                    record_modification_outcome(effective_session_id, "error")
+                except Exception:
+                    pass  # non-critical
             # Save partial history on error
             try:
                 partial = _extract_new_messages(streaming_agent.messages, pre_stream_message_count)

--- a/backend/ecs/src/context/generation_progress.py
+++ b/backend/ecs/src/context/generation_progress.py
@@ -90,6 +90,34 @@ def _write_state(session_id: str, state: Dict[str, Any]) -> None:
         logger.warning(f"[generation_progress] failed to write state: {e}")
 
 
+# Completions are recorded on TWO paths: inline per toolResult during
+# stream_async (record_tool_completion — the primary path) and again by the
+# end-of-turn message scan (update_from_new_messages — the fallback for events
+# the inline path missed). Without dedup the scan re-recorded every completion
+# the inline path already logged, doubling the events list (observed: 17
+# identical entries in one second) and — worse — re-applying the review-aware
+# status transition, which downgraded a 'fixed' asset back to 'completed'.
+# Both paths now remember the toolUseIds they consumed and skip known ones.
+_MAX_RECORDED_TOOL_USE_IDS = 500
+
+
+def _already_recorded(state: Dict[str, Any], tool_use_id: Optional[str]) -> bool:
+    if not tool_use_id:
+        return False  # no id → can't dedupe; keep legacy behavior
+    return tool_use_id in state.get("recorded_tool_use_ids", [])
+
+
+def _remember_tool_use_id(state: Dict[str, Any], tool_use_id: Optional[str]) -> None:
+    if not tool_use_id:
+        return
+    ids: List[str] = state.setdefault("recorded_tool_use_ids", [])
+    if tool_use_id in ids:
+        return
+    ids.append(tool_use_id)
+    if len(ids) > _MAX_RECORDED_TOOL_USE_IDS:
+        state["recorded_tool_use_ids"] = ids[-_MAX_RECORDED_TOOL_USE_IDS:]
+
+
 def update_from_new_messages(session_id: str, messages: List[Dict[str, Any]]) -> None:
     """Scan Strands-format messages for sub-agent completions and update progress.
 
@@ -140,6 +168,7 @@ def update_from_new_messages(session_id: str, messages: List[Dict[str, Any]]) ->
                     "asset_id": asset_id,
                     "tool_name": tool_name,
                     "status": "completed" if status == "success" else status,
+                    "tool_use_id": tool_use_id,
                 })
 
     if unmatched_tools:
@@ -155,6 +184,20 @@ def update_from_new_messages(session_id: str, messages: List[Dict[str, Any]]) ->
 
     # Merge into persistent state
     state = _read_state(session_id)
+
+    # Drop completions the inline path (record_tool_completion) already logged
+    # this turn — re-recording duplicated every event and could downgrade a
+    # 'fixed' asset back to 'completed'.
+    deduped = [c for c in completions if not _already_recorded(state, c.get("tool_use_id"))]
+    skipped = len(completions) - len(deduped)
+    if skipped:
+        logger.info(
+            f"[generation_progress] skipped {skipped} completion(s) already recorded inline"
+        )
+    if not deduped:
+        return
+    completions = deduped
+
     assets = state.setdefault("assets", {})
     events = state.setdefault("events", [])
     now = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
@@ -178,12 +221,16 @@ def update_from_new_messages(session_id: str, messages: List[Dict[str, Any]]) ->
             "tool": c["tool_name"],
             "updated_at": now,
         }
-        events.append({
+        event: Dict[str, Any] = {
             "asset_id": aid,
             "tool": c["tool_name"],
             "status": new_status,
             "timestamp": now,
-        })
+        }
+        if c.get("tool_use_id"):
+            event["toolUseId"] = c["tool_use_id"]
+        events.append(event)
+        _remember_tool_use_id(state, c.get("tool_use_id"))
 
     _write_state(session_id, state)
     logger.info(
@@ -196,6 +243,7 @@ def record_tool_completion(
     session_id: str,
     tool_name: str,
     status: str = "completed",
+    tool_use_id: Optional[str] = None,
 ) -> bool:
     """Record a single tool completion directly (called from streaming event loop).
 
@@ -203,13 +251,23 @@ def record_tool_completion(
     is received during stream_async, so it does not depend on post-hoc message
     scanning which can miss events due to message sanitization or reference issues.
 
-    Returns True if the tool was recorded, False if it was not a tracked tool.
+    ``tool_use_id`` (when available) is remembered so the end-of-turn fallback
+    scan (update_from_new_messages) does not record the same completion again.
+
+    Returns True if the tool was recorded, False if it was not a tracked tool
+    or was already recorded.
     """
     asset_id = _TOOL_TO_ASSET.get(tool_name)
     if not asset_id:
         return False
 
     state = _read_state(session_id)
+    if _already_recorded(state, tool_use_id):
+        logger.debug(
+            f"[generation_progress] {tool_name} ({tool_use_id}) already recorded — skipping"
+        )
+        return False
+
     assets = state.setdefault("assets", {})
     events = state.setdefault("events", [])
     now = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
@@ -230,12 +288,16 @@ def record_tool_completion(
         "tool": tool_name,
         "updated_at": now,
     }
-    events.append({
+    event: Dict[str, Any] = {
         "asset_id": asset_id,
         "tool": tool_name,
         "status": new_status,
         "timestamp": now,
-    })
+    }
+    if tool_use_id:
+        event["toolUseId"] = tool_use_id
+    events.append(event)
+    _remember_tool_use_id(state, tool_use_id)
 
     _write_state(session_id, state)
     logger.info(f"[generation_progress] recorded {tool_name} -> {asset_id}={new_status} for {session_id}")

--- a/backend/ecs/src/tools/s3_asset_storage.py
+++ b/backend/ecs/src/tools/s3_asset_storage.py
@@ -94,6 +94,40 @@ def _get_from_nfs(session_id: str, asset_type: str, file_name: str,
     return None
 
 
+def get_asset_mtime_ms(s3_key: str) -> Optional[int]:
+    """Best-effort creation/modification time for an asset, in epoch MILLISECONDS.
+
+    Used by the session-restore rehydration path so replayed asset_preview
+    events carry a `createdAt` the frontend can position chronologically in the
+    chat timeline (previews without one used to default to "now" and pile up at
+    the bottom of a restored conversation).
+
+    NFS mtime first (fast, no network); falls back to S3 HeadObject
+    LastModified. Returns None when neither source is available.
+    """
+    session_id, asset_type, file_name, operation_id = _parse_s3_key_to_nfs_components(s3_key)
+    if session_id is not None and _nfs_available():
+        try:
+            path = _nfs_asset_path(session_id, asset_type, file_name, operation_id)
+            if path.exists():
+                return int(path.stat().st_mtime * 1000)
+        except Exception as e:
+            logger.debug(f"[NFS] mtime read failed for {s3_key}: {e}")
+
+    bucket = get_bucket_name()
+    if not bucket:
+        return None
+    try:
+        s3 = get_s3_client()
+        response = s3.head_object(Bucket=bucket, Key=s3_key)
+        last_modified = response.get("LastModified")
+        if last_modified is not None:
+            return int(last_modified.timestamp() * 1000)
+    except Exception as e:
+        logger.debug(f"[S3] head_object failed for {s3_key}: {e}")
+    return None
+
+
 def _parse_s3_key_to_nfs_components(s3_key: str):
     """
     Parse an S3 key into NFS path components.

--- a/backend/ecs/tests/test_generation_progress_dedup.py
+++ b/backend/ecs/tests/test_generation_progress_dedup.py
@@ -1,0 +1,108 @@
+"""Regression tests for generation_progress toolUseId dedup.
+
+The same completion used to be recorded TWICE: once inline per toolResult
+(record_tool_completion, streaming loop) and again by the end-of-turn message
+scan (update_from_new_messages). That doubled the events list (observed live:
+17 identical entries in one second) and could downgrade a 'fixed' asset back
+to 'completed' by re-applying the review-aware transition.
+"""
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+@pytest.fixture()
+def gp(tmp_path, monkeypatch):
+    monkeypatch.setenv("S3FILES_MOUNT_PATH", str(tmp_path))
+    import context.generation_progress as module
+    importlib.reload(module)
+    return module
+
+
+def _state(tmp_path, session_id):
+    path = Path(tmp_path) / "sessions" / session_id / "context" / "generation_progress.json"
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _turn_messages(tool_name, tool_use_id):
+    """Strands-format assistant toolUse + user toolResult pair."""
+    return [
+        {"role": "assistant", "content": [
+            {"toolUse": {"toolUseId": tool_use_id, "name": tool_name, "input": {}}},
+        ]},
+        {"role": "user", "content": [
+            {"toolResult": {"toolUseId": tool_use_id, "status": "success", "content": []}},
+        ]},
+    ]
+
+
+def test_inline_then_scan_records_once(gp, tmp_path):
+    sid = "sess-dedup-1"
+    # Inline path records the completion first (streaming loop).
+    assert gp.record_tool_completion(sid, "lambda_generator_agent", "completed", tool_use_id="tu-1") is True
+    # End-of-turn fallback scan sees the same toolResult — must be a no-op.
+    gp.update_from_new_messages(sid, _turn_messages("lambda_generator_agent", "tu-1"))
+
+    state = _state(tmp_path, sid)
+    assert len(state["events"]) == 1
+    assert state["events"][0]["toolUseId"] == "tu-1"
+    assert state["assets"]["lambda"]["status"] == "completed"
+
+
+def test_inline_duplicate_is_skipped(gp, tmp_path):
+    sid = "sess-dedup-2"
+    assert gp.record_tool_completion(sid, "prompt_generator_agent", "completed", tool_use_id="tu-2") is True
+    # Replay of the same toolResult (e.g. reconnect catch-up) is ignored.
+    assert gp.record_tool_completion(sid, "prompt_generator_agent", "completed", tool_use_id="tu-2") is False
+    assert len(_state(tmp_path, sid)["events"]) == 1
+
+
+def test_scan_does_not_downgrade_fixed_status(gp, tmp_path):
+    sid = "sess-dedup-3"
+    # Generate → review → fix-regeneration, all inline.
+    gp.record_tool_completion(sid, "contact_flow_generator_agent", "completed", tool_use_id="tu-gen")
+    gp.record_tool_completion(sid, "reviewer_agent", "completed", tool_use_id="tu-rev")
+    # detect_phase requires review state; simulate the post-review fix:
+    state = _state(tmp_path, sid)
+    state["assets"]["contact_flow"]["status"] = "reviewed"
+    gp._write_state(sid, state)
+    gp.record_tool_completion(sid, "contact_flow_generator_agent", "completed", tool_use_id="tu-fix")
+    assert _state(tmp_path, sid)["assets"]["contact_flow"]["status"] == "fixed"
+
+    # End-of-turn scan replays the SAME fix toolResult. Before the dedup this
+    # re-applied the transition with prev_status='fixed' → downgraded to
+    # 'completed'. Now it must remain 'fixed'.
+    gp.update_from_new_messages(sid, _turn_messages("contact_flow_generator_agent", "tu-fix"))
+    assert _state(tmp_path, sid)["assets"]["contact_flow"]["status"] == "fixed"
+
+
+def test_scan_still_records_missed_completions(gp, tmp_path):
+    sid = "sess-dedup-4"
+    # Nothing recorded inline (e.g. event was missed) — the fallback scan must
+    # still record it, preserving its safety-net role.
+    gp.update_from_new_messages(sid, _turn_messages("openapi_generator_agent", "tu-4"))
+    state = _state(tmp_path, sid)
+    assert state["assets"]["openapi"]["status"] == "completed"
+    assert len(state["events"]) == 1
+    # And a later duplicate scan of the same turn is a no-op.
+    gp.update_from_new_messages(sid, _turn_messages("openapi_generator_agent", "tu-4"))
+    assert len(_state(tmp_path, sid)["events"]) == 1
+
+
+def test_recorded_ids_capped(gp, tmp_path):
+    sid = "sess-dedup-5"
+    for i in range(gp._MAX_RECORDED_TOOL_USE_IDS + 25):
+        gp.record_tool_completion(sid, "lambda_generator_agent", "completed", tool_use_id=f"tu-{i}")
+    ids = _state(tmp_path, sid)["recorded_tool_use_ids"]
+    assert len(ids) <= gp._MAX_RECORDED_TOOL_USE_IDS
+    # Most recent ids retained
+    assert f"tu-{gp._MAX_RECORDED_TOOL_USE_IDS + 24}" in ids

--- a/frontend/src/components/ChatWindow.tsx
+++ b/frontend/src/components/ChatWindow.tsx
@@ -109,10 +109,18 @@ export function ChatWindow() {
     | { type: 'asset'; data: (typeof assetPreviews)[keyof typeof assetPreviews]; key: string; timestamp: number };
 
   const timeline = useMemo<TimelineItem[]>(() => {
+    const markerMessages = messages.filter(m => m.role === 'asset' && m.assetRef);
     const assetsWithMarkers = new Set(
-      messages
-        .filter(m => m.role === 'asset' && m.assetRef)
-        .map(m => buildAssetKey(m.assetRef!.assetType, m.assetRef!.operationId, m.assetRef!.fileName))
+      markerMessages.map(m => buildAssetKey(m.assetRef!.assetType, m.assetRef!.operationId, m.assetRef!.fileName))
+    );
+    // Loose match: backend rehydration replays assets with a slightly different
+    // key shape (e.g. operationId '' vs the generator's id). Hide a store
+    // preview whenever a marker exists for the same assetType + fileName so the
+    // same asset isn't rendered twice (marker inline + preview at the bottom).
+    const looseMarkers = new Set(
+      markerMessages
+        .filter(m => m.assetRef!.fileName)
+        .map(m => `${m.assetRef!.assetType}::${m.assetRef!.fileName}`)
     );
 
     const items: TimelineItem[] = [
@@ -128,7 +136,9 @@ export function ChatWindow() {
           if (preview.isRegeneration) return true;
 
           const baseKey = key.replace(/-\d{13,}$/, '');
-          return !assetsWithMarkers.has(baseKey);
+          if (assetsWithMarkers.has(baseKey)) return false;
+          if (preview.fileName && looseMarkers.has(`${preview.assetType}::${preview.fileName}`)) return false;
+          return true;
         })
         .map(([key, preview]) => ({
           type: 'asset' as const,

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -11,7 +11,7 @@ import { useAuthStore } from "../stores/authStore";
 import { useSessionStore } from "../stores/sessionStore";
 import type { WebSocketMessage, SubagentActivity, SubagentToolCall, AttachedFile, MessageAttachment, AttachmentData, AssetPreview, BuilderPhase } from "../types";
 import { PHASE_LABELS } from "../types";
-import { getSessionHistory, getSessionAssets, getSessionData, getMessageLog, generatePresignedUrl, generateUploadPresignedUrl, uploadFileToS3, fetchAssetContent, type StoredAsset, type ConversationMessage } from "../services/sessions";
+import { getSessionHistory, getSessionAssets, getSessionData, getMessageLog, generatePresignedUrl, generateUploadPresignedUrl, uploadFileToS3, fetchAssetContent, type ConversationMessage } from "../services/sessions";
 import { fetchNfsDiagnostics } from "../services/workspaceApi";
 
 // Streaming timeout configuration
@@ -400,6 +400,25 @@ export function useWebSocket() {
     flushPendingStreamContent();
   }, [flushPendingStreamContent]);
 
+  // Timeline segmentation: close the current assistant bubble at a tool /
+  // thinking / sub-agent boundary. The backend streams the WHOLE agentic turn
+  // as anonymous `stream` chunks (no per-message id), so without this every
+  // text segment of the turn — the "starting generation…" narration AND the
+  // final "generation complete" summary — merged into the ONE bubble opened at
+  // the start of the turn, visually ABOVE all the tool cards and streamed
+  // assets. Bedrock/Claude orders content blocks text-then-toolUse within an
+  // assistant message, so any text that arrives after a tool boundary belongs
+  // to the NEXT assistant message: null the stream target and let the next
+  // `stream` chunk open a fresh bubble in chronological position (below the
+  // tool cards). Each segment then carries its own timestamp, which also keeps
+  // session restore ordering correct.
+  const breakStreamSegment = useCallback(() => {
+    flushBeforeInsert();
+    streamTargetMsgIdRef.current = null;
+    streamingMessageIdRef.current = null;
+    lastStreamContentRef.current = "";
+  }, [flushBeforeInsert]);
+
   // Performance: Register tool message index for O(1) lookup
   const registerToolMessage = useCallback((toolUseId: string, messageIndex: number) => {
     toolMessageIndexMapRef.current.set(toolUseId, messageIndex);
@@ -583,8 +602,9 @@ export function useWebSocket() {
     };
 
     // Race fix: a sub-agent card can appear while assistant text is still
-    // streaming. Flush the buffered text into the assistant bubble first.
-    flushBeforeInsert();
+    // streaming. Flush the buffered text into the assistant bubble and close
+    // that bubble — narration that follows belongs below the sub-agent card.
+    breakStreamSegment();
     addMessage({
       role: 'subagent',
       content: content || `${getSubagentDisplayName(subagent)} ${initialStatus}`,
@@ -594,7 +614,7 @@ export function useWebSocket() {
     const newIdx = useBuilderStore.getState().messages.length - 1;
     activeSubagentIndexRef.current.set(subagent, newIdx);
     return newIdx;
-  }, [addMessage, getSubagentDisplayName, flushBeforeInsert]);
+  }, [addMessage, getSubagentDisplayName, breakStreamSegment]);
 
   // Update existing subagent message
   const updateSubagentMessage = useCallback((subagent: string, update: Partial<SubagentActivity>) => {
@@ -752,17 +772,13 @@ export function useWebSocket() {
         case "typing":
           setTyping(true);
           clearStreamTimeout();
-          // Flush anything still buffered for the PREVIOUS bubble before opening
-          // a new one, so its tail isn't appended to the new empty message.
-          flushBeforeInsert();
-          lastStreamContentRef.current = "";
-          streamingMessageIdRef.current = `msg-${Date.now()}-${Math.random()
-            .toString(36)
-            .slice(2, 9)}`;
-          streamTargetMsgIdRef.current = addMessageWithId({
-            role: "assistant",
-            content: "",
-          });
+          // Flush anything still buffered for the PREVIOUS bubble and close it —
+          // this is a new turn. Do NOT pre-create an empty assistant bubble here:
+          // if the turn opens with a thinking/tool card before any text, the
+          // pre-created bubble would be abandoned as an empty gray blob above
+          // the card. The first `stream` chunk opens the bubble instead, in
+          // correct chronological position.
+          breakStreamSegment();
           // Set initial timeout - if no stream data arrives, auto-complete
           setStreamTimeout();
           break;
@@ -1019,8 +1035,9 @@ export function useWebSocket() {
                 (m) => m.role === "tool" && m.toolCall?.tool === data.tool && m.toolCall?.status === "running"
               );
               if (!hasRunningToolMsg) {
-                // Race fix: flush streaming text before inserting a tool card.
-                flushBeforeInsert();
+                // Segment boundary: close the streaming bubble before inserting
+                // the tool card so following text opens a new bubble below it.
+                breakStreamSegment();
                 addMessage({
                   role: "tool",
                   content: "",
@@ -1051,10 +1068,11 @@ export function useWebSocket() {
           // Add tool call message to chat - use toolUseId for deduplication (unique per invocation)
           // This allows same tool (e.g., save_operation_spec) to be called multiple times
           if (data.tool) {
-            // Race fix: a tool_start can arrive while assistant text is still
-            // streaming. Flush the buffered text into the assistant bubble FIRST
-            // so the message isn't left cut off mid-sentence.
-            flushBeforeInsert();
+            // Segment boundary: flush the streamed text into the assistant
+            // bubble and CLOSE it. Claude emits text before toolUse blocks, so
+            // any text after this belongs to the next assistant message — it
+            // must open a new bubble BELOW this tool card, not merge above it.
+            breakStreamSegment();
             const messages = useBuilderStore.getState().messages;
             // Performance: Check map first for O(1), fallback to array check
             const toolUseIdKey = data.toolUseId as string;
@@ -1180,8 +1198,8 @@ export function useWebSocket() {
               }
             } else {
               // Fallback: if tool message not found, add a completed tool message directly
-              // Race fix: flush streaming text before inserting a tool card.
-              flushBeforeInsert();
+              // Segment boundary: close the streaming bubble before the insert.
+              breakStreamSegment();
               addMessage({
                 role: "tool",
                 content: "",
@@ -1250,8 +1268,10 @@ export function useWebSocket() {
               // would target whatever is last, which may no longer be this message.
               appendToMessageById(lastMsg.id, data.content);
             } else {
-              // Race fix: flush streaming text before inserting a thinking card.
-              flushBeforeInsert();
+              // Segment boundary: a thinking block opens the NEXT assistant
+              // message, so close the current bubble — the text that follows
+              // this thinking card belongs in a new bubble below it.
+              breakStreamSegment();
               addMessage({
                 role: "thinking",
                 content: data.content,
@@ -1293,9 +1313,17 @@ export function useWebSocket() {
             }
 
             // Set messageIndex to current message count for proper placement during session restore
-            // This ensures assets appear AFTER the message that triggered their generation
+            // This ensures assets appear AFTER the message that triggered their generation.
+            // EXCEPTION: rehydrated events replay persisted assets on (re)connect —
+            // they are NOT part of the live message flow, and during a session
+            // load the live count is near 0, which would pin the asset to a
+            // bogus position. Leave their placement to createdAt (the backend
+            // sends the asset file's mtime).
+            const isRehydrated = data.assetPreview.rehydrated === true;
             const currentMessages = useBuilderStore.getState().messages;
-            const messageIndex = data.assetPreview.messageIndex ?? currentMessages.length;
+            const messageIndex = isRehydrated
+              ? data.assetPreview.messageIndex
+              : data.assetPreview.messageIndex ?? currentMessages.length;
             updateAssetPreview({
               ...data.assetPreview,
               messageIndex,
@@ -1795,6 +1823,7 @@ export function useWebSocket() {
       clearStreamTimeout,
       setStreamTimeout,
       flushBeforeInsert,
+      breakStreamSegment,
       // Performance optimization functions
       queueStreamUpdate,
       registerToolMessage,
@@ -2880,8 +2909,7 @@ export function useWebSocket() {
             }
           }
 
-          // Interleave messages and asset markers by messageIndex
-          // Assets are placed AFTER the message that triggered their generation
+          // Interleave messages and asset markers chronologically (by createdAt)
           if (history && history.length > 0) {
             console.log("[useWebSocket] Restoring", history.length, "messages from DynamoDB");
 
@@ -2904,77 +2932,90 @@ export function useWebSocket() {
               };
             }> = deserialized;
 
-            // Group assets by their messageIndex
-            // Assets with the same messageIndex will be grouped together
-            const assetsByMessageIndex = new Map<number, StoredAsset[]>();
+            // Placement is TIMESTAMP-FIRST. `messageIndex` was captured against
+            // the LIVE message array, which contains thinking / running-tool
+            // messages that are never persisted — so on restore those indices
+            // systematically overshoot the persisted history and every asset
+            // marker fell into the "past the end" bucket: all assets appeared
+            // appended at the bottom of the conversation. Timestamps don't
+            // drift (messages and asset previews are stamped by the same client
+            // clock), so `createdAt` puts each asset exactly where it was
+            // generated. A CLAMPED messageIndex remains the fallback for legacy
+            // assets saved without createdAt.
+
+            // Message times in ms, forward-filled so untimed messages inherit
+            // the previous known time (keeps the scan monotonic).
+            const msgTimes: number[] = [];
+            {
+              let lastKnown = 0;
+              for (const m of historyMessages) {
+                const t = m.timestamp instanceof Date ? m.timestamp.getTime() : NaN;
+                if (!Number.isNaN(t) && t > 0) lastKnown = t;
+                msgTimes.push(lastKnown);
+              }
+            }
+            const hasAnyMsgTime = msgTimes.some((t) => t > 0);
+
+            // Compute each asset's insertion slot: pos = insert BEFORE message[pos]
+            // (i.e. after message pos-1). pos may be 0 (before everything) or
+            // historyMessages.length (after everything).
+            const clampPos = (idx: number) => Math.min(Math.max(idx, 0), historyMessages.length);
+            const markerInserts: Array<{ pos: number; ts: number; marker: (typeof historyMessages)[number] }> = [];
             if (assets && assets.length > 0) {
               for (const asset of assets) {
-                // ISSUE #3 FIX: Use messageIndex directly, fallback to end of messages
-                // No longer using timestamp-based inference which caused ordering issues
-                let idx: number;
-                if (asset.messageIndex !== undefined && asset.messageIndex !== null) {
-                  idx = asset.messageIndex;
+                let pos: number;
+                let markerTime: number | undefined;
+
+                if (hasAnyMsgTime && typeof asset.createdAt === 'number' && asset.createdAt > 0) {
+                  // After the last message whose (forward-filled) time <= createdAt.
+                  pos = 0;
+                  for (let i = 0; i < msgTimes.length; i++) {
+                    if (msgTimes[i] <= asset.createdAt) pos = i + 1;
+                  }
+                  markerTime = asset.createdAt;
+                } else if (asset.messageIndex !== undefined && asset.messageIndex !== null) {
+                  // Legacy fallback: clamped index. Inherit the neighbor's time
+                  // (+1ms) so ChatWindow's timestamp sort keeps this slot.
+                  pos = clampPos(asset.messageIndex);
+                  markerTime = pos > 0 && msgTimes[pos - 1] > 0 ? msgTimes[pos - 1] + 1 : undefined;
                 } else {
-                  // Legacy assets without messageIndex - place at end
-                  console.warn("[useWebSocket] Asset missing messageIndex, placing at end:", asset.assetType, asset.fileName);
-                  idx = history.length;
+                  console.warn("[useWebSocket] Asset missing createdAt+messageIndex, placing at end:", asset.assetType, asset.fileName);
+                  pos = historyMessages.length;
+                  const lastTime = msgTimes.length > 0 ? msgTimes[msgTimes.length - 1] : 0;
+                  markerTime = lastTime > 0 ? lastTime + 1 : undefined;
                 }
-                if (!assetsByMessageIndex.has(idx)) {
-                  assetsByMessageIndex.set(idx, []);
-                }
-                assetsByMessageIndex.get(idx)!.push(asset);
+
+                markerInserts.push({
+                  pos,
+                  ts: markerTime ?? Number.MAX_SAFE_INTEGER,
+                  marker: {
+                    role: 'asset' as const,
+                    content: `[${getAssetTypeLabel(asset.assetType)}] ${asset.fileName || asset.operationId || ''}`,
+                    timestamp: markerTime ? new Date(markerTime) : undefined,
+                    assetRef: {
+                      assetType: asset.assetType,
+                      operationId: asset.operationId,
+                      fileName: asset.fileName,
+                    },
+                  },
+                });
               }
             }
 
-            // Build final message list by inserting asset markers after their corresponding messages
+            // Merge: walk the messages, injecting markers at their slots.
+            markerInserts.sort((a, b) => (a.pos - b.pos) || (a.ts - b.ts));
             const restoredMessages: typeof historyMessages = [];
-            for (let i = 0; i < historyMessages.length; i++) {
-              // Add the message
-              restoredMessages.push(historyMessages[i]);
-
-              // Add any assets that should appear after this message (messageIndex === i + 1)
-              // Assets with messageIndex N appear after message N-1 (0-indexed)
-              const assetsAfterThisMessage = assetsByMessageIndex.get(i + 1);
-              if (assetsAfterThisMessage) {
-                for (const asset of assetsAfterThisMessage) {
-                  const assetLabel = getAssetTypeLabel(asset.assetType);
-                  const fileName = asset.fileName || asset.operationId || '';
-                  restoredMessages.push({
-                    role: 'asset' as const,
-                    content: `[${assetLabel}] ${fileName}`,
-                    timestamp: asset.createdAt ? new Date(asset.createdAt) : undefined,
-                    assetRef: {
-                      assetType: asset.assetType,
-                      operationId: asset.operationId,
-                      fileName: asset.fileName,
-                    },
-                  });
-                }
+            let insertPtr = 0;
+            for (let i = 0; i <= historyMessages.length; i++) {
+              while (insertPtr < markerInserts.length && markerInserts[insertPtr].pos === i) {
+                restoredMessages.push(markerInserts[insertPtr].marker);
+                insertPtr++;
               }
-            }
-
-            // Add any remaining assets that have messageIndex >= history.length (placed at end)
-            for (const [idx, assetList] of assetsByMessageIndex) {
-              if (idx > history.length) {
-                for (const asset of assetList) {
-                  const assetLabel = getAssetTypeLabel(asset.assetType);
-                  const fileName = asset.fileName || asset.operationId || '';
-                  restoredMessages.push({
-                    role: 'asset' as const,
-                    content: `[${assetLabel}] ${fileName}`,
-                    timestamp: asset.createdAt ? new Date(asset.createdAt) : undefined,
-                    assetRef: {
-                      assetType: asset.assetType,
-                      operationId: asset.operationId,
-                      fileName: asset.fileName,
-                    },
-                  });
-                }
-              }
+              if (i < historyMessages.length) restoredMessages.push(historyMessages[i]);
             }
 
             if (assets && assets.length > 0) {
-              console.log("[useWebSocket] Interleaved", history.length, "messages with", assets.length, "assets by messageIndex");
+              console.log("[useWebSocket] Interleaved", history.length, "messages with", assets.length, "assets by timestamp");
             }
 
             setMessages(restoredMessages);

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -157,6 +157,9 @@ export interface AssetPreview {
   previousCreatedAt?: number; // Timestamp of the previous version
   // Diff support - unified diff from workspace modifications
   diffContent?: string; // Unified diff text (from patch_workspace_file or write_with_diff)
+  // True when this event replays a persisted asset on (re)connect (backend
+  // _rehydrate_assets_for_display) rather than reporting live generation.
+  rehydrated?: boolean;
 }
 
 /** Debug information sent with error messages */


### PR DESCRIPTION
## Summary

Fixes two related chat-timeline problems reported from a live workshop
session, plus two backend state-file bugs found while auditing that
session's persisted state.

### 1. Assistant bubbles merged across the whole turn (frontend)

The backend streams an entire agentic turn as anonymous `stream` chunks
with no message boundary. The frontend pre-created one empty assistant
bubble at `typing` and appended every chunk of the turn into it, so the
"starting generation..." narration and the final "generation complete"
summary merged into a **single** bubble positioned above every tool card
and streamed asset — a completed generation visually looked stuck
mid-run.

Fix: `breakStreamSegment()` closes the current bubble whenever a tool /
thinking / sub-agent card is inserted, and the eager empty-bubble
creation on `typing` was removed (the first `stream` chunk now opens the
bubble in its correct chronological slot). Each segment gets its own
timestamp.

### 2. Assets piled up at the bottom on session restore (frontend)

Asset placement used `messageIndex` captured against the *live* message
array, which includes thinking/running-tool messages that are never
persisted. Those indices systematically overshot the persisted history
length, so every asset landed in the "past the end" bucket regardless of
when it was actually generated.

Fix: replaced with a timestamp-first interleave (asset `createdAt` vs.
forward-filled message times), with a clamped `messageIndex` fallback
for legacy assets saved without `createdAt`.

### 3. Duplicate progress events / status downgrade (backend)

`generation_progress.json` recorded every sub-agent completion twice —
once inline per `toolResult` during streaming, once again by the
end-of-turn message scan — doubling the events log and letting the scan
re-apply the review-aware status transition, which could downgrade a
`fixed` asset back to `completed`.

Fix: both paths now remember the `toolUseId`s they've recorded (capped
ring buffer) and skip duplicates.

### 4. Modification outcome always null (backend)

`modification_state.json`'s per-request `outcome` field was always
`null` because `record_modification_outcome` was only ever called from
tests, never from the live request path — so the "same edit requested
2x+ after a claimed success → ask, don't re-patch" disambiguation rule
could never fire.

Fix: wired into the streaming loop — `claimed_success` on a clean turn,
`skipped` on cancellation, `error` on max-tokens truncation or an
unhandled exception.

### 5. Rehydrated assets had no timestamp (backend)

Session-restore asset rehydration (`_rehydrate_assets_for_display`)
replayed persisted assets on reconnect without a `createdAt`, so the
frontend defaulted them to "now" and they rendered at the bottom.

Fix: new `get_asset_mtime_ms()` reads NFS mtime (S3 `HeadObject`
`LastModified` fallback); rehydrated `asset_preview` events now carry
it. The frontend also no longer fabricates a `messageIndex` for these
events, and `ChatWindow`'s marker/preview dedup now also matches loosely
by `assetType+fileName` so a rehydrated preview's slightly different
key shape doesn't render twice.

## Testing

- `npm run build` (tsc + vite): passes
- New `tests/test_generation_progress_dedup.py` (5 tests): inline+scan
  records once, duplicate inline is skipped, scan does not downgrade
  `fixed` back to `completed`, scan still records genuinely missed
  completions, recorded-id ring buffer caps at 500 — all pass
- Full backend suite: 226 passed. 4 pre-existing failures in
  `test_session_isolation.py` are unrelated — reproduced identically
  with these changes stashed
- Manual interleave simulation: a drifted-index asset lands between its
  tool cards and the following summary bubble, and survives
  `ChatWindow`'s timestamp sort
