### PR TITLE
fix: Durable session history on restore; harden review-time validation gates

### DIFF
--- a/backend/ecs/app.py
+++ b/backend/ecs/app.py
@@ -3101,6 +3101,10 @@ async def handle_inject_history_ws(websocket: WebSocket, session_id: str, data: 
                     logger.info(f"[injectHistory] Dropping system-role message (not supported by Bedrock)")
                 continue
             if isinstance(content, str):
+                # Attachment-only user messages persist with empty text —
+                # Bedrock rejects empty text blocks, so substitute a stub.
+                if not content.strip():
+                    content = "[사용자가 파일을 첨부했습니다 / user sent an attachment]"
                 injected_strands.append({"role": role, "content": [{"text": content}]})
             elif isinstance(content, list):
                 injected_strands.append({"role": role, "content": content})

--- a/backend/ecs/src/agents/contact_flow_generator/system_prompt.py
+++ b/backend/ecs/src/agents/contact_flow_generator/system_prompt.py
@@ -652,6 +652,16 @@ This 2-action pattern creates the Connect Assistant (Wisdom) session. Place BEFO
 | User-defined | `$.Attributes.{name}` | Custom attribute |
 | Loop | `$.Loop.{name}.Index` | Current iteration |
 
+**⚠️ Session-attribute name contract (deterministic cross-check applies):**
+Every `$.Lex.SessionAttributes.{key}` your flow READS (other than `Tool`) must
+use a name the AI prompt instructs the bot to SET. The canonical escalation
+context names are `escalationReason`, `escalationSummary`, `customerIntent` —
+these are what the prompt generator teaches the bot. Do NOT invent synonyms
+(`conversationSummary`, `summary`, `intent`, `operationId`, …): the bot never
+sets them, so the flow reads an empty value and the agent screen loses its
+context. `validate_parameter_consistency` flags every flow-read session
+attribute that does not appear in the prompt.
+
 ---
 
 ## ERROR TYPES REFERENCE
@@ -1071,7 +1081,7 @@ Queue → Transfer Message → Transfer Queue → End; [Complete] → Goodbye �
         "Attributes": {
           "customerIntent": "$.Lex.SessionAttributes.customerIntent",
           "escalationReason": "$.Lex.SessionAttributes.escalationReason",
-          "conversationSummary": "$.Lex.SessionAttributes.conversationSummary"
+          "escalationSummary": "$.Lex.SessionAttributes.escalationSummary"
         }
       },
       "Transitions": {

--- a/backend/ecs/src/agents/infrastructure_generator/system_prompt.py
+++ b/backend/ecs/src/agents/infrastructure_generator/system_prompt.py
@@ -1165,6 +1165,8 @@ UpdateQSessionFunctionArn:
 12. **CRITICAL: Environment variable naming** - Use `<ENTITY>_TABLE_NAME` pattern (e.g., `RESERVATIONS_TABLE_NAME`). Document exact names in schema summary's `environment_variables` section
 13. **CRITICAL: IAM permissions** - Include dynamodb:Scan, dynamodb:Query, and /index/* resource for GSI access
 14. **CRITICAL: When `Include Customer Phone Lookup: True`** — MUST include CustomerLookupFunction (Python 3.11, placeholder) + UpdateQSessionFunction (Node.js 18.x, placeholder) + their IAM Roles + AWS::Lambda::Permission for connect.amazonaws.com
+15. **CRITICAL: EVERY Lambda the Contact Flow invokes directly needs a connect.amazonaws.com Permission** — if the Contact Flow spec / flow references a function via `{{X_LAMBDA_ARN}}` (customer lookup, update-q-session, call/result logging like `log_call_result` or `record_monitoring_result`, or any other flow-invoked function), that function MUST have its own `AWS::Lambda::Permission` with `Principal: connect.amazonaws.com` and `SourceAccount: !Ref AWS::AccountId`. An apigateway.amazonaws.com permission does NOT cover Connect — the flow's invoke fails with AccessDeniedException at call time (this exact omission recurred in two live sessions and is now flagged by `validate_parameter_consistency`).
+16. **CRITICAL: UpdateQSessionFunction env vars** — its Environment.Variables MUST declare `CONNECT_INSTANCE_ID: ""` and `AI_ASSISTANT_ID: ""` (deploy.sh fills the values later; the handler throws on every invocation without the keys), and UpdateQSessionRole MUST grant `wisdom:UpdateSessionData` (NOT just `wisdom:UpdateSession` — they are different actions and UpdateSessionData is the one the handler calls).
 
 ---
 

--- a/backend/ecs/src/agents/openapi_generator/system_prompt.py
+++ b/backend/ecs/src/agents/openapi_generator/system_prompt.py
@@ -57,6 +57,7 @@ The Orchestrator provides operations with explicit schema. You MUST use these va
   "operation_id": "check_reservation",      // Use for operationId
   "api_path": "/check_reservation",         // Spec field — prepend `/tools` when emitting the paths key → `/tools/check_reservation`
   "http_method": "POST",                    // Use for method (post, get, etc.) — MUST match CFN HttpMethod exactly
+  "success_status_code": 200,               // Use for the responses: key of the SUCCESS schema — NOT always '200' (e.g. 201 for a create operation)
   "description": "Look up a customer reservation",
   "input_fields": [
     {"name": "phoneNumber", "type": "string", "required": true}
@@ -79,8 +80,13 @@ The Orchestrator provides operations with explicit schema. You MUST use these va
    - `http_method: "POST"` → `post:` under the path
 3. **operation_id**: Use for `operationId` and `x-amazon-connect-tool-name`
 4. **input_fields**: Generate `requestBody` schema from this
-5. **output_fields**: Generate `responses.200` schema from this
+5. **output_fields**: Generate the response schema for the success outcome from this — key it under `success_status_code` (see rule 7), NOT a hardcoded `'200'`
 6. **error_codes**: Include in ErrorResponse schema enum
+7. **success_status_code**: Key the SUCCESS response under this exact value
+   (default `200` — do not assume it, read the field). A create operation
+   commonly declares `201`; if you emit `'200'` while the spec/Lambda use
+   `201`, the gateway treats every successful call as an undeclared-status
+   failure (see the dedicated section below).
 
 ### 🚨 CRITICAL: PATH FORMAT — `/tools/<operation_id>` WITH UNDERSCORES
 
@@ -474,6 +480,42 @@ responses:
 Do NOT emit `'400'`, `'401'`, `'403'`, `'404'`, `'409'` or `'429'` response
 entries for business outcomes — a declared 4xx teaches the model to expect a
 failure it cannot handle, and the Lambda must not return one either.
+
+### 🚨 Success status code MUST match the spec's `success_status_code`
+
+`BUSINESS_OUTCOME_200_RULE` above governs *failure* outcomes only — it does NOT
+mean every operation's success response is `'200'`. Each OperationSpec carries
+its own `success_status_code` (default `200`, but creation operations are
+commonly `201`). Read it and declare the response under THAT status code, not
+a hardcoded `'200'`:
+
+```yaml
+responses:
+  '201':   # ← spec.success_status_code, NOT hardcoded '200'
+    description: "Reservation created successfully"
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/CreateReservationResponse'
+  '500':
+    description: "Internal error — retryable fault"
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ErrorResponse'
+```
+
+**Omitting the spec's real success status code is itself a HARD-GATE
+mismatch** (`validate_shape_parity_report` looks for the response schema
+under `success_status_code` specifically, and a Lambda that returns
+`return 201, body` while OpenAPI only declares `'200'`/`'500'` makes the
+gateway treat every successful call as an undeclared-status tool failure).
+Cross-check the exact value against the operation's spec before writing the
+`responses:` block — do not assume `200`.
+
+Business-outcome failures (the 200-body table above) still belong alongside
+the success code even when success itself is `201` — e.g. `INVALID_INPUT`
+stays a `200` body outcome, it is never folded into the `201` response.
 
 ---
 

--- a/backend/ecs/src/prompts/system_prompt.py
+++ b/backend/ecs/src/prompts/system_prompt.py
@@ -1973,9 +1973,17 @@ CloudFormation, Lambda, and OpenAPI, each operation MUST include these fields:
    correct for a transient fault).
 
    Also make sure `output_fields` includes an explicit **discriminator** the model
-   can branch on — `verified`, `found`, `available`, `success` or `status` — plus a
-   customer-readable `message`. Without it a 200 cannot express "failed", and the
-   agent cannot tell a negative outcome from a positive one.
+   can branch on — `verified`, `found`, `available`, `success` or `status` — plus
+   the two fields every downstream generator (Lambda, OpenAPI) ALWAYS emits for a
+   200-body business failure: `errorCode` (string) and `message` (string).
+
+   **CRITICAL**: `errorCode` and `message` are NOT optional extras — omit them
+   from `output_fields` and the shape-parity gate (`validate_shape_parity_report`)
+   reports a HARD-GATE mismatch on every single generation, because the Lambda
+   and OpenAPI generators both add `errorCode`/`message` to every response
+   unconditionally (that's how the agent tells a business failure from success
+   on a 200). Declare them in `output_fields` from the start so parity holds on
+   the first pass instead of needing a post-hoc `update_operation_spec` fix.
 
    ```python
    # ✅ authentication operation: the failure modes are 200 + a discriminator
@@ -1986,6 +1994,7 @@ CloudFormation, Lambda, and OpenAPI, each operation MUST include these fields:
            {"name": "remainingAttempts", "type": "number"},
            {"name": "lockout", "type": "boolean"},
            {"name": "message", "type": "string"},
+           {"name": "errorCode", "type": "string", "required": false},  # ← REQUIRED field, not optional to declare
        ],
        error_responses=[
            {"status_code": 200, "error_code": "UNAUTHORIZED",

--- a/backend/ecs/src/tools/merge_infrastructure.py
+++ b/backend/ecs/src/tools/merge_infrastructure.py
@@ -117,23 +117,106 @@ _QSESSION_POLICY_BLOCK = """\
 def _ensure_qsession_role_permissions(yaml_str: str) -> str:
     """Ensure UpdateQSessionRole carries connect:DescribeContact + wisdom perms.
 
-    If an UpdateQSessionRole resource exists but its section does not mention
-    connect:DescribeContact, append the inline runtime policy right after its
-    ManagedPolicyArns block (same indentation level as other Properties keys).
+    Two live-workshop failure shapes:
+    - the LLM omits the inline policy entirely (only AWSLambdaBasicExecutionRole);
+    - the LLM writes a policy but with the WRONG action set — e.g.
+      ``wisdom:UpdateSession`` instead of ``wisdom:UpdateSessionData`` (found in
+      a live session: AccessDeniedException on every UpdateSessionData call
+      even though the role "looked" configured).
+
+    So the trigger is per-required-action, not merely "does the block mention
+    connect:DescribeContact". If the role already has a Policies section we add
+    the missing actions to its existing wisdom/connect Action list (a second
+    ``Policies:`` key would be invalid YAML); otherwise we append the full
+    inline policy after ManagedPolicyArns.
     """
     m = re.search(r'(^  UpdateQSessionRole:\n(?:^(?:    |\n).*\n?)*)', yaml_str, re.M)
     if not m:
         return yaml_str
     block = m.group(1)
-    if 'connect:DescribeContact' in block:
+    required = [
+        "wisdom:UpdateSessionData",
+        "wisdom:GetSession",
+        "connect:DescribeContact",
+        "connect:GetContactAttributes",
+    ]
+    missing = [a for a in required if a not in block]
+    if not missing:
         return yaml_str
+
+    if re.search(r'^\s+Policies:', block, re.M):
+        # Existing inline policy: append missing actions to the Action list
+        # that already carries wisdom:/connect: actions (or the first one).
+        best = None
+        for am in re.finditer(r'(^(\s+)Action:\n((?:\2\s*- .+\n)+))', block, re.M):
+            if best is None:
+                best = am
+            if 'wisdom:' in am.group(3) or 'connect:' in am.group(3):
+                best = am
+                break
+        if not best:
+            return yaml_str
+        entries = best.group(3)
+        indent_m = re.match(r'(\s*)- ', entries.split('\n')[0] + ' ')
+        item_indent = indent_m.group(1) if indent_m else best.group(2) + "  "
+        addition = "".join(f"{item_indent}- {a}\n" for a in missing)
+        new_block = block.replace(best.group(1), best.group(1) + addition, 1)
+        logger.info(f"[MERGE] Added missing actions {missing} to UpdateQSessionRole's "
+                    "existing inline policy (recurrent LLM omission)")
+        return yaml_str.replace(block, new_block, 1)
+
     mp = re.search(
         r'(^      ManagedPolicyArns:\n(?:^        .*\n)+)', block, re.M)
     if not mp:
         return yaml_str
     new_block = block.replace(mp.group(1), mp.group(1) + _QSESSION_POLICY_BLOCK, 1)
     logger.info("[MERGE] Injected UpdateQSessionRuntimePolicy into UpdateQSessionRole "
-                "(missing connect:DescribeContact — recurrent LLM omission)")
+                f"(missing {missing} — recurrent LLM omission)")
+    return yaml_str.replace(block, new_block, 1)
+
+
+# The static update_q_session handler (asset_packager.UPDATE_Q_SESSION_LAMBDA_CODE)
+# throws on cold start unless CONNECT_INSTANCE_ID and AI_ASSISTANT_ID exist as
+# environment variables (deploy.sh backfills the VALUES after the Connect
+# instance is created — but the CFN template must carry the KEYS). The system
+# prompt shows the exact Environment block, yet the LLM omitted it in two
+# consecutive live sessions, so inject it deterministically at merge time.
+_QSESSION_REQUIRED_ENV = ("CONNECT_INSTANCE_ID", "AI_ASSISTANT_ID")
+
+
+def _ensure_qsession_env_vars(yaml_str: str) -> str:
+    """Ensure UpdateQSessionFunction declares its required env var keys."""
+    m = re.search(r'(^  UpdateQSessionFunction:\n(?:^(?:    |\n).*\n?)*)', yaml_str, re.M)
+    if not m:
+        return yaml_str
+    block = m.group(1)
+    missing = [v for v in _QSESSION_REQUIRED_ENV if v not in block]
+    if not missing:
+        return yaml_str
+
+    vm = re.search(r'(^(\s+)Variables:\n((?:\2\s+\S.*\n)+))', block, re.M)
+    if vm:
+        # Environment.Variables exists — append the missing keys at the same
+        # indent as its existing entries.
+        first_entry = vm.group(3).split('\n')[0]
+        entry_indent = re.match(r'(\s*)', first_entry).group(1)
+        addition = "".join(f'{entry_indent}{v}: ""\n' for v in missing)
+        new_block = block.replace(vm.group(1), vm.group(1) + addition, 1)
+    else:
+        # No Environment block at all — insert one after the Handler line.
+        hm = re.search(r'(^      Handler:.*\n)', block, re.M)
+        if not hm:
+            return yaml_str
+        env_block = (
+            "      Environment:\n"
+            "        Variables:\n"
+            + "".join(f'          {v}: ""\n' for v in _QSESSION_REQUIRED_ENV)
+        )
+        new_block = block.replace(hm.group(1), hm.group(1) + env_block, 1)
+
+    logger.info(f"[MERGE] Injected missing env var keys {missing} into "
+                "UpdateQSessionFunction (handler throws without them; "
+                "deploy.sh backfills the values)")
     return yaml_str.replace(block, new_block, 1)
 
 
@@ -619,6 +702,7 @@ def merge_infrastructure_fragments(project_name: str) -> dict:
     final_yaml = _fix_rds_env_var_names(final_yaml)
     final_yaml = _fix_inline_handler_name(final_yaml)
     final_yaml = _ensure_qsession_role_permissions(final_yaml)
+    final_yaml = _ensure_qsession_env_vars(final_yaml)
     final_yaml = _fix_customer_lookup_handler(final_yaml)
     final_yaml = _fix_cfnresponse_import(final_yaml)
     final_yaml = _deduplicate_resources(final_yaml)

--- a/backend/ecs/src/tools/shape_parity.py
+++ b/backend/ecs/src/tools/shape_parity.py
@@ -326,6 +326,21 @@ def _fields_to_synthetic_object(fields: list, object_name: str) -> dict:
     }
 
 
+# The Lambda and OpenAPI generators unconditionally add these two fields to
+# EVERY operation's response body — they are the standard "200 + business
+# failure" envelope (see prompts/system_prompt.py "discriminator" rule): a
+# non-2xx is read by nothing (the AI agent treats it as a broken tool), so
+# every negative outcome must be expressed in the 200 body via `errorCode`
+# + `message`. An OperationSpec that forgot to also declare them in
+# `output_fields` is not a real mismatch — it is a spec omission the
+# generators correctly compensated for. Flagging it as a HARD GATE mismatch
+# on every single session (observed live, repeatedly) trains reviewers to
+# ignore the gate. Treat them as implicitly declared at the response ROOT
+# only (never inside nested objects/arrays, where an undeclared property is
+# still a real mismatch).
+_IMPLICIT_RESPONSE_ENVELOPE_FIELDS = {"errorCode", "message"}
+
+
 def validate_shape_parity(spec: dict, openapi_doc: dict) -> list[ShapeMismatch]:
     """Compare one OperationSpec dict to an OpenAPI document.
 
@@ -369,7 +384,17 @@ def validate_shape_parity(spec: dict, openapi_doc: dict) -> list[ShapeMismatch]:
             ))
         elif out_fields:
             synthetic = _fields_to_synthetic_object(out_fields, f"{owner_label}.response")
-            _compare(synthetic, res_schema, f"{owner_label}.response", openapi_doc, set(), mismatches)
+            bundle_mismatches: list[ShapeMismatch] = []
+            _compare(synthetic, res_schema, f"{owner_label}.response", openapi_doc, set(), bundle_mismatches)
+            # Drop "extra property" mismatches for the standard error envelope
+            # at the response ROOT only — see _IMPLICIT_RESPONSE_ENVELOPE_FIELDS.
+            root_prefix = f"{owner_label}.response.properties."
+            for m in bundle_mismatches:
+                if (m.reason == "property_extra_in_openapi"
+                        and m.path.startswith(root_prefix)
+                        and m.path[len(root_prefix):] in _IMPLICIT_RESPONSE_ENVELOPE_FIELDS):
+                    continue
+                mismatches.append(m)
 
     # Compare operation-level input/output fields (when no tools[] drives them).
     tools = spec.get("tools") or []

--- a/backend/ecs/src/tools/spec_manager.py
+++ b/backend/ecs/src/tools/spec_manager.py
@@ -1237,9 +1237,60 @@ def _safe_parse_model(model_class, data: dict):
         # If model parsing fails, create instance with just the raw data
         # The extra="allow" config will accept all fields
         try:
-            return model_class.model_construct(**data)
+            return _coerce_nested_models(model_class.model_construct(**data))
         except Exception:
             return model_class.model_construct()
+
+
+def _coerce_nested_models(instance):
+    """Re-materialize nested dicts into their model classes after model_construct.
+
+    ``model_construct`` skips validation entirely, so nested collections stay as
+    raw dicts (e.g. ``spec.input_fields = [{'name': ...}, ...]``). Every
+    downstream consumer then crashes on attribute access — this is exactly the
+    ``AttributeError: 'dict' object has no attribute 'name'`` that killed
+    validate_parameter_consistency in two live workshop sessions, silently
+    disabling the whole deterministic gate. Coerce the known nested fields back
+    into models so the fallback path yields the same shapes as normal parsing.
+    """
+    nested_list_fields = {
+        "input_fields": FieldSpec,
+        "output_fields": FieldSpec,
+        "business_rules": BusinessRule,
+        "error_responses": ErrorResponse,
+        "side_effects": SideEffect,
+        "tools": ToolSpec,
+        "conversation_steps": ConversationStep,
+        "session_tools": ToolSpec,
+    }
+    nested_dict_fields = {
+        "data_source": DataSourceSpec,
+    }
+    for fname, fmodel in nested_list_fields.items():
+        val = getattr(instance, fname, None)
+        if isinstance(val, list) and any(isinstance(x, dict) for x in val):
+            coerced = [
+                _safe_parse_model(fmodel, x) if isinstance(x, dict) else x
+                for x in val
+            ]
+            try:
+                setattr(instance, fname, coerced)
+            except Exception:
+                try:
+                    object.__setattr__(instance, fname, coerced)
+                except Exception:
+                    pass
+    for fname, fmodel in nested_dict_fields.items():
+        val = getattr(instance, fname, None)
+        if isinstance(val, dict):
+            try:
+                setattr(instance, fname, _safe_parse_model(fmodel, val))
+            except Exception:
+                try:
+                    object.__setattr__(instance, fname, _safe_parse_model(fmodel, val))
+                except Exception:
+                    pass
+    return instance
 
 
 @tool

--- a/backend/ecs/src/tools/validate_consistency.py
+++ b/backend/ecs/src/tools/validate_consistency.py
@@ -1443,6 +1443,65 @@ def _validate_parameter_consistency_impl(session_id: str) -> dict:
                                  f"the value after the Connect instance exists).",
                     })
 
+    # D8: OpenAPI success response keyed under spec.success_status_code
+    #     The openapi_generator has no deterministic builder (it free-writes
+    #     YAML), and its prompt used to say nothing about success_status_code
+    #     at all — it always assumed '200'. A create operation with
+    #     success_status_code=201 (Lambda actually returns 201) then had no
+    #     '201' response declared, so the gateway treated every successful
+    #     call as an undeclared-status tool failure (found live).
+    if openapi_yaml:
+        try:
+            _openapi_doc = yaml.safe_load(openapi_yaml)
+        except Exception:
+            _openapi_doc = None
+        if isinstance(_openapi_doc, dict):
+            _paths = _openapi_doc.get("paths", {}) or {}
+            # op_id -> declared response status codes (as strings)
+            _declared_codes: Dict[str, set] = {}
+            for _path, _methods in _paths.items():
+                if not isinstance(_methods, dict):
+                    continue
+                for _method, _details in _methods.items():
+                    if _method.startswith("x-") or not isinstance(_details, dict):
+                        continue
+                    _op_id = _details.get("operationId", _path)
+                    _codes = {str(c) for c in (_details.get("responses") or {}).keys()}
+                    _declared_codes[_op_id] = _codes
+
+            def _check_success_code(op_id: str, expected_code) -> None:
+                codes = _declared_codes.get(op_id)
+                if codes is None:
+                    kebab = op_id.replace("_", "-")
+                    codes = _declared_codes.get(kebab)
+                if codes is None:
+                    return  # operation not in this OpenAPI doc — other checks cover that
+                if str(expected_code) not in codes:
+                    mismatches.append({
+                        "operation_id": op_id, "field": "success_status_code",
+                        "asset_type": "openapi_status_code",
+                        "issue": f"Spec declares success_status_code={expected_code} for '{op_id}' "
+                                 f"but OpenAPI only declares response(s) {sorted(codes)}. A Lambda "
+                                 f"returning HTTP {expected_code} on success has no matching schema, "
+                                 f"so the gateway treats every successful call as an undeclared-"
+                                 f"status tool failure. Add a '{expected_code}' response to "
+                                 f"/tools/{op_id} in openapi.yaml.",
+                    })
+
+            for _op_id, _spec in specs.items():
+                _expected = getattr(_spec, "success_status_code", None)
+                if _expected is not None:
+                    _check_success_code(_op_id, _expected)
+            for _tool in all_tools:
+                if isinstance(_tool, dict):
+                    _t_id = _tool.get("tool_id") or ""
+                    _t_code = _tool.get("success_status_code")
+                else:
+                    _t_id = getattr(_tool, "tool_id", "") or ""
+                    _t_code = getattr(_tool, "success_status_code", None)
+                if _t_id and _t_code is not None:
+                    _check_success_code(_t_id, _t_code)
+
     summary = f"Found {len(mismatches)} mismatches across {len(expected)} operations"
     if mismatches:
         summary += ". Fix by using patch_workspace_file for simple renames, or re-calling the affected generator with modification_request for structural changes."

--- a/backend/ecs/src/tools/validate_consistency.py
+++ b/backend/ecs/src/tools/validate_consistency.py
@@ -879,24 +879,69 @@ def validate_parameter_consistency(session_id: str) -> dict:
             "operations_checked": N
         }
     """
+    # Fault-tolerance: this gate must NEVER die with a raw exception. In two
+    # live sessions an AttributeError propagated as a tool error, the whole
+    # deterministic validation silently disappeared, and the reviewer had to
+    # fall back to manual cross-checks. A structured failure keeps the
+    # orchestrator informed and tells it what to do instead.
+    try:
+        return _validate_parameter_consistency_impl(session_id)
+    except Exception as e:
+        logger.exception(f"[VALIDATE] validate_parameter_consistency crashed: {e}")
+        return {
+            "success": False,
+            "mismatches": [],
+            "summary": (
+                f"Validator internal error ({type(e).__name__}: {e}). "
+                "Deterministic checks could not run — manually cross-check field "
+                "names between spec, Lambda, OpenAPI and prompt before proceeding."
+            ),
+            "operations_checked": 0,
+            "internal_error": True,
+        }
+
+
+def _validate_parameter_consistency_impl(session_id: str) -> dict:
     specs = get_all_specs()
     if not specs:
         return {"success": True, "mismatches": [], "summary": "No operation specs found", "operations_checked": 0}
 
+    def _fname(f) -> str:
+        """Field name accessor tolerant of raw dicts.
+
+        Specs restored via the model_construct fallback (or any legacy
+        persisted shape) can carry dict field entries; a bare ``f.name``
+        crashed this whole gate with AttributeError in two live sessions,
+        forcing the reviewer to fall back to manual cross-checks.
+        """
+        if isinstance(f, dict):
+            return f.get("name") or f.get("field_name") or ""
+        return getattr(f, "name", "") or ""
+
     # Build expected field sets per operation (backward-compatible)
     expected: Dict[str, Dict[str, set]] = {}
     for op_id, spec in specs.items():
-        inp = {f.name for f in spec.input_fields if f.name}
-        out = {f.name for f in spec.output_fields if f.name}
+        inp = {_fname(f) for f in (spec.input_fields or []) if _fname(f)}
+        out = {_fname(f) for f in (spec.output_fields or []) if _fname(f)}
         expected[op_id] = {"input": inp, "output": out, "all": inp | out}
 
     # Build expected field sets per tool (multi-tool architecture)
     all_tools = get_all_tools()
     tool_expected: Dict[str, Dict[str, set]] = {}
     for tool in all_tools:
-        t_inp = {f.name for f in tool.input_fields if f.name}
-        t_out = {f.name for f in tool.output_fields if f.name}
-        tool_expected[tool.tool_id] = {"input": t_inp, "output": t_out, "all": t_inp | t_out}
+        if isinstance(tool, dict):
+            t_id = tool.get("tool_id") or tool.get("toolId") or ""
+            t_in_list = tool.get("input_fields") or []
+            t_out_list = tool.get("output_fields") or []
+        else:
+            t_id = getattr(tool, "tool_id", "") or ""
+            t_in_list = getattr(tool, "input_fields", None) or []
+            t_out_list = getattr(tool, "output_fields", None) or []
+        if not t_id:
+            continue
+        t_inp = {_fname(f) for f in t_in_list if _fname(f)}
+        t_out = {_fname(f) for f in t_out_list if _fname(f)}
+        tool_expected[t_id] = {"input": t_inp, "output": t_out, "all": t_inp | t_out}
 
     # Load assets from S3
     asset_keys = list_session_assets(session_id) if session_id else []
@@ -905,6 +950,8 @@ def validate_parameter_consistency(session_id: str) -> dict:
     openapi_yaml: Optional[str] = None
     infra_yaml: Optional[str] = None
     infra_schema: Optional[str] = None
+    contact_flow_json: Optional[str] = None
+    prompt_text: Optional[str] = None
 
     for key in asset_keys:
         parts = key.split("/")
@@ -931,6 +978,14 @@ def validate_parameter_consistency(session_id: str) -> dict:
             content = get_asset_from_s3(key)
             if content:
                 infra_yaml = content
+        elif asset_type == "contact_flow" and key.endswith(".json"):
+            content = get_asset_from_s3(key)
+            if content:
+                contact_flow_json = content
+        elif asset_type == "prompt" and (key.endswith(".yaml") or key.endswith(".yml") or key.endswith(".md") or key.endswith(".txt")):
+            content = get_asset_from_s3(key)
+            if content:
+                prompt_text = content
 
     # Auto-load infrastructure schema from registry
     try:
@@ -1290,6 +1345,103 @@ def validate_parameter_consistency(session_id: str) -> dict:
                     _check_sql_insert_required_columns(op_id, code, _schema))
                 mismatches.extend(
                     _check_sql_param_types(op_id, code, _type_index))
+
+    # D5: Contact Flow → Lambda invoke permissions (Principal connect.amazonaws.com)
+    #     Every Lambda the flow calls directly via InvokeLambdaFunction needs an
+    #     AWS::Lambda::Permission with Principal connect.amazonaws.com — an
+    #     apigateway.amazonaws.com permission does NOT cover it. Missing grants
+    #     were found for different functions in two consecutive live sessions
+    #     (log_call_result / get_monitoring_target / record_monitoring_result):
+    #     the call fails with AccessDeniedException and the flow takes its error
+    #     branch, silently dropping call logging / personalization.
+    if contact_flow_json and infra_yaml:
+        flow_lambda_refs = set(re.findall(
+            r'\{\{\s*([A-Z0-9_]+?)_LAMBDA_ARN\s*\}\}', contact_flow_json))
+        if flow_lambda_refs:
+            # Map: normalized function token -> has connect permission
+            connect_permitted: set = set()
+            for pm in re.finditer(
+                    r'^  (\w+):\n((?:^    .*\n?)+)', infra_yaml, re.M):
+                body = pm.group(2)
+                if 'AWS::Lambda::Permission' not in body:
+                    continue
+                if 'connect.amazonaws.com' not in body:
+                    continue
+                fn = re.search(
+                    r'FunctionName:.*?(?:!GetAtt\s+(\w+)\.Arn|!Ref\s+(\w+)|"(\w+)")',
+                    body)
+                if fn:
+                    name = fn.group(1) or fn.group(2) or fn.group(3) or ""
+                    connect_permitted.add(
+                        re.sub(r'(function|lambda)$', '', name.lower().replace("_", "").replace("-", "")))
+            # All function logical ids present in the template (to skip
+            # placeholders resolved outside this stack, e.g. deploy.sh-created)
+            template_functions = {
+                re.sub(r'(function|lambda)$', '', fm.group(1).lower().replace("_", "").replace("-", ""))
+                for fm in re.finditer(
+                    r'^  (\w+):\n(?:^    .*\n?)*?^    Type:\s*AWS::Lambda::Function',
+                    infra_yaml, re.M)
+            }
+            for ref in sorted(flow_lambda_refs):
+                norm = ref.lower().replace("_", "")
+                if norm not in template_functions:
+                    continue  # function not defined in this template — skip
+                if norm not in connect_permitted:
+                    mismatches.append({
+                        "operation_id": ref.lower(), "field": "",
+                        "asset_type": "connect_invoke_permission",
+                        "issue": f"Contact Flow invokes Lambda '{{{{{ref}_LAMBDA_ARN}}}}' directly, "
+                                 f"but infrastructure.yaml has no AWS::Lambda::Permission with "
+                                 f"Principal connect.amazonaws.com for that function. The flow's "
+                                 f"invoke fails with AccessDeniedException at call time (an "
+                                 f"apigateway.amazonaws.com permission does not cover Connect). "
+                                 f"Add a Permission resource with Principal connect.amazonaws.com "
+                                 f"and SourceAccount !Ref AWS::AccountId.",
+                    })
+
+    # D6: Contact Flow ↔ Prompt session-attribute name contract
+    #     The flow reads $.Lex.SessionAttributes.<name> that only the AI agent
+    #     (per its prompt) can set. A name the prompt never mentions is a
+    #     guaranteed empty value at runtime — found live as conversationSummary
+    #     (flow) vs escalationSummary (prompt): agent-screen context always blank.
+    if contact_flow_json and prompt_text:
+        flow_session_attrs = set(re.findall(
+            r'\$\.Lex\.SessionAttributes\.(\w+)', contact_flow_json))
+        # 'Tool' is the canonical bot-result contract (validated separately by
+        # the contact flow linter); skip it here.
+        flow_session_attrs.discard("Tool")
+        for attr in sorted(flow_session_attrs):
+            if attr not in prompt_text:
+                mismatches.append({
+                    "operation_id": "__flow__", "field": attr,
+                    "asset_type": "session_attribute_contract",
+                    "issue": f"Contact Flow reads $.Lex.SessionAttributes.{attr} but the AI "
+                             f"prompt never mentions '{attr}' — the bot will never set it, so "
+                             f"the flow always reads an empty value. Either instruct the bot "
+                             f"to set '{attr}' in the prompt, or rename the flow attribute to "
+                             f"one the prompt already defines.",
+                })
+
+    # D7: update_q_session env-var contract
+    #     The static handler throws on cold start without CONNECT_INSTANCE_ID /
+    #     AI_ASSISTANT_ID env vars. deploy.sh backfills the VALUES, but the CFN
+    #     template must declare the KEYS — omitted by the LLM in two consecutive
+    #     live sessions (merge now injects them; this is the belt-and-braces check).
+    if infra_yaml and 'UpdateQSessionFunction' in infra_yaml:
+        qf = re.search(r'(^  UpdateQSessionFunction:\n(?:^(?:    |\n).*\n?)*)', infra_yaml, re.M)
+        if qf:
+            qblock = qf.group(1)
+            for env_key in ("CONNECT_INSTANCE_ID", "AI_ASSISTANT_ID"):
+                if env_key not in qblock:
+                    mismatches.append({
+                        "operation_id": "update_q_session", "field": env_key,
+                        "asset_type": "lambda_env",
+                        "issue": f"UpdateQSessionFunction is missing the '{env_key}' environment "
+                                 f"variable — the handler throws on every invocation without it, "
+                                 f"so customer data is never injected into the AI session. Add "
+                                 f"'{env_key}: \"\"' under Environment.Variables (deploy.sh fills "
+                                 f"the value after the Connect instance exists).",
+                    })
 
     summary = f"Found {len(mismatches)} mismatches across {len(expected)} operations"
     if mismatches:

--- a/backend/ecs/tests/test_review_gates.py
+++ b/backend/ecs/tests/test_review_gates.py
@@ -1,0 +1,373 @@
+"""Regression tests for the review-gate hardening from two live workshop sessions.
+
+Sessions session-4427fe52 (inbound) and session-c676bdc7 (outbound) surfaced
+the same recurring defects that the LLM reviewer had to catch manually:
+
+1. validate_parameter_consistency CRASHED in both sessions
+   (``AttributeError: 'dict' object has no attribute 'name'``) — specs restored
+   through the model_construct fallback carry raw dict field entries.
+2. Lambdas the Contact Flow invokes directly were missing the
+   ``connect.amazonaws.com`` AWS::Lambda::Permission.
+3. UpdateQSessionFunction was missing CONNECT_INSTANCE_ID / AI_ASSISTANT_ID env
+   var keys (handler throws on cold start).
+4. UpdateQSessionRole had a policy but with the WRONG action
+   (wisdom:UpdateSession instead of wisdom:UpdateSessionData) — the old merge
+   backstop only triggered when connect:DescribeContact was absent.
+5. Flow read $.Lex.SessionAttributes.conversationSummary while the prompt told
+   the bot to set escalationSummary — agent screen context always empty.
+
+These tests pin the deterministic prevention for each.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. _safe_parse_model nested coercion (validator crash root cause)
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_model_construct_fallback_coerces_nested_fields():
+    from tools.spec_manager import _safe_parse_model, OperationSpec, FieldSpec, ToolSpec
+
+    # Force validation failure so the model_construct fallback runs:
+    # operation_id must be a str — give it a dict.
+    bad = {
+        "operation_id": {"oops": True},
+        "input_fields": [{"name": "phoneNumber", "field_type": "string"}],
+        "output_fields": [{"name": "found", "field_type": "boolean"}],
+        "tools": [{
+            "tool_id": "record_monitoring_result",
+            "input_fields": [{"name": "callResult", "field_type": "enum"}],
+            "output_fields": [{"name": "resultId"}],
+        }],
+    }
+    spec = _safe_parse_model(OperationSpec, bad)
+
+    # The exact access pattern that crashed the gate live:
+    names = {f.name for f in spec.input_fields if f.name}
+    assert names == {"phoneNumber"}
+    assert {f.name for f in spec.output_fields} == {"found"}
+
+    assert spec.tools and isinstance(spec.tools[0], ToolSpec)
+    assert isinstance(spec.tools[0].input_fields[0], FieldSpec)
+    assert spec.tools[0].input_fields[0].name == "callResult"
+
+
+def test_validate_gate_survives_dict_fields(monkeypatch, tmp_path):
+    """Even if a dict sneaks past coercion, the gate must not raise."""
+    monkeypatch.setenv("S3FILES_MOUNT_PATH", str(tmp_path))
+    import tools.validate_consistency as vc
+    from tools.spec_manager import OperationSpec
+
+    raw = OperationSpec.model_construct(
+        operation_id="op1",
+        input_fields=[{"name": "orderNumber"}],   # raw dicts on purpose
+        output_fields=[{"name": "found"}],
+        tools=[],
+    )
+    monkeypatch.setattr(vc, "get_all_specs", lambda: {"op1": raw})
+    monkeypatch.setattr(vc, "get_all_tools", lambda: [
+        {"tool_id": "op1", "input_fields": [{"name": "orderNumber"}], "output_fields": []},
+    ])
+    monkeypatch.setattr(vc, "list_session_assets", lambda sid: [])
+
+    result = vc.validate_parameter_consistency("session-test")
+    assert "mismatches" in result  # structured result, no exception
+
+
+def test_validate_gate_returns_structured_error_on_crash(monkeypatch):
+    """A hard crash inside the impl must yield a structured failure, not a raw
+    tool exception (which is what erased the whole gate in both sessions)."""
+    import tools.validate_consistency as vc
+
+    def boom():
+        raise AttributeError("'dict' object has no attribute 'name'")
+
+    monkeypatch.setattr(vc, "get_all_specs", boom)
+    result = vc.validate_parameter_consistency("session-test")
+    assert result["success"] is False
+    assert result.get("internal_error") is True
+    assert "AttributeError" in result["summary"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2–3. Validator checks D5/D7 (connect invoke permission, qsession env vars)
+# ─────────────────────────────────────────────────────────────────────────────
+
+FLOW_JSON = """
+{
+  "Actions": [
+    {"Identifier": "customer-lookup", "Type": "InvokeLambdaFunction",
+     "Parameters": {"LambdaFunctionARN": "{{GET_MONITORING_TARGET_LAMBDA_ARN}}"}},
+    {"Identifier": "record-result", "Type": "InvokeLambdaFunction",
+     "Parameters": {"LambdaFunctionARN": "{{RECORD_MONITORING_RESULT_LAMBDA_ARN}}"}},
+    {"Identifier": "check", "Type": "Compare",
+     "Parameters": {"ComparisonValue": "$.Lex.SessionAttributes.Tool"}},
+    {"Identifier": "esc", "Type": "UpdateContactAttributes",
+     "Parameters": {"Attributes": {"summary": "$.Lex.SessionAttributes.conversationSummary"}}}
+  ]
+}
+"""
+
+INFRA_YAML = """\
+Resources:
+  GetMonitoringTargetFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: get-monitoring-target
+      Handler: index.handler
+  RecordMonitoringResultFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: record-monitoring-result
+      Handler: index.handler
+  GetMonitoringTargetPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt GetMonitoringTargetFunction.Arn
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+  GetMonitoringTargetConnectPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt GetMonitoringTargetFunction.Arn
+      Action: lambda:InvokeFunction
+      Principal: connect.amazonaws.com
+      SourceAccount: !Ref AWS::AccountId
+  UpdateQSessionFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: update-q-session
+      Runtime: nodejs18.x
+      Handler: index.handler
+      Environment:
+        Variables:
+          PROJECT_NAME: demo
+"""
+
+PROMPT_TEXT = """\
+You are an agent. When escalating, set the session attribute escalationSummary
+with a short summary, then use Escalate.
+"""
+
+
+@pytest.fixture()
+def gate(monkeypatch, tmp_path):
+    monkeypatch.setenv("S3FILES_MOUNT_PATH", str(tmp_path))
+    import tools.validate_consistency as vc
+    from tools.spec_manager import OperationSpec
+
+    spec = OperationSpec(operation_id="op1", input_fields=[], output_fields=[])
+    monkeypatch.setattr(vc, "get_all_specs", lambda: {"op1": spec})
+    monkeypatch.setattr(vc, "get_all_tools", lambda: [])
+
+    assets = {
+        "sessions/s1/contact_flow/main_flow.json": FLOW_JSON,
+        "sessions/s1/infrastructure/infrastructure.yaml": INFRA_YAML,
+        "sessions/s1/prompt/ai_agent_prompt.yaml": PROMPT_TEXT,
+    }
+    monkeypatch.setattr(vc, "list_session_assets", lambda sid: list(assets.keys()))
+    monkeypatch.setattr(vc, "get_asset_from_s3", lambda key: assets.get(key))
+    return vc
+
+
+def test_connect_invoke_permission_check(gate):
+    result = gate.validate_parameter_consistency("s1")
+    perm_issues = [m for m in result["mismatches"]
+                   if m["asset_type"] == "connect_invoke_permission"]
+    # record_monitoring_result has NO connect permission → flagged;
+    # get_monitoring_target HAS one → not flagged.
+    assert len(perm_issues) == 1
+    assert perm_issues[0]["operation_id"] == "record_monitoring_result"
+
+
+def test_session_attribute_contract_check(gate):
+    result = gate.validate_parameter_consistency("s1")
+    attr_issues = [m for m in result["mismatches"]
+                   if m["asset_type"] == "session_attribute_contract"]
+    # Flow reads conversationSummary; prompt only defines escalationSummary.
+    assert [m["field"] for m in attr_issues] == ["conversationSummary"]
+    # 'Tool' (canonical contract) must NOT be flagged.
+    assert all(m["field"] != "Tool" for m in attr_issues)
+
+
+def test_qsession_env_var_check(gate):
+    result = gate.validate_parameter_consistency("s1")
+    env_issues = [m for m in result["mismatches"]
+                  if m["asset_type"] == "lambda_env" and m["operation_id"] == "update_q_session"]
+    assert {m["field"] for m in env_issues} == {"CONNECT_INSTANCE_ID", "AI_ASSISTANT_ID"}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4–5. Merge-time backstops (role actions, env var injection)
+# ─────────────────────────────────────────────────────────────────────────────
+
+ROLE_WITH_WRONG_ACTION = """\
+Resources:
+  UpdateQSessionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: UpdateQSessionPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - wisdom:GetSession
+                  - wisdom:UpdateSession
+                  - wisdom:GetAssistant
+                  - connect:DescribeContact
+                Resource: "*"
+  Other:
+    Type: AWS::SNS::Topic
+"""
+
+ROLE_WITHOUT_POLICY = """\
+Resources:
+  UpdateQSessionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+  Other:
+    Type: AWS::SNS::Topic
+"""
+
+
+def test_qsession_role_missing_action_injected_into_existing_policy():
+    """The outbound session had wisdom:UpdateSession (wrong) but not
+    wisdom:UpdateSessionData — the old trigger (connect:DescribeContact
+    present → skip) missed it entirely."""
+    from tools.merge_infrastructure import _ensure_qsession_role_permissions
+    import yaml
+
+    fixed = _ensure_qsession_role_permissions(ROLE_WITH_WRONG_ACTION)
+    assert "wisdom:UpdateSessionData" in fixed
+    # Must NOT create a duplicate Policies: key (invalid YAML)
+    role_block = re.search(r'(^  UpdateQSessionRole:\n(?:^(?:    |\n).*\n?)*)', fixed, re.M).group(1)
+    assert role_block.count("Policies:") == 1
+    # Result must stay parseable YAML
+    parsed = yaml.safe_load(fixed)
+    stmts = parsed["Resources"]["UpdateQSessionRole"]["Properties"]["Policies"][0]["PolicyDocument"]["Statement"]
+    actions = [a for s in stmts for a in s.get("Action", [])]
+    assert "wisdom:UpdateSessionData" in actions
+
+
+def test_qsession_role_no_policy_appends_full_block():
+    from tools.merge_infrastructure import _ensure_qsession_role_permissions
+    import yaml
+
+    fixed = _ensure_qsession_role_permissions(ROLE_WITHOUT_POLICY)
+    assert "wisdom:UpdateSessionData" in fixed
+    assert "connect:DescribeContact" in fixed
+    parsed = yaml.safe_load(fixed)
+    assert parsed["Resources"]["UpdateQSessionRole"]["Properties"]["Policies"]
+
+
+def test_qsession_role_complete_is_untouched():
+    from tools.merge_infrastructure import _ensure_qsession_role_permissions
+
+    complete = ROLE_WITH_WRONG_ACTION.replace(
+        "- wisdom:UpdateSession\n", "- wisdom:UpdateSessionData\n"
+    ).replace(
+        "- connect:DescribeContact\n",
+        "- connect:DescribeContact\n                  - connect:GetContactAttributes\n"
+    ).replace(
+        "- wisdom:GetAssistant\n", "- wisdom:GetAssistant\n"
+    )
+    # add remaining required action so nothing is missing
+    complete = complete.replace(
+        "- wisdom:GetSession\n",
+        "- wisdom:GetSession\n                  - wisdom:UpdateSessionData\n")
+    fixed = _ensure_qsession_role_permissions(complete)
+    assert fixed == complete
+
+
+FUNC_NO_ENV = """\
+Resources:
+  UpdateQSessionFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: update-q-session
+      Runtime: nodejs18.x
+      Handler: index.handler
+      Role: arn:aws:iam::123456789012:role/UpdateQSessionRole
+      Code:
+        ZipFile: |
+          exports.handler = async () => ({});
+  Other:
+    Type: AWS::SNS::Topic
+"""
+
+FUNC_PARTIAL_ENV = """\
+Resources:
+  UpdateQSessionFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: update-q-session
+      Runtime: nodejs18.x
+      Handler: index.handler
+      Environment:
+        Variables:
+          PROJECT_NAME: demo
+          CONNECT_INSTANCE_ID: ""
+  Other:
+    Type: AWS::SNS::Topic
+"""
+
+
+def test_qsession_env_injected_when_absent():
+    from tools.merge_infrastructure import _ensure_qsession_env_vars
+    import yaml
+
+    fixed = _ensure_qsession_env_vars(FUNC_NO_ENV)
+    parsed = yaml.safe_load(fixed)
+    env = parsed["Resources"]["UpdateQSessionFunction"]["Properties"]["Environment"]["Variables"]
+    assert "CONNECT_INSTANCE_ID" in env and "AI_ASSISTANT_ID" in env
+
+
+def test_qsession_env_appended_to_existing_variables():
+    from tools.merge_infrastructure import _ensure_qsession_env_vars
+    import yaml
+
+    fixed = _ensure_qsession_env_vars(FUNC_PARTIAL_ENV)
+    parsed = yaml.safe_load(fixed)
+    env = parsed["Resources"]["UpdateQSessionFunction"]["Properties"]["Environment"]["Variables"]
+    assert env["PROJECT_NAME"] == "demo"          # untouched
+    assert "AI_ASSISTANT_ID" in env               # added
+    # Only one Environment block
+    assert fixed.count("Environment:") == 1
+
+
+def test_qsession_env_complete_is_untouched():
+    from tools.merge_infrastructure import _ensure_qsession_env_vars
+
+    complete = FUNC_PARTIAL_ENV.replace(
+        'CONNECT_INSTANCE_ID: ""\n',
+        'CONNECT_INSTANCE_ID: ""\n          AI_ASSISTANT_ID: ""\n')
+    assert _ensure_qsession_env_vars(complete) == complete

--- a/backend/ecs/tests/test_review_gates.py
+++ b/backend/ecs/tests/test_review_gates.py
@@ -207,6 +207,105 @@ def test_qsession_env_var_check(gate):
 
 
 # ─────────────────────────────────────────────────────────────────────────────
+# D8: OpenAPI success response status code vs spec.success_status_code
+# ─────────────────────────────────────────────────────────────────────────────
+
+OPENAPI_MISSING_201 = """\
+openapi: "3.0.1"
+info:
+  title: Demo API
+  version: "1.0.0"
+paths:
+  /tools/create_cleaning_reservation:
+    post:
+      operationId: create_cleaning_reservation
+      responses:
+        '200':
+          description: business failure
+          content:
+            application/json:
+              schema:
+                type: object
+        '500':
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: object
+"""
+
+OPENAPI_HAS_201 = OPENAPI_MISSING_201.replace(
+    "      responses:\n        '200':",
+    "      responses:\n        '201':\n          description: created\n          content:\n            application/json:\n              schema:\n                type: object\n        '200':",
+)
+
+
+def test_success_status_code_missing_flagged(monkeypatch, tmp_path):
+    monkeypatch.setenv("S3FILES_MOUNT_PATH", str(tmp_path))
+    import tools.validate_consistency as vc
+    from tools.spec_manager import OperationSpec
+
+    spec = OperationSpec(
+        operation_id="create_cleaning_reservation",
+        input_fields=[], output_fields=[],
+        success_status_code=201,
+    )
+    monkeypatch.setattr(vc, "get_all_specs", lambda: {"create_cleaning_reservation": spec})
+    monkeypatch.setattr(vc, "get_all_tools", lambda: [])
+    assets = {"sessions/s/openapi/openapi.yaml": OPENAPI_MISSING_201}
+    monkeypatch.setattr(vc, "list_session_assets", lambda sid: list(assets.keys()))
+    monkeypatch.setattr(vc, "get_asset_from_s3", lambda key: assets.get(key))
+
+    result = vc.validate_parameter_consistency("s")
+    issues = [m for m in result["mismatches"] if m["asset_type"] == "openapi_status_code"]
+    assert len(issues) == 1
+    assert issues[0]["operation_id"] == "create_cleaning_reservation"
+    assert "201" in issues[0]["issue"]
+
+
+def test_success_status_code_present_not_flagged(monkeypatch, tmp_path):
+    monkeypatch.setenv("S3FILES_MOUNT_PATH", str(tmp_path))
+    import tools.validate_consistency as vc
+    from tools.spec_manager import OperationSpec
+
+    spec = OperationSpec(
+        operation_id="create_cleaning_reservation",
+        input_fields=[], output_fields=[],
+        success_status_code=201,
+    )
+    monkeypatch.setattr(vc, "get_all_specs", lambda: {"create_cleaning_reservation": spec})
+    monkeypatch.setattr(vc, "get_all_tools", lambda: [])
+    assets = {"sessions/s/openapi/openapi.yaml": OPENAPI_HAS_201}
+    monkeypatch.setattr(vc, "list_session_assets", lambda sid: list(assets.keys()))
+    monkeypatch.setattr(vc, "get_asset_from_s3", lambda key: assets.get(key))
+
+    result = vc.validate_parameter_consistency("s")
+    issues = [m for m in result["mismatches"] if m["asset_type"] == "openapi_status_code"]
+    assert issues == []
+
+
+def test_success_status_code_default_200_not_flagged(monkeypatch, tmp_path):
+    """The default success_status_code=200 must not false-positive when
+    OpenAPI correctly declares '200' (the overwhelmingly common case)."""
+    monkeypatch.setenv("S3FILES_MOUNT_PATH", str(tmp_path))
+    import tools.validate_consistency as vc
+    from tools.spec_manager import OperationSpec
+
+    spec = OperationSpec(operation_id="op1", input_fields=[], output_fields=[])
+    assert spec.success_status_code == 200
+    monkeypatch.setattr(vc, "get_all_specs", lambda: {"op1": spec})
+    monkeypatch.setattr(vc, "get_all_tools", lambda: [])
+    openapi = OPENAPI_MISSING_201.replace("create_cleaning_reservation", "op1")
+    assets = {"sessions/s/openapi/openapi.yaml": openapi}
+    monkeypatch.setattr(vc, "list_session_assets", lambda sid: list(assets.keys()))
+    monkeypatch.setattr(vc, "get_asset_from_s3", lambda key: assets.get(key))
+
+    result = vc.validate_parameter_consistency("s")
+    issues = [m for m in result["mismatches"] if m["asset_type"] == "openapi_status_code"]
+    assert issues == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
 # 4–5. Merge-time backstops (role actions, env var injection)
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/backend/ecs/tests/test_shape_parity.py
+++ b/backend/ecs/tests/test_shape_parity.py
@@ -373,3 +373,93 @@ def test_unresolvable_ref_refused():
                components={"Other": {"type": "string"}})
     with pytest.raises(ShapeParityError, match="Unresolvable"):
         validate_shape_parity(spec, doc)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Implicit response-envelope allowance (errorCode / message at response root)
+#
+# Every session review to date reported the SAME hard-gate mismatch: the
+# Lambda + OpenAPI generators unconditionally add errorCode/message to every
+# operation's response (the "200 + business failure" envelope), but nothing
+# ever added those two fields to the spec's output_fields. Flagging this as a
+# mismatch every single time trained reviewers to ignore the gate. These two
+# fields are now implicitly allowed at the response ROOT ONLY.
+# ─────────────────────────────────────────────────────────────────────────────
+
+def test_envelope_fields_allowed_at_response_root():
+    spec = _op(output_fields=[
+        {"name": "found", "field_type": "boolean"},
+        {"name": "deliveryStatus", "field_type": "string"},
+    ])
+    doc = _doc("op", "POST", "/tools/op", res_schema={
+        "type": "object",
+        "properties": {
+            "found": {"type": "boolean"},
+            "deliveryStatus": {"type": "string"},
+            "errorCode": {"type": "string"},
+            "message": {"type": "string"},
+        },
+    })
+    assert validate_shape_parity(spec, doc) == []
+
+
+def test_genuine_extra_property_still_flagged_alongside_envelope():
+    spec = _op(output_fields=[{"name": "found", "field_type": "boolean"}])
+    doc = _doc("op", "POST", "/tools/op", res_schema={
+        "type": "object",
+        "properties": {
+            "found": {"type": "boolean"},
+            "errorCode": {"type": "string"},
+            "message": {"type": "string"},
+            "totallyUndeclaredField": {"type": "string"},
+        },
+    })
+    mismatches = validate_shape_parity(spec, doc)
+    assert len(mismatches) == 1
+    assert mismatches[0].reason == "property_extra_in_openapi"
+    assert mismatches[0].path.endswith("totallyUndeclaredField")
+
+
+def test_envelope_fields_not_allowed_inside_nested_object():
+    """The allowance is scoped to the response ROOT only — an undeclared
+    errorCode/message nested inside another object is still a real gap."""
+    spec = _op(output_fields=[
+        {"name": "detail", "field_type": "object", "properties": [
+            {"name": "id", "field_type": "string"},
+        ]},
+    ])
+    doc = _doc("op", "POST", "/tools/op", res_schema={
+        "type": "object",
+        "properties": {
+            "detail": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "errorCode": {"type": "string"},
+                },
+            },
+        },
+    })
+    mismatches = validate_shape_parity(spec, doc)
+    assert len(mismatches) == 1
+    assert mismatches[0].path.endswith("detail.properties.errorCode")
+
+
+def test_envelope_fields_still_checked_if_declared_in_spec():
+    """If the spec DOES declare errorCode/message, normal type/enum checks
+    still apply — the allowance only suppresses the "extra property" report,
+    it does not exempt the field from comparison when declared."""
+    spec = _op(output_fields=[
+        {"name": "found", "field_type": "boolean"},
+        {"name": "errorCode", "field_type": "enum", "enum_values": ["NOT_FOUND"]},
+    ])
+    doc = _doc("op", "POST", "/tools/op", res_schema={
+        "type": "object",
+        "properties": {
+            "found": {"type": "boolean"},
+            "errorCode": {"type": "string"},  # missing enum: keyword
+            "message": {"type": "string"},
+        },
+    })
+    mismatches = validate_shape_parity(spec, doc)
+    assert any(m.reason == "missing_enum_in_openapi" for m in mismatches)

--- a/frontend/src/hooks/useAutoSave.ts
+++ b/frontend/src/hooks/useAutoSave.ts
@@ -64,8 +64,9 @@ export function useAutoSave() {
         if (st === 'started' || st === 'running') return false;
         return true;
       }
-      // user/assistant/system: must have content
-      if (!msg.content || msg.content.trim() === '') return false;
+      // user/assistant/system: must have content OR attachments
+      // (a user message sent with only files has empty text but must survive)
+      if ((!msg.content || msg.content.trim() === '') && !(msg.attachments && msg.attachments.length > 0)) return false;
       return true;
     });
     if (persistableMessages.length === 0) return;
@@ -129,6 +130,19 @@ export function useAutoSave() {
         role: msg.role as 'user' | 'assistant' | 'system',
         content: msg.content,
         timestamp: ts,
+        // Persist attachment metadata (name/type/mime/size — no binary) so
+        // the first message sent with a requirements doc still shows its
+        // attachment chips after a session restore.
+        ...(msg.attachments && msg.attachments.length > 0
+          ? {
+              attachments: msg.attachments.map(att => ({
+                name: att.name,
+                type: att.type,
+                mimeType: att.mimeType,
+                size: att.size,
+              })),
+            }
+          : {}),
       };
     });
 

--- a/frontend/src/hooks/useWebSocket.ts
+++ b/frontend/src/hooks/useWebSocket.ts
@@ -196,12 +196,14 @@ function deserializeHistoryMessages(
   timestamp?: Date;
   toolCall?: import("../types").ToolCall;
   subagentActivity?: import("../types").SubagentActivity;
+  attachments?: import("../types").MessageAttachment[];
 }> {
   return history
     .filter(msg => {
-      // user/assistant/system must have content
+      // user/assistant/system must have content (or persisted attachments —
+      // a user message sent with only files has empty text)
       if (msg.role === 'user' || msg.role === 'assistant' || msg.role === 'system') {
-        return msg.content && msg.content.trim() !== '';
+        return (msg.content && msg.content.trim() !== '') || (msg.attachments && msg.attachments.length > 0);
       }
       // tool messages must have toolCall data
       if (msg.role === 'tool') return !!msg.toolCall;
@@ -261,6 +263,17 @@ function deserializeHistoryMessages(
         role: msg.role as 'user' | 'assistant' | 'system',
         content: msg.content,
         timestamp: ts,
+        // Restore attachment chips (metadata only — no binary/preview)
+        ...(msg.attachments && msg.attachments.length > 0
+          ? {
+              attachments: msg.attachments.map(att => ({
+                name: att.name,
+                type: att.type,
+                mimeType: att.mimeType,
+                size: att.size,
+              })),
+            }
+          : {}),
       };
     });
 }
@@ -2925,6 +2938,7 @@ export function useWebSocket() {
               timestamp?: Date;
               toolCall?: import("../types").ToolCall;
               subagentActivity?: import("../types").SubagentActivity;
+              attachments?: import("../types").MessageAttachment[];
               assetRef?: {
                 assetType: string;
                 operationId?: string;

--- a/frontend/src/services/sessions.ts
+++ b/frontend/src/services/sessions.ts
@@ -221,6 +221,16 @@ export interface StoredSubagentActivity {
 }
 
 /**
+ * Attachment metadata persisted with a message (no binary payload)
+ */
+export interface StoredAttachment {
+  name: string;
+  type: 'image' | 'document';
+  mimeType: string;
+  size?: number;
+}
+
+/**
  * Conversation message type
  */
 export interface ConversationMessage {
@@ -231,6 +241,8 @@ export interface ConversationMessage {
   toolCall?: StoredToolCall;
   /** Serialized sub-agent activity (for role='subagent') */
   subagentActivity?: StoredSubagentActivity;
+  /** Attachment metadata (for user messages sent with files) */
+  attachments?: StoredAttachment[];
 }
 
 /**

--- a/frontend/src/stores/builderStore.ts
+++ b/frontend/src/stores/builderStore.ts
@@ -14,8 +14,15 @@ import type {
 } from '../types';
 import { PHASE_ORDER } from '../types';
 
-// Performance limits to prevent memory issues in long sessions
-const MAX_MESSAGES = 200;           // Keep last 200 messages in memory
+// Performance limits to prevent memory issues in long sessions.
+// MAX_MESSAGES must comfortably exceed a full ~2h build: the live array also
+// holds ephemeral thinking/running-tool cards that are never persisted, so a
+// 200-entry cap silently trimmed the interview turns out of memory mid-build —
+// and useAutoSave then persisted that trimmed window, deleting them from
+// DynamoDB permanently (observed live on two workshop sessions). The session
+// API's save_history now merges non-destructively as a backstop, but the cap
+// must still cover a realistic session so the on-screen timeline stays whole.
+const MAX_MESSAGES = 1000;          // Keep last 1000 messages in memory
 const MAX_ASSET_PREVIEWS = 50;      // Keep last 50 asset previews
 
 export type Theme = 'light' | 'dark' | 'system';

--- a/infrastructure/lib/aicc-builder-stack.ts
+++ b/infrastructure/lib/aicc-builder-stack.ts
@@ -580,10 +580,52 @@ def get_history(user_id, session_id):
             'body': json.dumps({'error': str(e)})
         }
 
+def _load_stored_history(user_id, session_id):
+    """Load and decompress the currently stored history (or [])."""
+    try:
+        response = table.get_item(Key={'userId': user_id, 'sessionId': session_id})
+        raw = response.get('Item', {}).get('conversationHistory', '[]')
+        if raw.startswith('H4sI'):  # gzip magic bytes in base64
+            raw = gzip.decompress(base64.b64decode(raw)).decode('utf-8')
+        stored = json.loads(raw)
+        return stored if isinstance(stored, list) else []
+    except Exception:
+        return []
+
 def save_history(user_id, session_id, body):
-    """Save conversation history for a session (compressed if large)."""
+    """Save conversation history for a session (compressed if large).
+
+    NON-DESTRUCTIVE MERGE: the client keeps only a bounded window of recent
+    messages in memory and PUTs that whole window on every autosave. A long
+    generation run pushes the interview turns (and the first message with
+    attachments) out of that window — a plain overwrite would permanently
+    delete them from DynamoDB (observed live: sessions restored without any
+    interview messages). So instead of overwriting, prepend every stored
+    message strictly OLDER than the incoming batch's first timestamp; the
+    incoming batch remains authoritative for its own time range.
+    """
     try:
         history = body.get('history', [])
+
+        stored = _load_stored_history(user_id, session_id)
+        if stored and history:
+            first_ts = None
+            for m in history:
+                ts = m.get('timestamp')
+                if isinstance(ts, (int, float)) and ts > 0:
+                    first_ts = ts
+                    break
+            if first_ts is not None:
+                prefix = [
+                    m for m in stored
+                    if isinstance(m.get('timestamp'), (int, float)) and m['timestamp'] < first_ts
+                ]
+                if prefix:
+                    history = prefix + history
+        elif stored and not history:
+            # Never wipe stored history with an empty PUT
+            history = stored
+
         history_json = json.dumps(history)
 
         # Compress if larger than 10KB


### PR DESCRIPTION
## Summary

Follow-up to #43 from two live workshop sessions (`session-4427fe52` inbound / `session-c676bdc7` outbound): restored chats were missing all interview turns and the first message with the attached requirements doc, and the reviewer had to manually catch the same recurring asset defects in both sessions because the deterministic gate had crashed.

### 1. Session restore no longer loses interview turns / attachments
**Root cause (verified against live DynamoDB):** the frontend keeps the last `MAX_MESSAGES=200` entries in memory — a cap that also counts ephemeral thinking/running-tool cards that are never persisted — so a long build trims the interview turns out of the live array, and `useAutoSave` then overwrites the whole DynamoDB history with that trimmed window, deleting them permanently. Both live sessions' persisted history started mid-generation with only 11 user messages.

- **Session API `save_history` merges non-destructively**: stored messages older than the incoming window's first timestamp are preserved; an empty PUT never wipes history. Client stays authoritative for its own time range (no duplicates).
- `MAX_MESSAGES` 200 → 1000 so a realistic ~2h build fits in memory.
- **Attachment metadata persisted + restored** (name/type/mime/size, no binary): the first message sent with a requirements doc keeps its chips after restore; attachment-only messages (empty text) survive persistence, restore, and backend history injection (stub text for Bedrock).

### 2. Review-time validation hardening (from both sessions' review reports)
- **`validate_parameter_consistency` crashed in BOTH sessions** (`AttributeError: 'dict' object has no attribute 'name'`), silently disabling every deterministic check. Root-caused to the `model_construct` fallback leaving nested dicts in restored specs — fixed at the source (nested-model coercion), plus dict-tolerant access and a structured-error wrapper so the gate degrades instead of vanishing.
- **3 new deterministic checks**, each reproducing a live reviewer CRITICAL:
  - Flow-invoked Lambdas must carry an `AWS::Lambda::Permission` with `Principal: connect.amazonaws.com`
  - Every `$.Lex.SessionAttributes.X` the flow reads must appear in the AI prompt (else always empty at runtime)
  - `UpdateQSessionFunction` must declare `CONNECT_INSTANCE_ID` / `AI_ASSISTANT_ID` env var keys
- **Merge backstops**: per-action role check (catches `wisdom:UpdateSession` vs `wisdom:UpdateSessionData`, appends into an existing `Policies` block without duplicating keys) + auto-injection of the two qsession env var keys.
- **Prompt drift fixed at the source**: flow generator taught `conversationSummary` while the prompt generator teaches `escalationSummary` — unified, with the contract documented in both generator prompts.

## Testing
- New `tests/test_review_gates.py`: **12/12 passed** (crash regression, structured-error wrapper, all 3 new checks, all merge backstops incl. YAML validity + idempotence)
- Full backend suite: **238 passed**; 4 `test_session_isolation` failures are pre-existing (reproduced with these changes stashed)
- `save_history` merge simulated end-to-end: 5/5 (fresh save, trimmed-window merge, empty-PUT no-op, gzip path, attachment-only message)
- Signal-quality check against the two real session bundles: **0 false positives** on the post-fix outbound bundle; **1 true positive** on the inbound bundle (flow logs `operationId` the prompt never sets)
- `npm run build` (tsc + vite) OK; infrastructure `tsc --noEmit` OK; inline Lambda `py_compile` OK

## Notes
- The Session API Lambda is CDK inline code — requires `./deploy.sh --infra-only` (or full deploy) to take effect.