### PR TITLE
fix(skill): Re-sync skill with the webapp's hardened validation gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 [![Python](https://img.shields.io/badge/Python-3.11-blue?style=flat&logo=python)](https://python.org/)
 [![Strands Agents](https://img.shields.io/badge/Strands-Agents-purple?style=flat)](https://strandsagents.com/)
 
+[![Use as a CLI Skill — no deployment needed](https://img.shields.io/badge/%E2%9A%A1_Use_as_a_CLI_Skill-Claude_Code_%C2%B7_Kiro-1a1a2e?style=for-the-badge)](skills/aicc-builder-skill/)
+
 [English](#english) · [한국어](#한국어) · [日本語](#日本語)
 
 </div>

--- a/skills/aicc-builder-skill/README.md
+++ b/skills/aicc-builder-skill/README.md
@@ -120,6 +120,11 @@ rm -rf ~/.kiro/skills/aicc-builder/claude ~/.kiro/skills/aicc-builder/kiro \
 rm -f  ~/.kiro/skills/aicc-builder/README.md
 ```
 
+Then verify: restart Kiro (or start a new `kiro-cli chat` session) and confirm
+`aicc-builder` appears in the loaded-skills list. Trigger it with any of the
+natural-language triggers in the frontmatter description ("amazon connect",
+"aicc", …).
+
 ## Requirements
 
 - **Python 3.9+** for the bundled validator scripts
@@ -240,7 +245,13 @@ silently fall out of sync. Review the diff, commit, done.
 > `resources/scripts/{validate_consistency,shape_parity,check_spec_complete,clues_format}.py`,
 > and both `SKILL.md` files. `validate_consistency.py` / `shape_parity.py` are hand
 > ports of `tools/validate_consistency.py` / `tools/shape_parity.py` — when a check
-> changes there, port it here and re-run the smoke tests. Also update by hand when
+> changes there, port it here and re-run the smoke tests:
+>
+> ```bash
+> python3 scripts/smoke_test_validators.py   # requires PyYAML
+> ```
+>
+> Also update by hand when
 > `agents/contact_flow_generator/vision_import.py` or `tools/asset_packager.py`
 > change.
 

--- a/skills/aicc-builder-skill/claude/SKILL.md
+++ b/skills/aicc-builder-skill/claude/SKILL.md
@@ -314,6 +314,11 @@ substitute for the webapp's `input_hint`), e.g. "다음으로 환불 가능 기�
 Checklist before leaving interview mode — every operation must have:
 - `operation_id` (snake_case, verb_noun)
 - `input_fields[]` / `output_fields[]` with `name` (camelCase), `field_type`, `required`
+  — `output_fields` MUST include a branchable discriminator (`verified`/`found`/
+  `success`/`status`/…) **plus `errorCode` (string) and `message` (string)**: the
+  Lambda and OpenAPI generators emit both unconditionally on every response, so a
+  spec that omits them fails the `shape_parity.py` HARD GATE on every run
+- `success_status_code` when success is not `200` (e.g. `201` for a create operation)
 - `primary_key_field` (if DB-backed)
 - `data_source` (db_type, table_name) — optional for stateless ops
 - `tools[]` with `role: "primary"` and any helpers

--- a/skills/aicc-builder-skill/kiro/SKILL.md
+++ b/skills/aicc-builder-skill/kiro/SKILL.md
@@ -324,6 +324,11 @@ substitute for the webapp's `input_hint`), e.g. "다음으로 환불 가능 기�
 Checklist before leaving interview mode — every operation must have:
 - `operation_id` (snake_case, verb_noun)
 - `input_fields[]` / `output_fields[]` with `name` (camelCase), `field_type`, `required`
+  — `output_fields` MUST include a branchable discriminator (`verified`/`found`/
+  `success`/`status`/…) **plus `errorCode` (string) and `message` (string)**: the
+  Lambda and OpenAPI generators emit both unconditionally on every response, so a
+  spec that omits them fails the `shape_parity.py` HARD GATE on every run
+- `success_status_code` when success is not `200` (e.g. `201` for a create operation)
 - `primary_key_field` (if DB-backed)
 - `data_source` (db_type, table_name) — optional for stateless ops
 - `tools[]` with `role: "primary"` and any helpers

--- a/skills/aicc-builder-skill/resources/orchestrator/system_prompt.md
+++ b/skills/aicc-builder-skill/resources/orchestrator/system_prompt.md
@@ -2280,9 +2280,17 @@ CloudFormation, Lambda, and OpenAPI, each operation MUST include these fields:
    correct for a transient fault).
 
    Also make sure `output_fields` includes an explicit **discriminator** the model
-   can branch on — `verified`, `found`, `available`, `success` or `status` — plus a
-   customer-readable `message`. Without it a 200 cannot express "failed", and the
-   agent cannot tell a negative outcome from a positive one.
+   can branch on — `verified`, `found`, `available`, `success` or `status` — plus
+   the two fields every downstream generator (Lambda, OpenAPI) ALWAYS emits for a
+   200-body business failure: `errorCode` (string) and `message` (string).
+
+   **CRITICAL**: `errorCode` and `message` are NOT optional extras — omit them
+   from `output_fields` and the shape-parity gate (`validate_shape_parity_report`)
+   reports a HARD-GATE mismatch on every single generation, because the Lambda
+   and OpenAPI generators both add `errorCode`/`message` to every response
+   unconditionally (that's how the agent tells a business failure from success
+   on a 200). Declare them in `output_fields` from the start so parity holds on
+   the first pass instead of needing a post-hoc `update_operation_spec` fix.
 
    ```python
    # ✅ authentication operation: the failure modes are 200 + a discriminator
@@ -2293,6 +2301,7 @@ CloudFormation, Lambda, and OpenAPI, each operation MUST include these fields:
            {"name": "remainingAttempts", "type": "number"},
            {"name": "lockout", "type": "boolean"},
            {"name": "message", "type": "string"},
+           {"name": "errorCode", "type": "string", "required": false},  # ← REQUIRED field, not optional to declare
        ],
        error_responses=[
            {"status_code": 200, "error_code": "UNAUTHORIZED",

--- a/skills/aicc-builder-skill/resources/scripts/shape_parity.py
+++ b/skills/aicc-builder-skill/resources/scripts/shape_parity.py
@@ -344,6 +344,21 @@ def _fields_to_synthetic_object(fields: list, object_name: str) -> dict:
     }
 
 
+# The Lambda and OpenAPI generators unconditionally add these two fields to
+# EVERY operation's response body — they are the standard "200 + business
+# failure" envelope (see the orchestrator "discriminator" rule): a
+# non-2xx is read by nothing (the AI agent treats it as a broken tool), so
+# every negative outcome must be expressed in the 200 body via `errorCode`
+# + `message`. An OperationSpec that forgot to also declare them in
+# `output_fields` is not a real mismatch — it is a spec omission the
+# generators correctly compensated for. Flagging it as a HARD GATE mismatch
+# on every single session (observed live, repeatedly) trains reviewers to
+# ignore the gate. Treat them as implicitly declared at the response ROOT
+# only (never inside nested objects/arrays, where an undeclared property is
+# still a real mismatch).
+_IMPLICIT_RESPONSE_ENVELOPE_FIELDS = {"errorCode", "message"}
+
+
 def validate_shape_parity(spec: dict, openapi_doc: dict) -> list[ShapeMismatch]:
     """Compare one OperationSpec dict to an OpenAPI document.
 
@@ -387,7 +402,17 @@ def validate_shape_parity(spec: dict, openapi_doc: dict) -> list[ShapeMismatch]:
             ))
         elif out_fields:
             synthetic = _fields_to_synthetic_object(out_fields, f"{owner_label}.response")
-            _compare(synthetic, res_schema, f"{owner_label}.response", openapi_doc, set(), mismatches)
+            bundle_mismatches: list[ShapeMismatch] = []
+            _compare(synthetic, res_schema, f"{owner_label}.response", openapi_doc, set(), bundle_mismatches)
+            # Drop "extra property" mismatches for the standard error envelope
+            # at the response ROOT only — see _IMPLICIT_RESPONSE_ENVELOPE_FIELDS.
+            root_prefix = f"{owner_label}.response.properties."
+            for m in bundle_mismatches:
+                if (m.reason == "property_extra_in_openapi"
+                        and m.path.startswith(root_prefix)
+                        and m.path[len(root_prefix):] in _IMPLICIT_RESPONSE_ENVELOPE_FIELDS):
+                    continue
+                mismatches.append(m)
 
     # Compare operation-level input/output fields (when no tools[] drives them).
     tools = spec.get("tools") or []

--- a/skills/aicc-builder-skill/resources/scripts/validate_consistency.py
+++ b/skills/aicc-builder-skill/resources/scripts/validate_consistency.py
@@ -47,6 +47,16 @@ Checks (check id → what it catches):
     sql_missing_required_column  INSERT omits a NOT NULL column with no default
     sql_param_type_mismatch      :param bound with the wrong Data API value key
 
+  Contact Flow / prompt / status-code contracts (D6–D9)
+    connect_invoke_permission    flow-invoked Lambda without a
+                                 connect.amazonaws.com AWS::Lambda::Permission
+    session_attribute_contract   flow reads $.Lex.SessionAttributes.<name>
+                                 the AI prompt never instructs the bot to set
+    lambda_env                   UpdateQSessionFunction missing the
+                                 CONNECT_INSTANCE_ID / AI_ASSISTANT_ID keys
+    openapi_status_code          spec success_status_code (e.g. 201) has no
+                                 matching response declared in openapi.yaml
+
 Usage:
     python validate_consistency.py <output_dir>
     python validate_consistency.py <output_dir> --json
@@ -250,6 +260,68 @@ def load_openapi(assets_dir: Path) -> Dict[str, Dict[str, Set[str]]]:
                         out_f |= _schema_props(spec, sw["schema"])
             out[op_id] = {"input": in_f, "output": out_f}
     return out
+
+
+def load_openapi_response_codes(assets_dir: Path) -> Dict[str, Set[str]]:
+    """operationId (or path) -> declared response status codes, as strings.
+
+    Used by the success_status_code check (webapp D8): a Lambda that returns
+    HTTP 201 on success while OpenAPI only declares '200'/'500' makes the
+    gateway treat every successful call as an undeclared-status tool failure.
+    """
+    cand = list((assets_dir / "openapi").glob("*.y*ml")) if (assets_dir / "openapi").is_dir() else []
+    if not cand:
+        return {}
+    try:
+        spec = yaml.safe_load(cand[0].read_text())
+    except Exception as e:
+        print(f"WARN: openapi parse failed: {e}", file=sys.stderr)
+        return {}
+    codes_by_op: Dict[str, Set[str]] = {}
+    for path, methods in (spec.get("paths") or {}).items():
+        if not isinstance(methods, dict):
+            continue
+        for method, details in methods.items():
+            if method.startswith("x-") or not isinstance(details, dict):
+                continue
+            op_id = details.get("operationId") or path
+            codes_by_op[op_id] = {str(c) for c in (details.get("responses") or {}).keys()}
+    return codes_by_op
+
+
+def load_contact_flow_text(assets_dir: Path) -> Optional[str]:
+    """Concatenated raw JSON text of every Contact Flow under assets/.../contact_flow/.
+
+    The session-attribute and connect-permission checks scan it textually,
+    exactly like the webapp validator does. Handles both the flat layout
+    (contact_flow/contact_flow.json) and imported ids
+    (contact_flow/imported_flow/contact_flow.json).
+    """
+    cf_dir = assets_dir / "contact_flow"
+    if not cf_dir.is_dir():
+        return None
+    texts: List[str] = []
+    for p in sorted(cf_dir.rglob("*.json")):
+        try:
+            texts.append(p.read_text())
+        except Exception as e:
+            print(f"WARN: failed to read {p}: {e}", file=sys.stderr)
+    return "\n".join(texts) if texts else None
+
+
+def load_prompt_text(assets_dir: Path) -> Optional[str]:
+    """Raw text of the AI agent prompt(s) (yaml / yml / md / txt)."""
+    p_dir = assets_dir / "prompt"
+    if not p_dir.is_dir():
+        return None
+    texts: List[str] = []
+    for pat in ("*.yaml", "*.yml", "*.md", "*.txt"):
+        for p in sorted(p_dir.rglob(pat)):
+            try:
+                texts.append(p.read_text())
+            except Exception as e:
+                print(f"WARN: failed to read {p}: {e}", file=sys.stderr)
+    return "\n".join(texts) if texts else None
 
 
 # --------------------------------------------------------------------------
@@ -1274,6 +1346,137 @@ def validate(output_dir: Path) -> List[dict]:
             mismatches.extend(_check_sql_casts(op_id, code, enum_types))
             mismatches.extend(_check_sql_insert_required_columns(op_id, code, infra))
             mismatches.extend(_check_sql_param_types(op_id, code, type_index))
+
+    contact_flow_json = load_contact_flow_text(assets)
+    prompt_text = load_prompt_text(assets)
+
+    # D6) Contact Flow → Lambda invoke permissions (Principal connect.amazonaws.com)
+    #     Every Lambda the flow calls directly via InvokeLambdaFunction needs an
+    #     AWS::Lambda::Permission with Principal connect.amazonaws.com — an
+    #     apigateway.amazonaws.com permission does NOT cover it. Missing grants
+    #     were found for different functions in two consecutive live sessions
+    #     (log_call_result / get_monitoring_target / record_monitoring_result):
+    #     the call fails with AccessDeniedException and the flow takes its error
+    #     branch, silently dropping call logging / personalization.
+    if contact_flow_json and infra_yaml:
+        flow_lambda_refs = set(re.findall(
+            r'\{\{\s*([A-Z0-9_]+?)_LAMBDA_ARN\s*\}\}', contact_flow_json))
+        if flow_lambda_refs:
+            # Map: normalized function token -> has connect permission
+            connect_permitted: Set[str] = set()
+            for pm in re.finditer(
+                    r'^  (\w+):\n((?:^    .*\n?)+)', infra_yaml, re.M):
+                body = pm.group(2)
+                if 'AWS::Lambda::Permission' not in body:
+                    continue
+                if 'connect.amazonaws.com' not in body:
+                    continue
+                fn = re.search(
+                    r'FunctionName:.*?(?:!GetAtt\s+(\w+)\.Arn|!Ref\s+(\w+)|"(\w+)")',
+                    body)
+                if fn:
+                    name = fn.group(1) or fn.group(2) or fn.group(3) or ""
+                    connect_permitted.add(
+                        re.sub(r'(function|lambda)$', '', name.lower().replace("_", "").replace("-", "")))
+            # All function logical ids present in the template (to skip
+            # placeholders resolved outside this stack, e.g. deploy.sh-created)
+            template_functions = {
+                re.sub(r'(function|lambda)$', '', fm.group(1).lower().replace("_", "").replace("-", ""))
+                for fm in re.finditer(
+                    r'^  (\w+):\n(?:^    .*\n?)*?^    Type:\s*AWS::Lambda::Function',
+                    infra_yaml, re.M)
+            }
+            for ref in sorted(flow_lambda_refs):
+                norm = ref.lower().replace("_", "")
+                if norm not in template_functions:
+                    continue  # function not defined in this template — skip
+                if norm not in connect_permitted:
+                    mismatches.append({
+                        "check": "connect_invoke_permission", "operation_id": ref.lower(), "field": "",
+                        "issue": f"Contact Flow invokes Lambda '{{{{{ref}_LAMBDA_ARN}}}}' directly, "
+                                 f"but the CloudFormation template has no AWS::Lambda::Permission with "
+                                 f"Principal connect.amazonaws.com for that function. The flow's "
+                                 f"invoke fails with AccessDeniedException at call time (an "
+                                 f"apigateway.amazonaws.com permission does not cover Connect). "
+                                 f"Add a Permission resource with Principal connect.amazonaws.com "
+                                 f"and SourceAccount !Ref AWS::AccountId.",
+                    })
+
+    # D7) Contact Flow ↔ Prompt session-attribute name contract
+    #     The flow reads $.Lex.SessionAttributes.<name> that only the AI agent
+    #     (per its prompt) can set. A name the prompt never mentions is a
+    #     guaranteed empty value at runtime — found live as conversationSummary
+    #     (flow) vs escalationSummary (prompt): agent-screen context always blank.
+    if contact_flow_json and prompt_text:
+        flow_session_attrs = set(re.findall(
+            r'\$\.Lex\.SessionAttributes\.(\w+)', contact_flow_json))
+        # 'Tool' is the canonical bot-result contract (validated separately by
+        # the contact flow linter); skip it here.
+        flow_session_attrs.discard("Tool")
+        for attr in sorted(flow_session_attrs):
+            if attr not in prompt_text:
+                mismatches.append({
+                    "check": "session_attribute_contract", "operation_id": "__flow__", "field": attr,
+                    "issue": f"Contact Flow reads $.Lex.SessionAttributes.{attr} but the AI "
+                             f"prompt never mentions '{attr}' — the bot will never set it, so "
+                             f"the flow always reads an empty value. Either instruct the bot "
+                             f"to set '{attr}' in the prompt, or rename the flow attribute to "
+                             f"one the prompt already defines.",
+                })
+
+    # D8) update_q_session env-var contract
+    #     The static handler throws on cold start without CONNECT_INSTANCE_ID /
+    #     AI_ASSISTANT_ID env vars. deploy.sh backfills the VALUES, but the CFN
+    #     template must declare the KEYS — omitted by the LLM in two consecutive
+    #     live sessions.
+    if infra_yaml and 'UpdateQSessionFunction' in infra_yaml:
+        qf = re.search(r'(^  UpdateQSessionFunction:\n(?:^(?:    |\n).*\n?)*)', infra_yaml, re.M)
+        if qf:
+            qblock = qf.group(1)
+            for env_key in ("CONNECT_INSTANCE_ID", "AI_ASSISTANT_ID"):
+                if env_key not in qblock:
+                    mismatches.append({
+                        "check": "lambda_env", "operation_id": "update_q_session", "field": env_key,
+                        "issue": f"UpdateQSessionFunction is missing the '{env_key}' environment "
+                                 f"variable — the handler throws on every invocation without it, "
+                                 f"so customer data is never injected into the AI session. Add "
+                                 f"'{env_key}: \"\"' under Environment.Variables (deploy.sh fills "
+                                 f"the value after the Connect instance exists).",
+                    })
+
+    # D9) OpenAPI success response keyed under spec.success_status_code
+    #     The openapi_generator has no deterministic builder (it free-writes
+    #     YAML) and historically always assumed '200'. A create operation with
+    #     success_status_code=201 (Lambda actually returns 201) then had no
+    #     '201' response declared, so the gateway treated every successful
+    #     call as an undeclared-status tool failure (found live).
+    declared_codes = load_openapi_response_codes(assets)
+    if declared_codes:
+        def _check_success_code(op_id: str, expected_code) -> None:
+            codes = declared_codes.get(op_id)
+            if codes is None:
+                codes = declared_codes.get("/" + op_id.replace("_", "-"))
+            if codes is None:
+                return  # operation not in this OpenAPI doc — other checks cover that
+            if str(expected_code) not in codes:
+                mismatches.append({
+                    "check": "openapi_status_code", "operation_id": op_id, "field": "success_status_code",
+                    "issue": f"Spec declares success_status_code={expected_code} for '{op_id}' "
+                             f"but OpenAPI only declares response(s) {sorted(codes)}. A Lambda "
+                             f"returning HTTP {expected_code} on success has no matching schema, "
+                             f"so the gateway treats every successful call as an undeclared-"
+                             f"status tool failure. Add a '{expected_code}' response to "
+                             f"/tools/{op_id} in openapi.yaml.",
+                })
+
+        for op_id, s in specs.items():
+            expected_code = s.get("success_status_code")
+            if expected_code is not None:
+                _check_success_code(op_id, expected_code)
+        for tool_id, t in tools.items():
+            t_code = t.get("success_status_code")
+            if t_code is not None:
+                _check_success_code(tool_id, t_code)
 
     return mismatches
 

--- a/skills/aicc-builder-skill/resources/sub-agents/contact_flow_generator.md
+++ b/skills/aicc-builder-skill/resources/sub-agents/contact_flow_generator.md
@@ -682,6 +682,16 @@ This 2-action pattern creates the Connect Assistant (Wisdom) session. Place BEFO
 | User-defined | `$.Attributes.{name}` | Custom attribute |
 | Loop | `$.Loop.{name}.Index` | Current iteration |
 
+**⚠️ Session-attribute name contract (deterministic cross-check applies):**
+Every `$.Lex.SessionAttributes.{key}` your flow READS (other than `Tool`) must
+use a name the AI prompt instructs the bot to SET. The canonical escalation
+context names are `escalationReason`, `escalationSummary`, `customerIntent` —
+these are what the prompt generator teaches the bot. Do NOT invent synonyms
+(`conversationSummary`, `summary`, `intent`, `operationId`, …): the bot never
+sets them, so the flow reads an empty value and the agent screen loses its
+context. `validate_parameter_consistency` flags every flow-read session
+attribute that does not appear in the prompt.
+
 ---
 
 ## ERROR TYPES REFERENCE
@@ -1101,7 +1111,7 @@ Queue → Transfer Message → Transfer Queue → End; [Complete] → Goodbye �
         "Attributes": {
           "customerIntent": "$.Lex.SessionAttributes.customerIntent",
           "escalationReason": "$.Lex.SessionAttributes.escalationReason",
-          "conversationSummary": "$.Lex.SessionAttributes.conversationSummary"
+          "escalationSummary": "$.Lex.SessionAttributes.escalationSummary"
         }
       },
       "Transitions": {

--- a/skills/aicc-builder-skill/resources/sub-agents/infrastructure_generator.md
+++ b/skills/aicc-builder-skill/resources/sub-agents/infrastructure_generator.md
@@ -1415,6 +1415,8 @@ UpdateQSessionFunctionArn:
 12. **CRITICAL: Environment variable naming** - Use `<ENTITY>_TABLE_NAME` pattern (e.g., `RESERVATIONS_TABLE_NAME`). Document exact names in schema summary's `environment_variables` section
 13. **CRITICAL: IAM permissions** - Include dynamodb:Scan, dynamodb:Query, and /index/* resource for GSI access
 14. **CRITICAL: When `Include Customer Phone Lookup: True`** — MUST include CustomerLookupFunction (Python 3.11, placeholder) + UpdateQSessionFunction (Node.js 18.x, placeholder) + their IAM Roles + AWS::Lambda::Permission for connect.amazonaws.com
+15. **CRITICAL: EVERY Lambda the Contact Flow invokes directly needs a connect.amazonaws.com Permission** — if the Contact Flow spec / flow references a function via `{{X_LAMBDA_ARN}}` (customer lookup, update-q-session, call/result logging like `log_call_result` or `record_monitoring_result`, or any other flow-invoked function), that function MUST have its own `AWS::Lambda::Permission` with `Principal: connect.amazonaws.com` and `SourceAccount: !Ref AWS::AccountId`. An apigateway.amazonaws.com permission does NOT cover Connect — the flow's invoke fails with AccessDeniedException at call time (this exact omission recurred in two live sessions and is now flagged by `validate_parameter_consistency`).
+16. **CRITICAL: UpdateQSessionFunction env vars** — its Environment.Variables MUST declare `CONNECT_INSTANCE_ID: ""` and `AI_ASSISTANT_ID: ""` (deploy.sh fills the values later; the handler throws on every invocation without the keys), and UpdateQSessionRole MUST grant `wisdom:UpdateSessionData` (NOT just `wisdom:UpdateSession` — they are different actions and UpdateSessionData is the one the handler calls).
 
 ---
 

--- a/skills/aicc-builder-skill/resources/sub-agents/openapi_generator.md
+++ b/skills/aicc-builder-skill/resources/sub-agents/openapi_generator.md
@@ -310,6 +310,7 @@ The Orchestrator provides operations with explicit schema. You MUST use these va
   "operation_id": "check_reservation",      // Use for operationId
   "api_path": "/check_reservation",         // Spec field — prepend `/tools` when emitting the paths key → `/tools/check_reservation`
   "http_method": "POST",                    // Use for method (post, get, etc.) — MUST match CFN HttpMethod exactly
+  "success_status_code": 200,               // Use for the responses: key of the SUCCESS schema — NOT always '200' (e.g. 201 for a create operation)
   "description": "Look up a customer reservation",
   "input_fields": [
     {"name": "phoneNumber", "type": "string", "required": true}
@@ -332,8 +333,13 @@ The Orchestrator provides operations with explicit schema. You MUST use these va
    - `http_method: "POST"` → `post:` under the path
 3. **operation_id**: Use for `operationId` and `x-amazon-connect-tool-name`
 4. **input_fields**: Generate `requestBody` schema from this
-5. **output_fields**: Generate `responses.200` schema from this
+5. **output_fields**: Generate the response schema for the success outcome from this — key it under `success_status_code` (see rule 7), NOT a hardcoded `'200'`
 6. **error_codes**: Include in ErrorResponse schema enum
+7. **success_status_code**: Key the SUCCESS response under this exact value
+   (default `200` — do not assume it, read the field). A create operation
+   commonly declares `201`; if you emit `'200'` while the spec/Lambda use
+   `201`, the gateway treats every successful call as an undeclared-status
+   failure (see the dedicated section below).
 
 ### 🚨 CRITICAL: PATH FORMAT — `/tools/<operation_id>` WITH UNDERSCORES
 
@@ -727,6 +733,42 @@ responses:
 Do NOT emit `'400'`, `'401'`, `'403'`, `'404'`, `'409'` or `'429'` response
 entries for business outcomes — a declared 4xx teaches the model to expect a
 failure it cannot handle, and the Lambda must not return one either.
+
+### 🚨 Success status code MUST match the spec's `success_status_code`
+
+`BUSINESS_OUTCOME_200_RULE` above governs *failure* outcomes only — it does NOT
+mean every operation's success response is `'200'`. Each OperationSpec carries
+its own `success_status_code` (default `200`, but creation operations are
+commonly `201`). Read it and declare the response under THAT status code, not
+a hardcoded `'200'`:
+
+```yaml
+responses:
+  '201':   # ← spec.success_status_code, NOT hardcoded '200'
+    description: "Reservation created successfully"
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/CreateReservationResponse'
+  '500':
+    description: "Internal error — retryable fault"
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/ErrorResponse'
+```
+
+**Omitting the spec's real success status code is itself a HARD-GATE
+mismatch** (`validate_shape_parity_report` looks for the response schema
+under `success_status_code` specifically, and a Lambda that returns
+`return 201, body` while OpenAPI only declares `'200'`/`'500'` makes the
+gateway treat every successful call as an undeclared-status tool failure).
+Cross-check the exact value against the operation's spec before writing the
+`responses:` block — do not assume `200`.
+
+Business-outcome failures (the 200-body table above) still belong alongside
+the success code even when success itself is `201` — e.g. `INVALID_INPUT`
+stays a `200` body outcome, it is never folded into the `201` response.
 
 ---
 

--- a/skills/aicc-builder-skill/scripts/smoke_test_validators.py
+++ b/skills/aicc-builder-skill/scripts/smoke_test_validators.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Smoke tests for the hand-ported validator scripts.
+
+`resources/scripts/validate_consistency.py` and `resources/scripts/shape_parity.py`
+are hand ports of `backend/ecs/src/tools/{validate_consistency,shape_parity}.py` —
+they are NOT covered by `extract_prompts.sh --check` (which only guards the
+auto-extracted prompts/schemas/linter). When a check changes in the backend,
+port it by hand and re-run THIS file. It is the "smoke tests" the top-level
+README's re-sync section refers to.
+
+What it does, with a synthetic <output_dir> built in a tempdir:
+
+  1. Seeds violations for every contract-level consistency check
+     (connect_invoke_permission, session_attribute_contract, lambda_env,
+     openapi_status_code) and asserts each one is reported.
+  2. Asserts the canonical 'Tool' session attribute is exempted.
+  3. Fixes the fixtures and asserts the same checks report nothing
+     (no false positives).
+  4. Asserts shape_parity exempts the standard errorCode/message response
+     envelope at the response ROOT, still flags a genuinely undeclared extra
+     property, and passes cleanly when the success response is keyed under
+     the spec's success_status_code (201).
+
+Usage:
+    python3 scripts/smoke_test_validators.py
+
+Exit 0 = all pass. Requires PyYAML (same as the validators themselves).
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SKILL_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = SKILL_ROOT / "resources" / "scripts"
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+BAD_FLOW = json.dumps({
+    "Actions": [
+        {"Type": "InvokeLambdaFunction",
+         "Parameters": {"LambdaFunctionARN": "{{LOG_CALL_RESULT_LAMBDA_ARN}}"}},
+        {"Type": "UpdateContactAttributes",
+         "Parameters": {"Attributes": {
+             # 'conversationSummary' is the live-observed synonym drift the
+             # session_attribute_contract check exists for.
+             "summaryText": "$.Lex.SessionAttributes.conversationSummary",
+             "reason": "$.Lex.SessionAttributes.escalationReason"}}},
+        {"Type": "Compare",
+         "Parameters": {"ComparisonValue": "$.Lex.SessionAttributes.Tool"}},
+    ]
+})
+
+GOOD_FLOW = BAD_FLOW.replace("conversationSummary", "escalationSummary")
+
+PROMPT = "Set escalationReason, escalationSummary and customerIntent before escalating.\n"
+
+BAD_INFRA = """\
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  LogCallResultFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: log-call-result
+  UpdateQSessionFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Environment:
+        Variables:
+          OTHER: ""
+  LogCallResultApiPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt LogCallResultFunction.Arn
+      Principal: apigateway.amazonaws.com
+"""
+
+GOOD_INFRA = """\
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  LogCallResultFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: log-call-result
+  UpdateQSessionFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      Environment:
+        Variables:
+          CONNECT_INSTANCE_ID: ""
+          AI_ASSISTANT_ID: ""
+  LogCallResultConnectPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt LogCallResultFunction.Arn
+      Principal: connect.amazonaws.com
+      SourceAccount: !Ref AWS::AccountId
+"""
+
+SPEC = {
+    "operation_id": "create_reservation",
+    "http_method": "POST",
+    "path": "/tools/create_reservation",
+    "success_status_code": 201,
+    "input_fields": [{"name": "customerName", "field_type": "string", "required": True}],
+    "output_fields": [
+        {"name": "reservationId", "field_type": "string"},
+        {"name": "success", "field_type": "boolean"},
+    ],
+}
+
+BAD_OPENAPI = """\
+openapi: 3.0.0
+info: {title: t, version: '1.0'}
+paths:
+  /tools/create_reservation:
+    post:
+      operationId: create_reservation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                customerName: {type: string}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  reservationId: {type: string}
+                  success: {type: boolean}
+                  errorCode: {type: string}
+                  message: {type: string}
+                  bogusField: {type: string}
+        '500':
+          description: err
+"""
+
+GOOD_OPENAPI = BAD_OPENAPI.replace("'200':", "'201':").replace(
+    "                  bogusField: {type: string}\n", "")
+
+LAMBDA = """\
+def handler(event, context):
+    body = event.get("body") or {}
+    name = body.get("customerName")
+    return {"statusCode": 201, "body": {"reservationId": "r1", "success": True,
+                                        "errorCode": None, "message": "ok"}}
+"""
+
+NEW_CHECKS = {"connect_invoke_permission", "session_attribute_contract",
+              "lambda_env", "openapi_status_code"}
+
+
+def build(root: Path, good: bool) -> None:
+    (root / "state/specs").mkdir(parents=True)
+    a = root / "assets/v1"
+    for d in ("contact_flow", "prompt", "infrastructure", "openapi",
+              "lambda/create_reservation"):
+        (a / d).mkdir(parents=True)
+    (root / "state/specs/create_reservation.json").write_text(json.dumps(SPEC))
+    (a / "contact_flow/contact_flow.json").write_text(GOOD_FLOW if good else BAD_FLOW)
+    (a / "prompt/ai_agent_prompt.yaml").write_text(PROMPT)
+    (a / "infrastructure/template.yaml").write_text(GOOD_INFRA if good else BAD_INFRA)
+    (a / "openapi/openapi.yaml").write_text(GOOD_OPENAPI if good else BAD_OPENAPI)
+    (a / "lambda/create_reservation/index.py").write_text(LAMBDA)
+
+
+def run_vc(root: Path) -> dict:
+    p = subprocess.run([sys.executable, str(SCRIPTS / "validate_consistency.py"),
+                        str(root), "--json"], capture_output=True, text=True)
+    try:
+        return json.loads(p.stdout)
+    except json.JSONDecodeError:
+        print(f"FATAL: validate_consistency.py produced no JSON.\n"
+              f"stderr: {p.stderr}", file=sys.stderr)
+        sys.exit(2)
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    with tempfile.TemporaryDirectory() as td:
+        bad = Path(td) / "bad"
+        build(bad, good=False)
+        res = run_vc(bad)
+        checks = {m["check"] for m in res["mismatches"]}
+        for want in sorted(NEW_CHECKS):
+            if want in checks:
+                print(f"PASS  bad fixture triggers {want}")
+            else:
+                failures.append(f"bad fixture did NOT trigger {want}; got {checks}")
+
+        attrs = {m["field"] for m in res["mismatches"]
+                 if m["check"] == "session_attribute_contract"}
+        if "Tool" in attrs:
+            failures.append("'Tool' must be exempt from session_attribute_contract")
+        else:
+            print("PASS  'Tool' session attribute exempted")
+
+        good = Path(td) / "good"
+        build(good, good=True)
+        res2 = run_vc(good)
+        fp = [m for m in res2["mismatches"] if m["check"] in NEW_CHECKS]
+        if fp:
+            failures.append(f"good fixture false positives: {fp}")
+        else:
+            print("PASS  good fixture: no false positives from the contract checks")
+
+        # ---- shape_parity: envelope exemption + real extras still flagged ----
+        sys.path.insert(0, str(SCRIPTS))
+        import yaml  # required by the validators themselves
+        from shape_parity import validate_shape_parity
+
+        bad_doc = yaml.safe_load(BAD_OPENAPI)
+        mm = validate_shape_parity(SPEC, bad_doc)
+        reasons = {(m.reason, m.path.rsplit(".", 1)[-1]) for m in mm}
+        if ("property_extra_in_openapi", "errorCode") in reasons or \
+           ("property_extra_in_openapi", "message") in reasons:
+            failures.append(f"shape_parity flagged the standard envelope: {reasons}")
+        else:
+            print("PASS  shape_parity exempts errorCode/message at response root")
+        if ("property_extra_in_openapi", "bogusField") in reasons:
+            print("PASS  shape_parity still flags a genuinely undeclared extra property")
+        else:
+            failures.append(f"shape_parity missed bogusField: {reasons}")
+
+        good_doc = yaml.safe_load(GOOD_OPENAPI)
+        mm2 = validate_shape_parity(SPEC, good_doc)
+        if mm2:
+            failures.append(
+                f"shape_parity good fixture not clean: {[(m.reason, m.path) for m in mm2]}")
+        else:
+            print("PASS  shape_parity clean on the fixed fixture (201 response found)")
+
+    if failures:
+        print("\nFAILURES:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("\nALL SMOKE TESTS PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

The CLI skill drifted from the webapp after the last skill sync (5796241): de244ef, f149fd1 and 455528a changed generator prompts and validators without a matching skill update. This re-syncs everything.

### Prompt resources (re-extracted via `scripts/extract_prompts.sh`)
- **openapi_generator**: `success_status_code` rules — declare the success response under the spec's status code (e.g. `201` for creates), never a hardcoded `'200'`
- **contact_flow_generator**: session-attribute name contract (canonical `escalationReason`/`escalationSummary`/`customerIntent`); example flow's `conversationSummary` → `escalationSummary`
- **infrastructure_generator**: rule 15 (every flow-invoked Lambda needs its own `connect.amazonaws.com` Permission) and rule 16 (UpdateQSession env keys + `wisdom:UpdateSessionData`)
- **orchestrator**: `errorCode` + `message` are mandatory in `output_fields`
- `extract_prompts.sh --check` passes (no drift against `backend/ecs/src/`)

### Validator ports
- **shape_parity.py**: `_IMPLICIT_RESPONSE_ENVELOPE_FIELDS` — stop flagging the standard `errorCode`/`message` envelope at the response root (still flagged when nested)
- **validate_consistency.py**: 4 new checks mirroring the webapp — `connect_invoke_permission`, `session_attribute_contract`, `lambda_env` (UpdateQSession keys), `openapi_status_code`

### SKILL.md (kiro + claude, identical text)
- Interview checklist now requires `errorCode` + `message` in `output_fields` and `success_status_code` when success ≠ 200

## Testing
- Synthetic bad/good fixtures: all 4 new consistency checks trigger on seeded violations (incl. `Tool` attribute exemption), zero false positives on fixed fixtures
- shape_parity: envelope exempted at root, genuinely undeclared extra property still flagged, clean on the fixed fixture with a `201` response
- All four Phase-7 gate scripts (`check_spec_complete`, `lint_assets`, `validate_consistency`, `shape_parity`) run standalone against a bare output dir
- `python -m py_compile` on both edited scripts

## Follow-up commits
- **188e6d0**: `scripts/smoke_test_validators.py` — the smoke tests the docs referenced but that never existed. Self-contained fixtures verify the 4 new consistency checks (positive trigger + `Tool` exemption + no false positives) and the shape_parity envelope exemption. Run: `python3 scripts/smoke_test_validators.py` (all 9 assertions pass). Also adds the missing post-install verify step to the Kiro install section.
- **2d103ad**: README header badge — one-click jump to `skills/aicc-builder-skill/` for the no-deployment CLI-skill path.